### PR TITLE
Support `LastLedgerSequence` in transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6684,9 +6684,9 @@
       }
     },
     "xpring-common-js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-1.1.7.tgz",
-      "integrity": "sha512-zqXdiPXgexSpwdeS+Pl+SMMJfSCYsKGJTDLQs9TSw1ZzS07yoBRackQCDQCcuLs94b2jGtk32j+WkuONNX6YhQ==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-1.1.8.tgz",
+      "integrity": "sha512-AfeGvzympXBoxjDQf/qoKsD5H4cUD94xhURSbxeMqjUjJM/PcZtwbitn1/zwWk9l+CtdNKMWMhUPX9DSoK6zhg==",
       "requires": {
         "bip32": "2.0.4",
         "bip39": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint **/*.ts",
     "lint:fix": "eslint **/*.ts --fix",
     "prepublishOnly": "npm run clean && npm test && tsc -d",
-    "test": "nyc mocha"
+    "test": "npm run lint && nyc mocha"
   },
   "homepage": "https://github.com/xpring-eng/Xpring-JS#readme",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint **/*.ts",
     "lint:fix": "eslint **/*.ts --fix",
     "prepublishOnly": "npm run clean && npm test && tsc -d",
-    "test": "npm run lint && nyc mocha"
+    "test": "nyc mocha"
   },
   "homepage": "https://github.com/xpring-eng/Xpring-JS#readme",
   "devDependencies": {
@@ -51,7 +51,7 @@
     "typescript-eslint-parser": "22.0.0"
   },
   "dependencies": {
-    "xpring-common-js": "1.1.7"
+    "xpring-common-js": "1.1.8"
   },
   "nyc": {
     "extension": [

--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -7,7 +7,9 @@ import {
   GetFeeRequest,
   SubmitSignedTransactionRequest,
   SubmitSignedTransactionResponse,
-  grpcCredentials
+  grpcCredentials,
+  GetLatestValidatedLedgerSequenceRequest,
+  LedgerSequence
 } from "xpring-common-js";
 
 /**
@@ -58,6 +60,23 @@ class GRPCNetworkClient implements Networking.NetworkClient {
     return new Promise((resolve, reject): void => {
       this.grpcClient.submitSignedTransaction(
         submitSignedTransactionRequest,
+        (error, response): void => {
+          if (error != null || response == null) {
+            reject(error);
+            return;
+          }
+          resolve(response);
+        }
+      );
+    });
+  }
+
+  public async getLatestValidatedLedgerSequence(
+    getLatestValidatedLedgerSequenceRequest: GetLatestValidatedLedgerSequenceRequest
+  ): Promise<LedgerSequence> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.getLatestValidatedLedgerSequence(
+        getLatestValidatedLedgerSequenceRequest,
         (error, response): void => {
           if (error != null || response == null) {
             reject(error);

--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -61,7 +61,7 @@ class GRPCNetworkClient implements Networking.NetworkClient {
       this.grpcClient.submitSignedTransaction(
         submitSignedTransactionRequest,
         (error, response): void => {
-          if (error != null || response == null) {
+          if (error !== null || response === null) {
             reject(error);
             return;
           }

--- a/src/network-client.ts
+++ b/src/network-client.ts
@@ -4,7 +4,9 @@ import {
   GetAccountInfoRequest,
   GetFeeRequest,
   SubmitSignedTransactionRequest,
-  SubmitSignedTransactionResponse
+  SubmitSignedTransactionResponse,
+  GetLatestValidatedLedgerSequenceRequest,
+  LedgerSequence
 } from "xpring-common-js";
 
 /**
@@ -27,4 +29,7 @@ export interface NetworkClient {
   submitSignedTransaction(
     submitSignedTransactionRequest: SubmitSignedTransactionRequest
   ): Promise<SubmitSignedTransactionResponse>;
+  getLatestValidatedLedgerSequence(
+    getLatestValidatedLedgerSequenceRequest: GetLatestValidatedLedgerSequenceRequest
+  ): Promise<LedgerSequence>;
 }

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -33,7 +33,7 @@ export class XpringClientErrorMessages {
  * XpringClient is a client which interacts with the Xpring platform.
  */
 class XpringClient {
-  private ledgerSequenceMargin = 10;
+  private ledgerSequenceMargin: number = 10;
 
   /**
    * Create a new XpringClient.
@@ -167,7 +167,7 @@ class XpringClient {
           transaction.setFee(fee);
           transaction.setSequence(accountInfo.getSequence());
           transaction.setPayment(payment);
-          transaction.setLastLedgerSequence(ledgerSequence + 100);
+          transaction.setLastLedgerSequence(ledgerSequence + this.ledgerSequenceMargin);
           transaction.setSigningPublicKeyHex(sender.getPublicKey());
 
           var signedTransaction;

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -223,8 +223,7 @@ class XpringClient {
     const ledgerSequence = await this.networkClient.getLatestValidatedLedgerSequence(
       getLatestValidatedLedgerSequenceRequest
     );
-    const index = ledgerSequence.getIndex();
-    return index;
+    return ledgerSequence.getIndex();
   }
 
   private async getAccountInfo(address: string): Promise<AccountInfo> {

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -33,7 +33,8 @@ export class XpringClientErrorMessages {
  * XpringClient is a client which interacts with the Xpring platform.
  */
 class XpringClient {
-  private ledgerSequenceMargin: number = 10;
+  /** A margin to pad the current ledger sequence with when submitting transactions. */
+  private readonly ledgerSequenceMargin: number = 10;
 
   /**
    * Create a new XpringClient.

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -151,7 +151,7 @@ class XpringClient {
         async accountInfo => {
           return this.getLastValidatedLedgerSequence().then(
             async ledgerSequence => {
-              if (accountInfo.getSequence() == undefined) {
+              if (accountInfo.getSequence() === undefined) {
                 return Promise.reject(
                   new Error(XpringClientErrorMessages.malformedResponse)
                 );

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -6,7 +6,9 @@ import {
   GetFeeRequest,
   SubmitSignedTransactionResponse,
   SubmitSignedTransactionRequest,
-  XRPAmount
+  XRPAmount,
+  GetLatestValidatedLedgerSequenceRequest,
+  LedgerSequence
 } from "xpring-common-js";
 
 /**
@@ -137,5 +139,11 @@ export class FakeNetworkClient implements NetworkClient {
     }
 
     return Promise.resolve(submitSignedTransactionResponse);
+  }
+
+  getLatestValidatedLedgerSequence(
+    _getLatestValidatedLedgerSequenceRequest: GetLatestValidatedLedgerSequenceRequest
+  ): Promise<LedgerSequence> {
+    return Promise.resolve(new LedgerSequence());
   }
 }

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -36,6 +36,7 @@ export class FakeNetworkClientResponses {
   public static defaultErrorResponses = new FakeNetworkClientResponses(
     FakeNetworkClientResponses.defaultError,
     FakeNetworkClientResponses.defaultError,
+    FakeNetworkClientResponses.defaultError,
     FakeNetworkClientResponses.defaultError
   );
 
@@ -45,7 +46,7 @@ export class FakeNetworkClientResponses {
    * @param getAccountInfoResponse The response or error that will be returned from the getAccountInfo request. Default is the default account info response.
    * @param getFeeResponse The response or error that will be returned from the getFee request. Defaults to the default fee response.
    * @param submitSignedTransactionResponse The response or error that will be returned from the submitSignedTransaction request. Defaults to the default submit signed transaction response.
-
+   * @param getLatestValidatedLedgerSequenceResponse The response or error that will be returned from the getLatestValidatedLedgerRequest. Defaults to the default ledger sequence response.
    */
   public constructor(
     public readonly getAccountInfoResponse: Response<
@@ -56,7 +57,8 @@ export class FakeNetworkClientResponses {
     > = FakeNetworkClientResponses.defaultFeeResponse(),
     public readonly submitSignedTransactionResponse: Response<
       SubmitSignedTransactionResponse
-    > = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse()
+    > = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+    public readonly getLatestValidatedLedgerSequenceResponse: Response<LedgerSequence> = FakeNetworkClientResponses.defaultLedgerSequenceResponse()
   ) {}
 
   /**
@@ -98,6 +100,16 @@ export class FakeNetworkClientResponses {
     submitSignedTransactionResponse.setTransactionBlob("DEADBEEF");
 
     return submitSignedTransactionResponse;
+  }
+
+  /**
+   * Construct a default LedgerSequence response.
+   */
+  public static defaultLedgerSequenceResponse(): LedgerSequence {
+    const ledgerSequence = new LedgerSequence();
+    ledgerSequence.setIndex(12);
+
+    return ledgerSequence;
   }
 }
 
@@ -144,6 +156,10 @@ export class FakeNetworkClient implements NetworkClient {
   getLatestValidatedLedgerSequence(
     _getLatestValidatedLedgerSequenceRequest: GetLatestValidatedLedgerSequenceRequest
   ): Promise<LedgerSequence> {
-    return Promise.resolve(new LedgerSequence());
-  }
+    const ledgerSequenceResponse = this.responses.getLatestValidatedLedgerSequenceResponse;
+    if (ledgerSequenceResponse instanceof Error) {
+      return Promise.reject(ledgerSequenceResponse);
+    }
+
+    return Promise.resolve(ledgerSequenceResponse);  }
 }

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -16,7 +16,7 @@ const recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
 const wallet = Wallet.generateWalletFromSeed("snYP7oArxKepd3GPDcrjMsJYiJeJB")!;
 
 // The XpringClient that makes requests
-const grpcURL = "127.0.0.1:3002";
+const grpcURL = "grpc.xpring.tech:80";
 const xrpClient = XpringClient.xpringClientWithEndpoint(grpcURL);
 
 // Some amount of XRP to send.
@@ -32,8 +32,6 @@ describe("Xpring JS Integration Tests", function(): void {
 
   it("Send XRP", async function() {
     this.timeout(timeoutMs);
-
-    console.log("hitting " + grpcURL);
 
     const result = await xrpClient.send(amount, recipientAddress, wallet);
     assert.exists(result);

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -16,7 +16,7 @@ const recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
 const wallet = Wallet.generateWalletFromSeed("snYP7oArxKepd3GPDcrjMsJYiJeJB")!;
 
 // The XpringClient that makes requests
-const grpcURL = "grpc.xpring.tech:80";
+const grpcURL = "127.0.0.1:3002";
 const xrpClient = XpringClient.xpringClientWithEndpoint(grpcURL);
 
 // Some amount of XRP to send.
@@ -32,6 +32,8 @@ describe("Xpring JS Integration Tests", function(): void {
 
   it("Send XRP", async function() {
     this.timeout(timeoutMs);
+
+    console.log("hitting " + grpcURL);
 
     const result = await xrpClient.send(amount, recipientAddress, wallet);
     assert.exists(result);

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -239,6 +239,33 @@ describe("Xpring Client", function(): void {
     });
   });
 
+  it("Send XRP Transaction - get latest ledger sequence failure", function(done) {
+    // GIVEN a XpringClient which will fail to retrieve account info.
+    const feeFailureResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeNetworkClientResponses.defaultError
+    );
+    const feeFailingNetworkClient = new FakeNetworkClient(feeFailureResponses);
+    const xpringClient = new XpringClient(feeFailingNetworkClient);
+    const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
+      .wallet;
+    const destinationAddress =
+      "X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH";
+    const amount = BigInt("10");
+
+    // WHEN a payment is attempted THEN an error is propagated.
+    xpringClient.send(amount, destinationAddress, wallet).catch(error => {
+      assert.typeOf(error, "Error");
+      assert.equal(
+        error.message,
+        FakeNetworkClientResponses.defaultError.message
+      );
+      done();
+    });
+  });
+
   it("Send XRP Transaction - submission failure", function(done) {
     // GIVEN a XpringClient which will to submit a transaction.
     const feeFailureResponses = new FakeNetworkClientResponses(


### PR DESCRIPTION
- Update `xpring-common-js`
- Wire a new RPC for retrieving the latest ledger sequence
- When sending, retrieve the last ledger sequence, pad by a constant amount, and add to `lastLedgerSequence` 
- Add tests