### PR TITLE
Remove Protocol Buffers from Public APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      - run: nyc npm test
+      - run: npm rebuild && nyc npm test
 
       - run:
           name: Code Coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      - run: npm rebuild && nyc npm test
+      - run: nyc npm test
 
       - run:
           name: Code Coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:12.11.1
 
     working_directory: ~/repo
 
@@ -36,4 +36,3 @@ jobs:
             mkdir coverage
             nyc report --reporter=text-lcov > coverage/coverage.json
             codecov
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:12.11.1
+      - image: circleci/node:10.4.0
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           command: |
             sudo npm -g i nyc codecov
             npm i xpring-common-js@latest
+            npm rebuild
       - save_cache:
           paths:
             - node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6944,9 +6944,9 @@
       }
     },
     "xpring-common-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-1.1.1.tgz",
-      "integrity": "sha512-rRDT8v8zm638rGvq0EoBewIO+3O7YMV5Y9YK9Q/jcimpG08wuzO32QcZrXOVHGpp2LN1OaywocJ1EzBRqXT9NA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-1.1.3.tgz",
+      "integrity": "sha512-RPjcTIa63ONMiUZwp/FG09QYQ5muxAgNk8UgewTZKVXPWVWMjRr5KyX3Pjb/ITy7TFhw55bNR4M+Nroom10hBg==",
       "requires": {
         "@types/google-protobuf": "3.7.1",
         "@typescript-eslint/eslint-plugin": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grpc-tools": "1.8.0",
     "mocha": "6.2.0",
     "typescript": "3.5.3",
-    "xpring-common-js": "1.1.1"
+    "xpring-common-js": "1.1.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "XpringJS provides a Javascript based SDK for interacting with the Ripple Ledger.",
   "main": "build/src/index.js",
   "repository": {

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -124,9 +124,13 @@ class XpringClient {
             .submitSignedTransaction(submitSignedTransactionRequest)
             .then(async response => {
               const transactionBlob = response.getTransactionBlob();
-              const transactionHash = Utils.transactionBlobToTransactionHash(transactionBlob);
+              const transactionHash = Utils.transactionBlobToTransactionHash(
+                transactionBlob
+              );
               if (!transactionHash) {
-                return Promise.reject(new Error(XpringClientErrorMessages.malformedResponse)) 
+                return Promise.reject(
+                  new Error(XpringClientErrorMessages.malformedResponse)
+                );
               }
               return Promise.resolve(transactionHash);
             });

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -66,7 +66,7 @@ class XpringClient {
       return BigInt(balance.getDrops());
     });
   }
-
+  
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
@@ -79,7 +79,51 @@ class XpringClient {
     amount: BigInt,
     destination: string,
     sender: Wallet
+  ): Promise<string>;
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination address.
+   *
+   * @param drops A numeric string representing the number of drops to send.
+   * @param destination A destination address to send the drops to.
+   * @param sender The wallet that XRP will be sent from and which will sign the request.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  public async send(
+    amount: string,
+    destination: string,
+    sender: Wallet
+  ): Promise<string>;
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination address.
+   *
+   * @param drops A number representing the number of drops to send.
+   * @param destination A destination address to send the drops to.
+   * @param sender The wallet that XRP will be sent from and which will sign the request.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  public async send(
+    amount: number,
+    destination: string,
+    sender: Wallet
+  ): Promise<string>;
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination address.
+   *
+   * @param drops A `BigInt`, number or numeric string representing the number of drops to send.
+   * @param destination A destination address to send the drops to.
+   * @param sender The wallet that XRP will be sent from and which will sign the request.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  public async send(
+    amount: BigInt | number | string,
+    destination: string,
+    sender: Wallet
   ): Promise<string> {
+    const normalizedAmount = this.toBigInt(amount);
+
     return this.getFee().then(async fee => {
       return this.getAccountInfo(sender.getAddress()).then(
         async accountInfo => {
@@ -90,7 +134,7 @@ class XpringClient {
           }
 
           const xrpAmount = new XRPAmount();
-          xrpAmount.setDrops(amount.toString());
+          xrpAmount.setDrops(normalizedAmount.toString());
 
           const payment = new Payment();
           payment.setXrpAmount(xrpAmount);
@@ -161,6 +205,21 @@ class XpringClient {
       }
       return feeAmount;
     });
+  }
+
+  /**
+   * Convert a polymorphic numeric value into a BigInt.
+   * 
+   * @param value The value to convert.
+   * @returns A BigInt representing the input value. 
+   */
+  private toBigInt(value: string | number | BigInt): BigInt {
+    if (typeof value == 'string' || typeof value == 'number') {
+      return BigInt(value);
+    } else {
+      // Value is already a BigInt.
+      return value;
+    }
   }
 }
 

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -5,7 +5,6 @@ import {
   Payment,
   Signer,
   SubmitSignedTransactionRequest,
-  SubmitSignedTransactionResponse,
   Transaction,
   Utils,
   Wallet,
@@ -13,6 +12,8 @@ import {
 } from "xpring-common-js";
 import { NetworkClient } from "./network-client";
 import GRPCNetworkClient from "./grpc-network-client";
+
+/* global BigInt */
 
 /**
  * Error messages from XpringClient.
@@ -51,9 +52,9 @@ class XpringClient {
    * Retrieve the balance for the given address.
    *
    * @param address The address to retrieve a balance for.
-   * @returns A numeric string representing the number of drops of XRP in the account.
+   * @returns A `BigInt` representing the number of drops of XRP in the account.
    */
-  public async getBalance(address: string): Promise<string> {
+  public async getBalance(address: string): Promise<BigInt> {
     return this.getAccountInfo(address).then(async accountInfo => {
       const balance = accountInfo.getBalance();
       if (balance === undefined) {
@@ -62,20 +63,20 @@ class XpringClient {
         );
       }
 
-      return balance.getDrops();
+      return BigInt(balance.getDrops());
     });
   }
 
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
-   * @param drops A numeric string indicating the number of drops to send.
+   * @param drops A `BigInt` representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async send(
-    amount: XRPAmount,
+    amount: BigInt,
     destination: string,
     sender: Wallet
   ): Promise<string> {
@@ -88,8 +89,11 @@ class XpringClient {
             );
           }
 
+          const xrpAmount = new XRPAmount();
+          xrpAmount.setDrops(amount.toString());
+
           const payment = new Payment();
-          payment.setXrpAmount(amount);
+          payment.setXrpAmount(xrpAmount);
           payment.setDestination(destination);
 
           const transaction = new Transaction();

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -67,7 +67,7 @@ class XpringClient {
     });
   }
 
-  /** eslint-disable no-dupe-class-members */
+  /* eslint-disable no-dupe-class-members */
 
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
@@ -188,6 +188,8 @@ class XpringClient {
       );
     });
   }
+
+  /* eslint-enable no-dupe-class-members */
 
   private async getAccountInfo(address: string): Promise<AccountInfo> {
     const getAccountInfoRequest = new GetAccountInfoRequest();

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -66,7 +66,9 @@ class XpringClient {
       return BigInt(balance.getDrops());
     });
   }
-  
+
+  /** eslint-disable no-dupe-class-members */
+
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
@@ -209,12 +211,12 @@ class XpringClient {
 
   /**
    * Convert a polymorphic numeric value into a BigInt.
-   * 
+   *
    * @param value The value to convert.
-   * @returns A BigInt representing the input value. 
+   * @returns A BigInt representing the input value.
    */
   private toBigInt(value: string | number | BigInt): BigInt {
-    if (typeof value == 'string' || typeof value == 'number') {
+    if (typeof value == "string" || typeof value == "number") {
       return BigInt(value);
     } else {
       // Value is already a BigInt.

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -7,6 +7,7 @@ import {
   SubmitSignedTransactionRequest,
   SubmitSignedTransactionResponse,
   Transaction,
+  Utils,
   Wallet,
   XRPAmount
 } from "xpring-common-js";
@@ -118,9 +119,10 @@ class XpringClient {
             signedTransaction
           );
 
-          return this.networkClient.submitSignedTransaction(
-            submitSignedTransactionRequest
-          );
+          return this.networkClient.submitSignedTransaction(submitSignedTransactionRequest).then(response => {
+            // const transactionHash = Utils.transactionBlobToTransactionHash()
+            return Promise.resolve(response);
+          });
         }
       );
     });

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -93,6 +93,7 @@ export class FakeNetworkClientResponses {
     submitSignedTransactionResponse.setEngineResultMessage(
       "The transaction was applied. Only final in a validated ledger."
     );
+    submitSignedTransactionResponse.setTransactionBlob("DEADBEEF");
 
     return submitSignedTransactionResponse;
   }

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -4,6 +4,7 @@ import { assert } from "chai";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
+/* global BigInt */
 
 // A timeout for these tests.
 const timeoutMs = 60 * 1000; // 1 minute
@@ -19,8 +20,7 @@ const grpcURL = "grpc.xpring.tech:80";
 const xrpClient = XpringClient.xpringClientWithEndpoint(grpcURL);
 
 // Some amount of XRP to send.
-const amount = new XRPAmount();
-amount.setDrops("1");
+const amount = BigInt("1");
 
 describe("Xpring JS Integration Tests", function(): void {
   it("Get Account Balance", async function() {

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -169,4 +169,34 @@ describe("Utils", function(): void {
     // Then the decoded address is undefined.
     assert.isUndefined(xAddress);
   });
+
+  it("transactionBlobHex() - Valid transaction blob", function(): void {
+    // GIVEN a transaction blob.
+    const transactionBlobHex =
+      "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6";
+
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.transactionBlobToTransactionHash(
+      transactionBlobHex
+    );
+
+    // THEN the transaction blob is as expected.
+    assert.strictEqual(
+      transactionHash,
+      "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667"
+    );
+  });
+
+  it("transactionBlobHex() - Invalid transaction blob", function(): void {
+    // GIVEN an invalid transaction blob.
+    const transactionBlobHex = "xrp";
+
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.transactionBlobToTransactionHash(
+      transactionBlobHex
+    );
+
+    // THEN the hash is undefined.
+    assert.isUndefined(transactionHash);
+  });
 });

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -148,7 +148,7 @@ describe("Xpring Client", function(): void {
     const amount = "not_a_number";
 
     // WHEN the account makes a transaction THEN an error is propagated.
-    const transactionHash = xpringClient
+    xpringClient
       .send(amount, destinationAddress, wallet)
       .catch(error => {
         assert.typeOf(error, "Error");

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -1,6 +1,11 @@
 import { assert } from "chai";
 
-import { Utils, Wallet, WalletGenerationResult, XRPAmount } from "xpring-common-js";
+import {
+  Utils,
+  Wallet,
+  WalletGenerationResult,
+  XRPAmount
+} from "xpring-common-js";
 
 import chai from "chai";
 import chaiString from "chai-string";
@@ -80,7 +85,9 @@ describe("Xpring Client", function(): void {
 
     // THEN the transaction hash exists and is the expected hash
     const expectedTransactionBlob = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
-    const expectedTransactionHash = Utils.transactionBlobToTransactionHash(expectedTransactionBlob);
+    const expectedTransactionHash = Utils.transactionBlobToTransactionHash(
+      expectedTransactionBlob
+    );
 
     assert.exists(transactionHash);
     assert.strictEqual(transactionHash, expectedTransactionHash);

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -64,8 +64,8 @@ describe("Xpring Client", function(): void {
     });
   });
 
-  it("Send XRP Transaction - success", async function() {
-    // GIVEN a XpringClient and a wallet.
+  it("Send XRP Transaction - success with BigInt", async function() {
+    // GIVEN a XpringClient, a wallet, and a BigInt denomonated amount.
     const xpringClient = new XpringClient(fakeSucceedingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
@@ -87,6 +87,73 @@ describe("Xpring Client", function(): void {
 
     assert.exists(transactionHash);
     assert.strictEqual(transactionHash, expectedTransactionHash);
+  });
+
+  it("Send XRP Transaction - success with number", async function() {
+    // GIVEN a XpringClient, a wallet, and a number denominated amount.
+    const xpringClient = new XpringClient(fakeSucceedingNetworkClient);
+    const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
+      .wallet;
+    const destinationAddress = "rUi8dmUEg8JM5Kc92TWvCcuHdA3Ng3NCe8";
+    const amount = 10;
+
+    // WHEN the account makes a transaction.
+    const transactionHash = await xpringClient.send(
+      amount,
+      destinationAddress,
+      wallet
+    );
+
+    // THEN the transaction hash exists and is the expected hash
+    const expectedTransactionBlob = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
+    const expectedTransactionHash = Utils.transactionBlobToTransactionHash(
+      expectedTransactionBlob
+    );
+
+    assert.exists(transactionHash);
+    assert.strictEqual(transactionHash, expectedTransactionHash);
+  });
+
+  it("Send XRP Transaction - success with string", async function() {
+    // GIVEN a XpringClient, a wallet, and a numeric string denominated amount.
+    const xpringClient = new XpringClient(fakeSucceedingNetworkClient);
+    const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
+      .wallet;
+    const destinationAddress = "rUi8dmUEg8JM5Kc92TWvCcuHdA3Ng3NCe8";
+    const amount = "10";
+
+    // WHEN the account makes a transaction.
+    const transactionHash = await xpringClient.send(
+      amount,
+      destinationAddress,
+      wallet
+    );
+
+    // THEN the transaction hash exists and is the expected hash
+    const expectedTransactionBlob = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
+    const expectedTransactionHash = Utils.transactionBlobToTransactionHash(
+      expectedTransactionBlob
+    );
+
+    assert.exists(transactionHash);
+    assert.strictEqual(transactionHash, expectedTransactionHash);
+  });
+
+  it("Send XRP Transaction - failure with invalid string", function(done) {
+    // GIVEN a XpringClient, a wallet and an amount that is invalid.
+    const xpringClient = new XpringClient(fakeSucceedingNetworkClient);
+    const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
+      .wallet;
+    const destinationAddress = "rUi8dmUEg8JM5Kc92TWvCcuHdA3Ng3NCe8";
+    const amount = "not_a_number";
+
+    // WHEN the account makes a transaction THEN an error is propagated.
+    const transactionHash = xpringClient
+      .send(amount, destinationAddress, wallet)
+      .catch(error => {
+        assert.typeOf(error, "Error");
+        done();
+      });
   });
 
   it("Send XRP Transaction - get fee failure", function(done) {

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { Wallet, WalletGenerationResult, XRPAmount } from "xpring-common-js";
+import { Utils, Wallet, WalletGenerationResult, XRPAmount } from "xpring-common-js";
 
 import chai from "chai";
 import chaiString from "chai-string";
@@ -72,16 +72,18 @@ describe("Xpring Client", function(): void {
     amount.setDrops("10");
 
     // WHEN the account makes a transaction.
-    const submissionResult = await xpringClient.send(
+    const transactionHash = await xpringClient.send(
       amount,
       destinationAddress,
       wallet
     );
 
-    // THEN the transaction has a success code attached.
-    const successCode = 0;
-    assert.exists(submissionResult);
-    assert.equal(submissionResult.getEngineResultCode(), successCode);
+    // THEN the transaction hash exists and is the expected hash
+    const expectedTransactionBlob = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
+    const expectedTransactionHash = Utils.transactionBlobToTransactionHash(expectedTransactionBlob);
+
+    assert.exists(transactionHash);
+    assert.strictEqual(transactionHash, expectedTransactionHash);
   });
 
   it("Send XRP Transaction - get fee failure", function(done) {

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -1,11 +1,8 @@
 import { assert } from "chai";
 
-import {
-  Utils,
-  Wallet,
-  WalletGenerationResult,
-  XRPAmount
-} from "xpring-common-js";
+/* global BigInt */
+
+import { Utils, Wallet, WalletGenerationResult } from "xpring-common-js";
 
 import chai from "chai";
 import chaiString from "chai-string";
@@ -73,8 +70,7 @@ describe("Xpring Client", function(): void {
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress = "rUi8dmUEg8JM5Kc92TWvCcuHdA3Ng3NCe8";
-    const amount = new XRPAmount();
-    amount.setDrops("10");
+    const amount = BigInt("10");
 
     // WHEN the account makes a transaction.
     const transactionHash = await xpringClient.send(
@@ -105,8 +101,7 @@ describe("Xpring Client", function(): void {
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress = "rUi8dmUEg8JM5Kc92TWvCcuHdA3Ng3NCe8";
-    const amount = new XRPAmount();
-    amount.setDrops("10");
+    const amount = BigInt("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch(error => {
@@ -131,8 +126,7 @@ describe("Xpring Client", function(): void {
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress = "rUi8dmUEg8JM5Kc92TWvCcuHdA3Ng3NCe8";
-    const amount = new XRPAmount();
-    amount.setDrops("10");
+    const amount = BigInt("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch(error => {
@@ -157,8 +151,7 @@ describe("Xpring Client", function(): void {
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress = "rUi8dmUEg8JM5Kc92TWvCcuHdA3Ng3NCe8";
-    const amount = new XRPAmount();
-    amount.setDrops("10");
+    const amount = BigInt("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch(error => {
@@ -177,8 +170,7 @@ describe("Xpring Client", function(): void {
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress = "invalid_xrp_address";
-    const amount = new XRPAmount();
-    amount.setDrops("10");
+    const amount = BigInt("10");
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch(error => {


### PR DESCRIPTION
Protocol buffers have proven hard for external developers to grok and they shouldn't need to learn how protocol buffers work to use Xpring SDK. Instead, provide native types in the API. 

Specifically: 
- Modify `getBalance` to return `BigInt` not a protocol buffer
- Modify `send` to take a `BigInt` amount instead of a protocol buffer.
- Modify `send` to return a transaction hash `string` instead of a protocol buffer
- Hook up tests for `transactionBlobToTransactionHash` (taken from xpring-common-js)

These are breaking API changes and will be accompanied with an appropriate version bump. 
