### PR TITLE
Standardize APIs for Sending Across Xpring SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,17 @@ const { Wallet, XRPAmount, XpringClient } = require("xpring-js");
 const remoteURL = "grpc.xpring.tech:80";
 const xpringClient = XpringClient.xpringClientWithEndpoint(remoteURL);
 
-// Wallet which will send XRP
-const senderWallet = Wallet.generateRandomWallet();
-
-// Destination address.
-const address = "r3v29rxf54cave7ooQE6eE7G5VFXofKZT7";
-
 // Amount of XRP to send
 const amount = new XRPAmount();
 amount.setDrops("10");
 
-const result = await xpringClient.send(senderWallet, amount, destinationAddress);
+// Destination address.
+const destinationAddress = "r3v29rxf54cave7ooQE6eE7G5VFXofKZT7";
+
+// Wallet which will send XRP
+const senderWallet = Wallet.generateRandomWallet();
+
+const result = await xpringClient.send(amount, destinationAddress, senderWallet);
 ```
 
 ### Utilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-js",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -73,7 +73,7 @@ class XpringClient {
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    */
   public async send(
-    drops: string,
+    amount: XRPAmount,
     destination: string,
     sender: Wallet
   ): Promise<SubmitSignedTransactionResponse> {

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -67,9 +67,9 @@ class XpringClient {
 
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
-   * 
-   * @param drops A numeric string indicating the number of drops to send. 
-   * @param destination A destination address to send the drops to. 
+   *
+   * @param drops A numeric string indicating the number of drops to send.
+   * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    */
   public async send(

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -65,10 +65,17 @@ class XpringClient {
     });
   }
 
+  /**
+   * Send the given amount of XRP from the source wallet to the destination address.
+   * 
+   * @param drops A numeric string indicating the number of drops to send. 
+   * @param destination A destination address to send the drops to. 
+   * @param sender The wallet that XRP will be sent from and which will sign the request.
+   */
   public async send(
-    sender: Wallet,
-    amount: XRPAmount,
-    destination: string
+    drops: string,
+    destination: string,
+    sender: Wallet
   ): Promise<SubmitSignedTransactionResponse> {
     return this.getFee().then(async fee => {
       return this.getAccountInfo(sender.getAddress()).then(

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -33,7 +33,7 @@ describe("Xpring JS Integration Tests", function(): void {
   it("Send XRP", async function() {
     this.timeout(timeoutMs);
 
-    const result = await xrpClient.send(wallet, amount, recipientAddress);
+    const result = await xrpClient.send(amount, recipientAddress, wallet);
     assert.exists(result);
   });
 });

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -74,9 +74,9 @@ describe("Xpring Client", function(): void {
 
     // WHEN the account makes a transaction.
     const submissionResult = await xpringClient.send(
-      wallet,
       amount,
-      destinationAddress
+      destinationAddress,
+      wallet
     );
 
     // THEN the transaction has a success code attached.
@@ -101,7 +101,7 @@ describe("Xpring Client", function(): void {
     amount.setDrops("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(wallet, amount, destinationAddress).catch(error => {
+    xpringClient.send(amount, destinationAddress, wallet).catch(error => {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
@@ -127,7 +127,7 @@ describe("Xpring Client", function(): void {
     amount.setDrops("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(wallet, amount, destinationAddress).catch(error => {
+    xpringClient.send(amount, destinationAddress, wallet).catch(error => {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
@@ -153,7 +153,7 @@ describe("Xpring Client", function(): void {
     amount.setDrops("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(wallet, amount, destinationAddress).catch(error => {
+    xpringClient.send(amount, destinationAddress, wallet).catch(error => {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
@@ -173,7 +173,7 @@ describe("Xpring Client", function(): void {
     amount.setDrops("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(wallet, amount, destinationAddress).catch(error => {
+    xpringClient.send(amount, destinationAddress, wallet).catch(error => {
       assert.typeOf(error, "Error");
       assert.startsWith(
         error.message,


### PR DESCRIPTION
XpringJ and XpringClient both take `send` parameters in the order of `amount`, `destination`, `sender`. Logically, this reads as "Send `amount` drops of XRP to `destination` from `sender`.

This is a breaking API change and will be accompanied with a major version bump. 

In a perfect world, we wouldn't make this change, *but* I'm about to break the public API by removing the protocol buffers anyway, so we might as well take this opportunity to make it better. 