### PR TITLE
Consume protocol buffers from Submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,18 @@ jobs:
             - v1-dependencies-
 
       - protobuf/install
+
+      - run:
+          name: "Pull submodules"
+          command: git submodule update --init --recursive
+
       - run:
           name: "Install dependencies"
           command: |
             sudo npm -g i nyc codecov
             npm i xpring-common-js@latest
             npm rebuild
+
       - save_cache:
           paths:
             - node_modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "xpring-common-protocol-buffers"]
+	path = xpring-common-protocol-buffers
+	url = http://github.com/xpring-eng/xpring-common-protocol-buffers
+	branch = master

--- a/package-lock.json
+++ b/package-lock.json
@@ -2738,6 +2738,419 @@
         }
       }
     },
+    "grpc-tools": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.8.0.tgz",
+      "integrity": "sha512-GzYHjPQ/sbV/DmnNRksapMlLj26Tvq2Qppmzjmd+lHYZNeWM1feiGsYCduzJLyy295P+3uYIPy2/w/1thAnOow==",
+      "requires": {
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true
+        }
+      }
+    },
     "grpc_tools_node_protoc_ts": {
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/grpc_tools_node_protoc_ts/-/grpc_tools_node_protoc_ts-2.5.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
   },
   "scripts": {
     "build": "tsc -d",
-    "clean": "rm -rf ./build",
+    "clean": "rm -rf ./generated ./dist ./build",
+    "pretest": "./scripts/regenerate_protos.sh && tsc",
     "lint": "eslint **/*.ts",
     "lint:fix": "eslint **/*.ts --fix",
-    "prepublishOnly": "npm run clean && npm test && tsc -d",
-    "test": "npm run lint && nyc mocha"
+    "test": "npm run lint && nyc mocha",
+    "prepublishOnly": "npm test && tsc -d"
   },
   "homepage": "https://github.com/xpring-eng/Xpring-JS#readme",
   "devDependencies": {
@@ -51,6 +52,7 @@
     "typescript-eslint-parser": "22.0.0"
   },
   "dependencies": {
+    "grpc-tools": "^1.8.0",
     "xpring-common-js": "1.1.13"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript-eslint-parser": "22.0.0"
   },
   "dependencies": {
+    "grpc": "^1.24.2",
     "grpc-tools": "^1.8.0",
     "xpring-common-js": "1.1.14"
   },

--- a/scripts/regenerate_protos.sh
+++ b/scripts/regenerate_protos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+echo "Regenerating Protocol Buffers"
+
+# Directory to write generated code to (.js and .d.ts files)
+JS_OUT_DIR="./build/generated"
+TS_OUT_DIR="./generated"
+
+mkdir -p $TS_OUT_DIR
+mkdir -p $JS_OUT_DIR
+
+# Generate node code.
+$PWD/node_modules/grpc-tools/bin/protoc \
+    --js_out=import_style=commonjs,binary:$TS_OUT_DIR \
+    --js_out=import_style=commonjs,binary:$JS_OUT_DIR \
+    --grpc_out=$TS_OUT_DIR \
+    --grpc_out=$JS_OUT_DIR \
+    --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` \
+    --proto_path=$PWD/xpring-common-protocol-buffers/proto \
+    $PWD/xpring-common-protocol-buffers/**/*.proto
+
+# Generate tyepscript declaration files.
+$PWD/node_modules/grpc-tools/bin/protoc \
+    --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts \
+    --ts_out=$TS_OUT_DIR \
+    --ts_out=$JS_OUT_DIR \
+    --proto_path=$PWD/xpring-common-protocol-buffers/proto \
+    $PWD/xpring-common-protocol-buffers/**/*.proto
+
+echo "All done!"

--- a/scripts/regenerate_protos.sh
+++ b/scripts/regenerate_protos.sh
@@ -21,7 +21,7 @@ $PWD/node_modules/grpc-tools/bin/protoc \
     --proto_path=$PWD/xpring-common-protocol-buffers/proto \
     $PWD/xpring-common-protocol-buffers/**/*.proto
 
-# Generate tyepscript declaration files.
+# Generate typescript declaration files.
 $PWD/node_modules/grpc-tools/bin/protoc \
     --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts \
     --ts_out=$TS_OUT_DIR \

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -1,18 +1,14 @@
-import {
-  AccountInfo,
-  GetAccountInfoRequest,
-  GetFeeRequest,
-  GetLatestValidatedLedgerSequenceRequest,
-  GetTransactionStatusRequest,
-  Payment,
-  Signer,
-  SubmitSignedTransactionRequest,
-  Transaction,
-  TransactionStatus as RawTransactionStatus,
-  Utils,
-  Wallet,
-  XRPAmount
-} from "xpring-common-js";
+import { Signer, Utils, Wallet } from "xpring-common-js";
+import { AccountInfo } from "../generated/account_info_pb";
+import { GetAccountInfoRequest } from "../generated/get_account_info_request_pb";
+import { GetFeeRequest } from "../generated/get_fee_request_pb";
+import { GetLatestValidatedLedgerSequenceRequest } from "../generated/get_latest_validated_ledger_sequence_request_pb";
+import { GetTransactionStatusRequest } from "../generated/get_transaction_status_request_pb";
+import { Payment } from "../generated/payment_pb";
+import { SubmitSignedTransactionRequest } from "../generated/submit_signed_transaction_request_pb";
+import { Transaction } from "../generated/transaction_pb";
+import { TransactionStatus as RawTransactionStatus } from "../generated/transaction_status_pb";
+import { XRPAmount } from "../generated/xrp_amount_pb";
 import { NetworkClient } from "./network-client";
 import GRPCNetworkClient from "./grpc-network-client";
 import { XpringClientDecorator } from "./xpring-client-decorator";

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -45,7 +45,7 @@ class DefaultXpringClient implements XpringClientDecorator {
   public static defaultXpringClientWithEndpoint(
     grpcURL: string
   ): DefaultXpringClient {
-    const grpcClient = new GRPCNetworkClient(grpcURL);
+    const grpcClient = new GRPCNetworkClient(grpcURL, null);
     return new DefaultXpringClient(grpcClient);
   }
 

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -45,7 +45,7 @@ class DefaultXpringClient implements XpringClientDecorator {
   public static defaultXpringClientWithEndpoint(
     grpcURL: string
   ): DefaultXpringClient {
-    const grpcClient = new GRPCNetworkClient(grpcURL, null);
+    const grpcClient = new GRPCNetworkClient(grpcURL);
     return new DefaultXpringClient(grpcClient);
   }
 

--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -1,18 +1,17 @@
 import * as Networking from "./network-client";
-import {
-  XRPLedgerAPIClient,
-  AccountInfo,
-  Fee,
-  GetAccountInfoRequest,
-  GetFeeRequest,
-  SubmitSignedTransactionRequest,
-  SubmitSignedTransactionResponse,
-  grpcCredentials,
-  GetLatestValidatedLedgerSequenceRequest,
-  LedgerSequence,
-  GetTransactionStatusRequest,
-  TransactionStatus
-} from "xpring-common-js";
+import { XRPLedgerAPIClient } from "../generated/xrp_ledger_grpc_pb";
+import { AccountInfo } from "../generated/account_info_pb";
+import { Fee } from "../generated/fee_pb";
+import { GetFeeRequest } from "../generated/get_fee_request_pb";
+import { GetAccountInfoRequest } from "../generated/get_account_info_request_pb";
+import { SubmitSignedTransactionRequest } from "../generated/submit_signed_transaction_request_pb";
+import { SubmitSignedTransactionResponse } from "../generated/submit_signed_transaction_response_pb";
+import { GetLatestValidatedLedgerSequenceRequest } from "../generated/get_latest_validated_ledger_sequence_request_pb";
+import { LedgerSequence } from "../generated/ledger_sequence_pb";
+import { GetTransactionStatusRequest } from "../generated/get_transaction_status_request_pb";
+import { TransactionStatus } from "../generated/transaction_status_pb";
+
+import { credentials } from "grpc";
 
 /**
  * A GRPC Based network client.
@@ -23,7 +22,7 @@ class GRPCNetworkClient implements Networking.NetworkClient {
   public constructor(grpcURL: string) {
     this.grpcClient = new XRPLedgerAPIClient(
       grpcURL,
-      grpcCredentials.createInsecure()
+      credentials.createInsecure()
     );
   }
 


### PR DESCRIPTION
Consume protocol buffers from a submodule rather than reading them from xpring-common-js. 

This is useful because this library will have to choose which protocol buffers it uses when it is compiled for webpack. Consuming protocol buffers from this top level target means that xpring-common-js doesn't need to do anything fancy for webpack to just work. 

