### PR TITLE
Implement Transaction Status API

### DIFF
--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -9,7 +9,9 @@ import {
   SubmitSignedTransactionResponse,
   grpcCredentials,
   GetLatestValidatedLedgerSequenceRequest,
-  LedgerSequence
+  LedgerSequence,
+  GetTransactionStatusRequest,
+  TransactionStatus
 } from "xpring-common-js";
 
 /**
@@ -77,6 +79,23 @@ class GRPCNetworkClient implements Networking.NetworkClient {
     return new Promise((resolve, reject): void => {
       this.grpcClient.getLatestValidatedLedgerSequence(
         getLatestValidatedLedgerSequenceRequest,
+        (error, response): void => {
+          if (error != null || response == null) {
+            reject(error);
+            return;
+          }
+          resolve(response);
+        }
+      );
+    });
+  }
+
+  public async getTransactionStatus(
+    getTransactionStatusRequest: GetTransactionStatusRequest
+  ): Promise<TransactionStatus> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.getTransactionStatus(
+        getTransactionStatusRequest,
         (error, response): void => {
           if (error != null || response == null) {
             reject(error);

--- a/src/network-client.ts
+++ b/src/network-client.ts
@@ -6,7 +6,9 @@ import {
   SubmitSignedTransactionRequest,
   SubmitSignedTransactionResponse,
   GetLatestValidatedLedgerSequenceRequest,
-  LedgerSequence
+  LedgerSequence,
+  GetTransactionStatusRequest,
+  TransactionStatus
 } from "xpring-common-js";
 
 /**
@@ -32,4 +34,7 @@ export interface NetworkClient {
   getLatestValidatedLedgerSequence(
     getLatestValidatedLedgerSequenceRequest: GetLatestValidatedLedgerSequenceRequest
   ): Promise<LedgerSequence>;
+  getTransactionStatus(
+    getTransactionStatusRequest: GetTransactionStatusRequest
+  ): Promise<TransactionStatus>;
 }

--- a/src/transaction-status.ts
+++ b/src/transaction-status.ts
@@ -1,0 +1,16 @@
+/** Represents statuses of transactions. */
+enum TransactionStatus {
+  /** The transaction was included in a finalized ledger and failed. */
+  Failed,
+
+  /** The transaction is not included in a finalized ledger. */
+  Pending,
+
+  /** The transaction was included in a finalized ledger and succeeded. */
+  Succeeded,
+
+  /** The transaction was included in a finalized ledger and succeeded. */
+  Unknown
+}
+
+export default TransactionStatus;

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -8,7 +8,9 @@ import {
   SubmitSignedTransactionRequest,
   XRPAmount,
   GetLatestValidatedLedgerSequenceRequest,
-  LedgerSequence
+  LedgerSequence,
+  GetTransactionStatusRequest,
+  TransactionStatus
 } from "xpring-common-js";
 
 /**
@@ -37,6 +39,7 @@ export class FakeNetworkClientResponses {
     FakeNetworkClientResponses.defaultError,
     FakeNetworkClientResponses.defaultError,
     FakeNetworkClientResponses.defaultError,
+    FakeNetworkClientResponses.defaultError,
     FakeNetworkClientResponses.defaultError
   );
 
@@ -46,7 +49,8 @@ export class FakeNetworkClientResponses {
    * @param getAccountInfoResponse The response or error that will be returned from the getAccountInfo request. Default is the default account info response.
    * @param getFeeResponse The response or error that will be returned from the getFee request. Defaults to the default fee response.
    * @param submitSignedTransactionResponse The response or error that will be returned from the submitSignedTransaction request. Defaults to the default submit signed transaction response.
-   * @param getLatestValidatedLedgerSequenceResponse The response or error that will be returned from the getLatestValidatedLedgerRequest. Defaults to the default ledger sequence response.
+   * @param getLatestValidatedLedgerSequenceResponse The response or error that will be returned from the getLatestValidatedLedger request. Defaults to the default ledger sequence response.
+   * @param getTransactionStatusResponse The response or error that will be returned from the getTransactionStatus request. Defaults to the default transaction status response.
    */
   public constructor(
     public readonly getAccountInfoResponse: Response<
@@ -58,7 +62,8 @@ export class FakeNetworkClientResponses {
     public readonly submitSignedTransactionResponse: Response<
       SubmitSignedTransactionResponse
     > = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-    public readonly getLatestValidatedLedgerSequenceResponse: Response<LedgerSequence> = FakeNetworkClientResponses.defaultLedgerSequenceResponse()
+    public readonly getLatestValidatedLedgerSequenceResponse: Response<LedgerSequence> = FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+    public readonly getTransactionStatusResponse: Response<TransactionStatus> = FakeNetworkClientResponses.defaultTransactionStatusResponse()
   ) {}
 
   /**
@@ -111,6 +116,17 @@ export class FakeNetworkClientResponses {
 
     return ledgerSequence;
   }
+
+  /**
+   * Construct a default Transaction status response.
+   */
+  public static defaultTransactionStatusResponse(): TransactionStatus {
+    const transactionStatus = new TransactionStatus();
+    transactionStatus.setValidated(true);
+    transactionStatus.setTransactionStatusCode("tesSUCCESS");
+
+    return transactionStatus;
+  }
 }
 
 /**
@@ -161,5 +177,15 @@ export class FakeNetworkClient implements NetworkClient {
       return Promise.reject(ledgerSequenceResponse);
     }
 
-    return Promise.resolve(ledgerSequenceResponse);  }
+    return Promise.resolve(ledgerSequenceResponse);  
+  }
+
+  getTransactionStatus( _getTransactionStatusRequest: GetTransactionStatusRequest): Promise<TransactionStatus> {
+    const transactionStatusResponse = this.responses.getTransactionStatusResponse;
+    if (transactionStatusResponse instanceof Error) {
+      return Promise.reject(transactionStatusResponse);
+    }
+
+    return Promise.resolve(transactionStatusResponse);
+  }
 }

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -1,6 +1,7 @@
 import { Wallet, XRPAmount } from "xpring-common-js";
 import XpringClient from "../src/xpring-client";
 import { assert } from "chai";
+import TransactionStatus from "../src/transaction-status";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-magic-numbers */
@@ -15,9 +16,13 @@ const recipientAddress = "X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4";
 // A wallet with some balance on TestNet.
 const wallet = Wallet.generateWalletFromSeed("snYP7oArxKepd3GPDcrjMsJYiJeJB")!;
 
+// A hash of a successfully validated transaction.
+const transactionHash =
+  "2CBBD2523478848DA256F8EBFCBD490DD6048A4A5094BF8E3034F57EA6AA0522";
+
 // The XpringClient that makes requests
 const grpcURL = "grpc.xpring.tech:80";
-const xrpClient = XpringClient.xpringClientWithEndpoint(grpcURL);
+const xpringClient = XpringClient.xpringClientWithEndpoint(grpcURL);
 
 // Some amount of XRP to send.
 const amount = BigInt("1");
@@ -26,14 +31,23 @@ describe("Xpring JS Integration Tests", function(): void {
   it("Get Account Balance", async function() {
     this.timeout(timeoutMs);
 
-    const balance = await xrpClient.getBalance(recipientAddress);
+    const balance = await xpringClient.getBalance(recipientAddress);
     assert.exists(balance);
+  });
+
+  it("Get Transaction Status", async function() {
+    this.timeout(timeoutMs);
+
+    const transactionStatus = await xpringClient.getTransactionStatus(
+      transactionHash
+    );
+    assert.deepEqual(transactionStatus, TransactionStatus.Succeeded);
   });
 
   it("Send XRP", async function() {
     this.timeout(timeoutMs);
 
-    const result = await xrpClient.send(amount, recipientAddress, wallet);
+    const result = await xpringClient.send(amount, recipientAddress, wallet);
     assert.exists(result);
   });
 });

--- a/test/xpring-client-test.ts
+++ b/test/xpring-client-test.ts
@@ -2,7 +2,12 @@ import { assert } from "chai";
 
 /* global BigInt */
 
-import { Utils, Wallet, WalletGenerationResult } from "xpring-common-js";
+import {
+  Utils,
+  Wallet,
+  WalletGenerationResult,
+  TransactionStatus as TransactionStatusResponse
+} from "xpring-common-js";
 
 import chai from "chai";
 import chaiString from "chai-string";
@@ -12,6 +17,7 @@ import {
   FakeNetworkClientResponses
 } from "./fakes/fake-network-client";
 import "mocha";
+import TransactionStatus from "../src/transaction-status";
 
 const fakeSucceedingNetworkClient = new FakeNetworkClient();
 const fakeErroringNetworkClient = new FakeNetworkClient(
@@ -21,6 +27,11 @@ const fakeErroringNetworkClient = new FakeNetworkClient(
 chai.use(chaiString);
 
 const testAddress = "X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH";
+
+const transactionStatusCodeSuccess = "tesSUCCESS";
+const transactionStatusCodeFailure = "tecFAILURE";
+
+const transactionHash = "DEADBEEF";
 
 describe("Xpring Client", function(): void {
   it("Get Account Balance - successful response", async function() {
@@ -283,6 +294,133 @@ describe("Xpring Client", function(): void {
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch(error => {
+      assert.typeOf(error, "Error");
+      assert.equal(
+        error.message,
+        FakeNetworkClientResponses.defaultError.message
+      );
+      done();
+    });
+  });
+
+  it("Get Transaction Status - Unvalidated Transaction and Failure Code", async function() {
+    // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
+    const transactionStatusResponse = new TransactionStatusResponse();
+    transactionStatusResponse.setValidated(false);
+    transactionStatusResponse.setTransactionStatusCode(
+      transactionStatusCodeFailure
+    );
+    const transactionStatusResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+      transactionStatusResponse
+    );
+    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
+    const xpringClient = new XpringClient(fakeNetworkClient);
+
+    // WHEN the transaction status is retrieved.
+    const transactionStatus = await xpringClient.getTransactionStatus(
+      transactionHash
+    );
+
+    // THEN the status is pending.
+    assert.deepEqual(transactionStatus, TransactionStatus.Pending);
+  });
+
+  it("Get Transaction Status - Unvalidated Transaction and Success Code", async function() {
+    // GIVEN a XpringClient which will return an unvalidated transaction with a success code.
+    const transactionStatusResponse = new TransactionStatusResponse();
+    transactionStatusResponse.setValidated(false);
+    transactionStatusResponse.setTransactionStatusCode(
+      transactionStatusCodeSuccess
+    );
+    const transactionStatusResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+      transactionStatusResponse
+    );
+    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
+    const xpringClient = new XpringClient(fakeNetworkClient);
+
+    // WHEN the transaction status is retrieved.
+    const transactionStatus = await xpringClient.getTransactionStatus(
+      transactionHash
+    );
+
+    // THEN the status is pending.
+    assert.deepEqual(transactionStatus, TransactionStatus.Pending);
+  });
+
+  it("Get Transaction Status - Validated Transaction and Failure Code", async function() {
+    // GIVEN a XpringClient which will return an validated transaction with a failure code.
+    const transactionStatusResponse = new TransactionStatusResponse();
+    transactionStatusResponse.setValidated(true);
+    transactionStatusResponse.setTransactionStatusCode(
+      transactionStatusCodeFailure
+    );
+    const transactionStatusResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+      transactionStatusResponse
+    );
+    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
+    const xpringClient = new XpringClient(fakeNetworkClient);
+
+    // WHEN the transaction status is retrieved.
+    const transactionStatus = await xpringClient.getTransactionStatus(
+      transactionHash
+    );
+
+    // THEN the status is failed.
+    assert.deepEqual(transactionStatus, TransactionStatus.Failed);
+  });
+
+  it("Get Transaction Status - Validated Transaction and Success Code", async function() {
+    // GIVEN a XpringClient which will return an validated transaction with a success code.
+    const transactionStatusResponse = new TransactionStatusResponse();
+    transactionStatusResponse.setValidated(true);
+    transactionStatusResponse.setTransactionStatusCode(
+      transactionStatusCodeSuccess
+    );
+    const transactionStatusResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+      transactionStatusResponse
+    );
+    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
+    const xpringClient = new XpringClient(fakeNetworkClient);
+
+    // WHEN the transaction status is retrieved.
+    const transactionStatus = await xpringClient.getTransactionStatus(
+      transactionHash
+    );
+
+    // THEN the status is succeeded.
+    assert.deepEqual(transactionStatus, TransactionStatus.Succeeded);
+  });
+
+  it("Get Transaction Status - Node Error", function(done) {
+    // GIVEN a XpringClient which will error when a transaction status is requested.
+    const transactionStatusResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+      FakeNetworkClientResponses.defaultError
+    );
+    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
+    const xpringClient = new XpringClient(fakeNetworkClient);
+
+    // WHEN the transaction status is retrieved THEN an error is thrown.
+    xpringClient.getTransactionStatus(transactionHash).catch(error => {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,


### PR DESCRIPTION
Code Changes:
- Wire RPC for getTransactionStatus
- Add enum for Transaction Status
- Wire RPC and enum to a new `getTransactionStatus` API

Tested:
- Add unit tests 
- Add integration Tests

This is part of a group of PRs:
- Xpring-JS / JavaScript: https://github.com/xpring-eng/Xpring-JS/pull/77
- Xpring4J / Java: https://github.com/xpring-eng/xpring4j/pull/44
- XpringKit / Swift: https://github.com/xpring-eng/XpringKit/pull/40

Note: Integration tests failing until the Appian node wrapper is updated. PR is here: https://github.com/xpring-eng/AppianJS/pull/29