### PR TITLE
Export `ClassicAddress` from Xpring-JS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
   AccountInfo,
+  ClassicAddress,
   SubmitSignedTransactionResponse,
   XRPAmount,
   Wallet,


### PR DESCRIPTION
Needed so clients can easily work with the returned interface when decoding an X-Address using the `Utils` class. 