### PR TITLE
Refactor `FakeNetworkClient` to allow failures

### DIFF
--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -38,31 +38,28 @@ class XpringClient {
     const accountInfoRequest = new AccountInfoRequest();
     accountInfoRequest.setAddress(address);
 
-    return new Promise((resolve, reject) => {
-      this.networkClient
-        .getAccountInfo(accountInfoRequest)
-        .then(accountInfo => {
-          const accountData = accountInfo.getAccountData();
-          if (accountData == undefined) {
-            reject(new Error(XpringClientErrorMessages.malformedResponse));
-            return;
-          }
+    return this.networkClient
+      .getAccountInfo(accountInfoRequest)
+      .then(async accountInfo => {
+        const accountData = accountInfo.getAccountData();
+        if (accountData == undefined) {
+          return Promise.reject(
+            new Error(XpringClientErrorMessages.malformedResponse)
+          );
+        }
 
-          const balance = accountData.getBalance();
-          if (balance === "") {
-            reject(new Error(XpringClientErrorMessages.malformedResponse));
-            return;
-          }
+        const balance = accountData.getBalance();
+        if (balance === "") {
+          return Promise.reject(
+            new Error(XpringClientErrorMessages.malformedResponse)
+          );
+        }
 
-          const xrpAmount = new XRPAmount();
-          xrpAmount.setDrops(balance);
+        const xrpAmount = new XRPAmount();
+        xrpAmount.setDrops(balance);
 
-          resolve(xrpAmount);
-        })
-        .catch(error => {
-          reject(error);
-        });
-    });
+        return xrpAmount;
+      });
   }
 }
 

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -4,7 +4,7 @@ import { AccountInfo } from "../../generated/rippled_pb";
 import { AccountInfoRequest } from "../../generated/rippled_pb";
 
 /**
- * A response for a request ot retrieve type T. Either an instance of T, or an error.
+ * A response for a request to retrieve type T. Either an instance of T, or an error.
  */
 type Response<T> = T | Error;
 
@@ -66,13 +66,10 @@ export class FakeNetworkClient implements NetworkClient {
     _accountInfoRequest: AccountInfoRequest
   ): Promise<AccountInfo> {
     const accountInfoResponse = this.responses.getAccountInfoResponse;
-    return new Promise(function(resolve, reject) {
-      if (accountInfoResponse instanceof Error) {
-        reject(accountInfoResponse);
-        return;
-      }
+    if (accountInfoResponse instanceof Error) {
+      return Promise.reject(accountInfoResponse);
+    }
 
-      resolve(accountInfoResponse);
-    });
+    return Promise.resolve(accountInfoResponse);
   }
 }

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -43,7 +43,9 @@ describe("Xpring Client", function(): void {
     // GIVEN a XpringClient which wraps a network client with a malformed response.
     const accountInfoResponse = FakeNetworkClientResponses.defaultAccountInfoResponse();
     accountInfoResponse.setAccountData(undefined);
-    const fakeNetworkClientResponses = new FakeNetworkClientResponses(accountInfoResponse);
+    const fakeNetworkClientResponses = new FakeNetworkClientResponses(
+      accountInfoResponse
+    );
     const fakeNetworkClient = new FakeNetworkClient(fakeNetworkClientResponses);
     const xpringClient = new XpringClient(fakeNetworkClient);
 
@@ -60,7 +62,9 @@ describe("Xpring Client", function(): void {
     const accountInfoResponse = FakeNetworkClientResponses.defaultAccountInfoResponse();
     const accountData = new AccountData();
     accountInfoResponse.setAccountData(accountData);
-    const fakeNetworkClientResponses = new FakeNetworkClientResponses(accountInfoResponse);
+    const fakeNetworkClientResponses = new FakeNetworkClientResponses(
+      accountInfoResponse
+    );
     const fakeNetworkClient = new FakeNetworkClient(fakeNetworkClientResponses);
     const xpringClient = new XpringClient(fakeNetworkClient);
 


### PR DESCRIPTION
Create a new compound type, `Response` which is generic in a response type or an error. 

Create an intermediate class, `FakeNetworkClientResponses` which will map a list of endpoints for the network client to `Responses`. `FakeNetworkClientResponses` contains static methods to get a default list of responses, or a default response of any specific type. 

Refactor `FakeNetworkClient` to contain a `FakeNetworkClientResponse` which it uses to resolve or reject promises for network requests. 

If this gets unruly in the future, it may be able to parameterize `FakeNetworkClientResponses` with an enum for even greater extensibility. This functionality is deferred so as to not over-engineer the class. 