### PR TITLE
Upgrade Xpring-Common-JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript-eslint-parser": "22.0.0"
   },
   "dependencies": {
-    "xpring-common-js": "1.1.13"
+    "xpring-common-js": "1.1.14"
   },
   "nyc": {
     "extension": [

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -160,11 +160,13 @@ describe("utils", function(): void {
     const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address and tag as are expected.
-    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(
+      classicAddress!.address,
+      "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+    );
     assert.strictEqual(classicAddress!.tag, 12345);
     assert.strictEqual(classicAddress!.test, false);
   });
-
 
   it("decodeXAddress() - Valid Testnet Address with Tag", function(): void {
     // GIVEN an x-address that encodes an address and a tag.
@@ -174,7 +176,10 @@ describe("utils", function(): void {
     const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address and tag as are expected.
-    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(
+      classicAddress!.address,
+      "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+    );
     assert.strictEqual(classicAddress!.tag, 12345);
     assert.strictEqual(classicAddress!.test, true);
   });
@@ -187,7 +192,10 @@ describe("utils", function(): void {
     const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address and tag as are expected.
-    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(
+      classicAddress!.address,
+      "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1"
+    );
     assert.isUndefined(classicAddress!.tag);
   });
 

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -1,4 +1,4 @@
-import Utils from "../src/utils";
+import Utils from "../src/index";
 import { assert } from "chai";
 import "mocha";
 

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -1,4 +1,4 @@
-import Utils from "../src/index";
+import { Utils } from "../src/index";
 import { assert } from "chai";
 import "mocha";
 

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -1,11 +1,11 @@
-import { Utils } from "xpring-common-js";
+import Utils from "../src/utils";
 import { assert } from "chai";
 import "mocha";
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-describe("Utils", function(): void {
+describe("utils", function(): void {
   it("isValidAddress() - Valid Classic Address", function(): void {
     // GIVEN a valid classic address.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
@@ -95,18 +95,35 @@ describe("Utils", function(): void {
     assert.isFalse(validAddress);
   });
 
-  it("encodeXAddress() - Address and Tag", function(): void {
-    // GIVEN a valid classic address and a tag.
+  it("encodeXAddress() - Mainnet Address and Tag", function(): void {
+    // GIVEN a valid classic address on MainNet and a tag.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
     const tag = 12345;
+    const isTest = false;
 
     // WHEN they are encoded to an x-address.
-    const xAddress = Utils.encodeXAddress(address, tag);
+    const xAddress = Utils.encodeXAddress(address, tag, isTest);
 
     // THEN the result is as expected.
     assert.strictEqual(
       xAddress,
       "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
+    );
+  });
+
+  it("encodeXAddress() - TestNet Address and Tag", function(): void {
+    // GIVEN a valid classic address on TestNet and a tag.
+    const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+    const tag = 12345;
+    const isTest = true;
+
+    // WHEN they are encoded to an x-address.
+    const xAddress = Utils.encodeXAddress(address, tag, isTest);
+
+    // THEN the result is as expected.
+    assert.strictEqual(
+      xAddress,
+      "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh"
     );
   });
 
@@ -135,16 +152,31 @@ describe("Utils", function(): void {
     assert.isUndefined(xAddress);
   });
 
-  it("decodeXAddress() - Valid Address with Tag", function(): void {
+  it("decodeXAddress() - Valid Mainnet Address with Tag", function(): void {
     // GIVEN an x-address that encodes an address and a tag.
     const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
 
     // WHEN it is decoded to an classic address
-    const xAddress = Utils.decodeXAddress(address);
+    const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address and tag as are expected.
-    assert.strictEqual(xAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
-    assert.strictEqual(xAddress!.tag, 12345);
+    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(classicAddress!.tag, 12345);
+    assert.strictEqual(classicAddress!.test, false);
+  });
+
+
+  it("decodeXAddress() - Valid Testnet Address with Tag", function(): void {
+    // GIVEN an x-address that encodes an address and a tag.
+    const address = "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh";
+
+    // WHEN it is decoded to an classic address
+    const classicAddress = Utils.decodeXAddress(address);
+
+    // Then the decoded address and tag as are expected.
+    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(classicAddress!.tag, 12345);
+    assert.strictEqual(classicAddress!.test, true);
   });
 
   it("decodeXAddress() - Valid Address without Tag", function(): void {
@@ -152,11 +184,11 @@ describe("Utils", function(): void {
     const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH";
 
     // WHEN it is decoded to an classic address
-    const xAddress = Utils.decodeXAddress(address);
+    const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address and tag as are expected.
-    assert.strictEqual(xAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
-    assert.isUndefined(xAddress!.tag);
+    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.isUndefined(classicAddress!.tag);
   });
 
   it("decodeXAddress() - Invalid Address", function(): void {
@@ -164,10 +196,76 @@ describe("Utils", function(): void {
     const address = "xrp";
 
     // WHEN it is decoded to an classic address
-    const xAddress = Utils.decodeXAddress(address);
+    const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address is undefined.
-    assert.isUndefined(xAddress);
+    assert.isUndefined(classicAddress);
+  });
+
+  it("isValidXAddress() - Valid X-Address", function(): void {
+    // GIVEN a valid X-Address.
+    const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
+
+    // WHEN the address is validated for being an X-Address.
+    const isValid = Utils.isValidXAddress(address);
+
+    // THEN the address is reported as valid.
+    assert.isTrue(isValid);
+  });
+
+  it("isValidXAddress() - Classic Address", function(): void {
+    // GIVEN a valid classic address.
+    const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+
+    // WHEN the address is validated for being an X-Address.
+    const isValid = Utils.isValidXAddress(address);
+
+    // THEN the address is reported as invalid.
+    assert.isFalse(isValid);
+  });
+
+  it("isValidXAddress() - Invalid Address", function(): void {
+    // GIVEN an invalid address.
+    const address = "xrp";
+
+    // WHEN the address is validated for being an X-Address.
+    const isValid = Utils.isValidXAddress(address);
+
+    // THEN the address is reported as invalid.
+    assert.isFalse(isValid);
+  });
+
+  it("isValidClassicAddress() - Valid X-Address", function(): void {
+    // GIVEN a valid X-Address.
+    const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
+
+    // WHEN the address is validated for being a classic address.
+    const isValid = Utils.isValidClassicAddress(address);
+
+    // THEN the address is reported as invalid.
+    assert.isFalse(isValid);
+  });
+
+  it("isValidClassicAddress() - Classic Address", function(): void {
+    // GIVEN a valid classic address.
+    const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+
+    // WHEN the address is validated for being a classic address.
+    const isValid = Utils.isValidClassicAddress(address);
+
+    // THEN the address is reported as valid.
+    assert.isTrue(isValid);
+  });
+
+  it("isValidClassicAddress() - Invalid Address", function(): void {
+    // GIVEN an invalid address.
+    const address = "xrp";
+
+    // WHEN the address is validated for being a classic address.
+    const isValid = Utils.isValidClassicAddress(address);
+
+    // THEN the address is reported as invalid.
+    assert.isFalse(isValid);
   });
 
   it("transactionBlobHex() - Valid transaction blob", function(): void {


### PR DESCRIPTION
This upgrade exposes a new `test` parameter on X-Address related functionality. 

Note that I also synced all Utils tests between the two libraries. This pulls in the new X-Address tests. 