### PR TITLE
Update documentation for X-Addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![CircleCI](https://img.shields.io/circleci/build/github/xpring-eng/xpring-js/master?style=flat-square)](https://circleci.com/gh/xpring-eng/xpring-js/tree/master) [![CodeCov](https://img.shields.io/codecov/c/github/xpring-eng/xpring-js?style=flat-square)]((https://codecov.io/gh/xpring-eng/xpring-js))
+[![CircleCI](https://img.shields.io/circleci/build/github/xpring-eng/Xpring-JS?style=flat-square)](https://circleci.com/gh/xpring-eng/xpring-js/tree/master) 
+[![CodeCov](https://img.shields.io/codecov/c/github/xpring-eng/xpring-js?style=flat-square)]((https://codecov.io/gh/xpring-eng/xpring-js))
+[![Dependabot Status](https://img.shields.io/static/v1?label=Dependabot&message=enabled&color=success&style=flat-square&logo=dependabot)](https://dependabot.com)
 
 # Xpring-JS
 
@@ -35,6 +37,9 @@ grpc.xpring.tech:80
 Xpring is working on building a zero-config way for XRP node users to deploy and use the adapter as an open-source component of [rippled](https://github.com/ripple/rippled). Watch this space!
 
 ## Usage
+
+*Note*: Xpring SDK only works with X-Addresses. You can learn more about working with X-Addresses in the `Utils` section below and at http://xrpaddress.info.
+
 ### Wallets
 A wallet is a fundamental model object in XpringKit which provides key management, address derivation, and signing functionality. Wallets can be derived from either a seed or a mnemonic and derivation path. You can also choose to generate a new random HD wallet.
 
@@ -133,10 +138,10 @@ const { XpringClient } = require("xpring-js");
 const remoteURL = "grpc.xpring.tech:80";
 const xpringClient = XpringClient.xpringClientWithEndpoint(remoteURL);
 
-const address = "r3v29rxf54cave7ooQE6eE7G5VFXofKZT7";
+const address = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
 
 const balance = await xpringClient.getBalance(address);
-console.log(balance.getDrops()); // Logs a balance in drops of XRP
+console.log(balance); // Logs a balance in drops of XRP
 ```
 
 #### Sending XRP
@@ -150,16 +155,15 @@ const remoteURL = "grpc.xpring.tech:80";
 const xpringClient = XpringClient.xpringClientWithEndpoint(remoteURL);
 
 // Amount of XRP to send
-const amount = new XRPAmount();
-amount.setDrops("10");
+const amount = BigInt("10")
 
 // Destination address.
-const destinationAddress = "r3v29rxf54cave7ooQE6eE7G5VFXofKZT7";
+const destinationAddress = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
 
 // Wallet which will send XRP
 const senderWallet = Wallet.generateRandomWallet();
 
-const result = await xpringClient.send(amount, destinationAddress, senderWallet);
+const transactionHash = await xpringClient.send(amount, destinationAddress, senderWallet);
 ```
 
 ### Utilities
@@ -170,11 +174,50 @@ The Utils object provides an easy way to validate addresses.
 ```javascript
 const { Utils } = require("xpring-js")
 
-const rippleAddress = "rnysDDrRXxz9z66DmCmfWpq4Z5s4TyUP3G";
+const rippleClassicAddress = "rnysDDrRXxz9z66DmCmfWpq4Z5s4TyUP3G"
+const rippleXAddress = "X7jjQ4d6bz1qmjwxYUsw6gtxSyjYv5iWPqPEjGqqhn9Woti";
 const bitcoinAddress = "1DiqLtKZZviDxccRpowkhVowsbLSNQWBE8";
 
-Utils.isValidAddress(rippleAddress); // returns true
+Utils.isValidAddress(rippleClassicAddress); // returns true
+Utils.isValidAddress(rippleXAddress); // returns true
 Utils.isValidAddress(bitcoinAddress); // returns false
+```
+
+You can also validate if an address is an X-Address or a classic address.
+```javascript
+const { Utils } = require("xpring-js")
+
+const rippleClassicAddress = "rnysDDrRXxz9z66DmCmfWpq4Z5s4TyUP3G"
+const rippleXAddress = "X7jjQ4d6bz1qmjwxYUsw6gtxSyjYv5iWPqPEjGqqhn9Woti";
+const bitcoinAddress = "1DiqLtKZZviDxccRpowkhVowsbLSNQWBE8";
+
+Utils.isValidXAddress(rippleClassicAddress); // returns false
+Utils.isValidXAddress(rippleXAddress); // returns true
+Utils.isValidXAddress(bitcoinAddress); // returns false
+
+Utils.isValidClassicAddress(rippleClassicAddress); // returns true
+Utils.isValidClassicAddress(rippleXAddress); // returns false
+Utils.isValidClassicAddress(bitcoinAddress); // returns false
+```
+
+### X-Address Encoding
+
+You can encode and decode X-Addresses with the SDK. 
+
+```javascript
+const { Utils } = require("xpring-js")
+
+const rippleClassicAddress = "rnysDDrRXxz9z66DmCmfWpq4Z5s4TyUP3G"
+const tag = 12345;
+
+// Encode an X-Address.
+const xAddress = Utils.encodeXAddress(rippleClassicAddress, tag); // X7jjQ4d6bz1qmjwxYUsw6gtxSyjYv5xRB7JM3ht8XC4P45P
+
+// Decode an X-Address.
+const decodedClassicAddress = Utils.decodeXAddress(xAddress);
+
+console.log(decodedClassicAddress.address); // rnysDDrRXxz9z66DmCmfWpq4Z5s4TyUP3G
+console.log(decodedClassicAddress.tag); // 12345
 ```
 
 ## Development


### PR DESCRIPTION
This PR updates the documentation for X-Address based features. Essentially, these changes are:
- If you call an API with a non X-Address, we now throw you an error
- New utilities for validating if an address is an X-Address or Classic Address
- New utilities for encoding and decoding X-Addresses
- You can now send to destination tags, but only if you encode as an X-Address (see above)

Also minor updates to our badges (add dependabot, fix build badge).

I'll send a separate PR that introduces the Contributing Guidelines and Code of Conduct. 