### PR TITLE
Don't return protocol buffers from the getBalance API

### DIFF
--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -50,9 +50,9 @@ class XpringClient {
    * Retrieve the balance for the given address.
    *
    * @param address The address to retrieve a balance for.
-   * @returns The amount of XRP in the account.
+   * @returns A numeric string representing the number of drops of XRP in the account.
    */
-  public async getBalance(address: string): Promise<XRPAmount> {
+  public async getBalance(address: string): Promise<string> {
     return this.getAccountInfo(address).then(async accountInfo => {
       const balance = accountInfo.getBalance();
       if (balance === undefined) {
@@ -61,7 +61,7 @@ class XpringClient {
         );
       }
 
-      return balance;
+      return balance.getDrops();
     });
   }
 

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -27,7 +27,7 @@ describe("Xpring JS Integration Tests", function(): void {
     this.timeout(timeoutMs);
 
     const balance = await xrpClient.getBalance(recipientAddress);
-    assert.exists(balance.getDrops());
+    assert.exists(balance);
   });
 
   it("Send XRP", async function() {

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -30,7 +30,6 @@ describe("Xpring Client", function(): void {
 
     // THEN the balance is returned.
     assert.exists(balance);
-    assert.exists(balance.getDrops());
   });
 
   it("Get Account Balance - error", function(done) {


### PR DESCRIPTION
Return strings instead of protocol buffers from the public API. 

This is motivated by the fact that a lot of feedback at the hackathon was around the fact that these objects being used as parameters and return types make the APIs clunky and unclear. It's easier to just return a native primitive. 

Some of the Java APIs do this already, and I plan to fully migrate the Swift / Java APIs after this. 

This is a breaking change and will be accompanied with a major bump in version number. 