### PR TITLE
Remove gRPC Installation Step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: "Install dependencies"
           command: |
-            sudo npm -g i nyc codecov grpc-tools
+            sudo npm -g i nyc codecov
             npm i xpring-common-js@latest
       - save_cache:
           paths:


### PR DESCRIPTION
gRPC protocol buffers are generated from xpring-common-js. This dep isn't needed to build this library. 