### PR TITLE
Migrate existing code to `Legacy` subfolders

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = xpring-common-protocol-buffers
 	url = http://github.com/xpring-eng/xpring-common-protocol-buffers
 	branch = master
-[submodule "rippled"]
-	path = rippled
-	url = http://github.com/cjcobb23/rippled
-    branch = grpcSupport

--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -1,25 +1,25 @@
 import { Signer, Utils, Wallet } from "xpring-common-js";
-import { AccountInfo } from "../generated/legacy/account_info_pb";
-import { GetAccountInfoRequest } from "../generated/legacy/get_account_info_request_pb";
-import { GetFeeRequest } from "../generated/legacy/get_fee_request_pb";
-import { GetLatestValidatedLedgerSequenceRequest } from "../generated/legacy/get_latest_validated_ledger_sequence_request_pb";
-import { GetTransactionStatusRequest } from "../generated/legacy/get_transaction_status_request_pb";
-import { Payment } from "../generated/legacy/payment_pb";
-import { SubmitSignedTransactionRequest } from "../generated/legacy/submit_signed_transaction_request_pb";
-import { Transaction } from "../generated/legacy/transaction_pb";
-import { TransactionStatus as RawTransactionStatus } from "../generated/legacy/transaction_status_pb";
-import { XRPAmount } from "../generated/legacy/xrp_amount_pb";
-import { NetworkClient } from "./network-client";
-import GRPCNetworkClient from "./grpc-network-client";
-import { XpringClientDecorator } from "./xpring-client-decorator";
-import TransactionStatus from "./transaction-status";
+import { AccountInfo } from "../../generated/legacy/account_info_pb";
+import { GetAccountInfoRequest } from "../../generated/legacy/get_account_info_request_pb";
+import { GetFeeRequest } from "../../generated/legacy/get_fee_request_pb";
+import { GetLatestValidatedLedgerSequenceRequest } from "../../generated/legacy/get_latest_validated_ledger_sequence_request_pb";
+import { GetTransactionStatusRequest } from "../../generated/legacy/get_transaction_status_request_pb";
+import { Payment } from "../../generated/legacy/payment_pb";
+import { SubmitSignedTransactionRequest } from "../../generated/legacy/submit_signed_transaction_request_pb";
+import { Transaction } from "../../generated/legacy/transaction_pb";
+import { TransactionStatus as RawTransactionStatus } from "../../generated/legacy/transaction_status_pb";
+import { XRPAmount } from "../../generated/legacy/xrp_amount_pb";
+import { LegacyNetworkClient } from "./legacy-network-client";
+import LegacyGRPCNetworkClient from "./legacy-grpc-network-client";
+import { XpringClientDecorator } from "../xpring-client-decorator";
+import TransactionStatus from "../transaction-status";
 
 /* global BigInt */
 
 /**
  * Error messages from XpringClient.
  */
-export class XpringClientErrorMessages {
+export class LegacyXpringClientErrorMessages {
   public static readonly malformedResponse = "Malformed Response.";
   public static readonly signingFailure = "Unable to sign the transaction";
   /* eslint-disable  @typescript-eslint/indent */
@@ -34,7 +34,7 @@ const ledgerSequenceMargin = 10;
 /**
  * DefaultXpringClient is a client which interacts with the Xpring platform.
  */
-class DefaultXpringClient implements XpringClientDecorator {
+class LegacyDefaultXpringClient implements XpringClientDecorator {
   /**
    * Create a new DefaultXpringClient.
    *
@@ -44,9 +44,9 @@ class DefaultXpringClient implements XpringClientDecorator {
    */
   public static defaultXpringClientWithEndpoint(
     grpcURL: string
-  ): DefaultXpringClient {
-    const grpcClient = new GRPCNetworkClient(grpcURL);
-    return new DefaultXpringClient(grpcClient);
+  ): LegacyDefaultXpringClient {
+    const grpcClient = new LegacyGRPCNetworkClient(grpcURL);
+    return new LegacyDefaultXpringClient(grpcClient);
   }
 
   /**
@@ -56,7 +56,7 @@ class DefaultXpringClient implements XpringClientDecorator {
    *
    * @param networkClient A network client which will manage remote RPCs to Rippled.
    */
-  public constructor(private readonly networkClient: NetworkClient) {}
+  public constructor(private readonly networkClient: LegacyNetworkClient) {}
 
   /**
    * Retrieve the balance for the given address.
@@ -67,7 +67,7 @@ class DefaultXpringClient implements XpringClientDecorator {
   public async getBalance(address: string): Promise<BigInt> {
     if (!Utils.isValidXAddress(address)) {
       return Promise.reject(
-        new Error(XpringClientErrorMessages.xAddressRequired)
+        new Error(LegacyXpringClientErrorMessages.xAddressRequired)
       );
     }
 
@@ -75,7 +75,7 @@ class DefaultXpringClient implements XpringClientDecorator {
       const balance = accountInfo.getBalance();
       if (balance === undefined) {
         return Promise.reject(
-          new Error(XpringClientErrorMessages.malformedResponse)
+          new Error(LegacyXpringClientErrorMessages.malformedResponse)
         );
       }
 
@@ -123,7 +123,7 @@ class DefaultXpringClient implements XpringClientDecorator {
   ): Promise<string> {
     if (!Utils.isValidXAddress(destination)) {
       return Promise.reject(
-        new Error(XpringClientErrorMessages.xAddressRequired)
+        new Error(LegacyXpringClientErrorMessages.xAddressRequired)
       );
     }
 
@@ -136,7 +136,7 @@ class DefaultXpringClient implements XpringClientDecorator {
             async ledgerSequence => {
               if (accountInfo.getSequence() === undefined) {
                 return Promise.reject(
-                  new Error(XpringClientErrorMessages.malformedResponse)
+                  new Error(LegacyXpringClientErrorMessages.malformedResponse)
                 );
               }
 
@@ -162,14 +162,14 @@ class DefaultXpringClient implements XpringClientDecorator {
                 signedTransaction = Signer.signTransaction(transaction, sender);
               } catch (signingError) {
                 const signingErrorMessage =
-                  XpringClientErrorMessages.signingFailure +
+                  LegacyXpringClientErrorMessages.signingFailure +
                   ". " +
                   signingError.message;
                 return Promise.reject(new Error(signingErrorMessage));
               }
               if (signedTransaction == undefined) {
                 return Promise.reject(
-                  new Error(XpringClientErrorMessages.signingFailure)
+                  new Error(LegacyXpringClientErrorMessages.signingFailure)
                 );
               }
 
@@ -187,7 +187,7 @@ class DefaultXpringClient implements XpringClientDecorator {
                   );
                   if (!transactionHash) {
                     return Promise.reject(
-                      new Error(XpringClientErrorMessages.malformedResponse)
+                      new Error(LegacyXpringClientErrorMessages.malformedResponse)
                     );
                   }
                   return Promise.resolve(transactionHash);
@@ -233,7 +233,7 @@ class DefaultXpringClient implements XpringClientDecorator {
       const feeAmount = fee.getAmount();
       if (feeAmount == undefined) {
         return Promise.reject(
-          new Error(XpringClientErrorMessages.malformedResponse)
+          new Error(LegacyXpringClientErrorMessages.malformedResponse)
         );
       }
       return feeAmount;
@@ -256,4 +256,4 @@ class DefaultXpringClient implements XpringClientDecorator {
   }
 }
 
-export default DefaultXpringClient;
+export default LegacyDefaultXpringClient;

--- a/src/legacy/legacy-grpc-network-client.ts
+++ b/src/legacy/legacy-grpc-network-client.ts
@@ -1,22 +1,22 @@
-import * as Networking from "./network-client";
-import { XRPLedgerAPIClient } from "../generated/legacy/xrp_ledger_grpc_pb";
-import { AccountInfo } from "../generated/legacy/account_info_pb";
-import { Fee } from "../generated/legacy/fee_pb";
-import { GetFeeRequest } from "../generated/legacy/get_fee_request_pb";
-import { GetAccountInfoRequest } from "../generated/legacy/get_account_info_request_pb";
-import { SubmitSignedTransactionRequest } from "../generated/legacy/submit_signed_transaction_request_pb";
-import { SubmitSignedTransactionResponse } from "../generated/legacy/submit_signed_transaction_response_pb";
-import { GetLatestValidatedLedgerSequenceRequest } from "../generated/legacy/get_latest_validated_ledger_sequence_request_pb";
-import { LedgerSequence } from "../generated/legacy/ledger_sequence_pb";
-import { GetTransactionStatusRequest } from "../generated/legacy/get_transaction_status_request_pb";
-import { TransactionStatus } from "../generated/legacy/transaction_status_pb";
+import { XRPLedgerAPIClient } from "../../generated/legacy/xrp_ledger_grpc_pb";
+import { AccountInfo } from "../../generated/legacy/account_info_pb";
+import { Fee } from "../../generated/legacy/fee_pb";
+import { GetFeeRequest } from "../../generated/legacy/get_fee_request_pb";
+import { GetAccountInfoRequest } from "../../generated/legacy/get_account_info_request_pb";
+import { SubmitSignedTransactionRequest } from "../../generated/legacy/submit_signed_transaction_request_pb";
+import { SubmitSignedTransactionResponse } from "../../generated/legacy/submit_signed_transaction_response_pb";
+import { GetLatestValidatedLedgerSequenceRequest } from "../../generated/legacy/get_latest_validated_ledger_sequence_request_pb";
+import { LedgerSequence } from "../../generated/legacy/ledger_sequence_pb";
+import { GetTransactionStatusRequest } from "../../generated/legacy/get_transaction_status_request_pb";
+import { TransactionStatus } from "../../generated/legacy/transaction_status_pb";
+import { LegacyNetworkClient } from "./legacy-network-client";
 
 import { credentials } from "grpc";
 
 /**
  * A GRPC Based network client.
  */
-class GRPCNetworkClient implements Networking.NetworkClient {
+class LegacyGRPCNetworkClient implements LegacyNetworkClient {
   private readonly grpcClient: XRPLedgerAPIClient;
 
   public constructor(grpcURL: string) {
@@ -107,4 +107,4 @@ class GRPCNetworkClient implements Networking.NetworkClient {
   }
 }
 
-export default GRPCNetworkClient;
+export default LegacyGRPCNetworkClient;

--- a/src/legacy/legacy-network-client.ts
+++ b/src/legacy/legacy-network-client.ts
@@ -14,7 +14,7 @@ import {
 /**
  * An error that can occur when making a request.
  */
-export interface NetworkServiceError {
+export interface LegacyNetworkServiceError {
   message: string;
   code: number;
   metadata: object;
@@ -23,7 +23,7 @@ export interface NetworkServiceError {
 /**
  * The network client interface provides a wrapper around network calls to the Xpring Platform.
  */
-export interface NetworkClient {
+export interface LegacyNetworkClient {
   getAccountInfo(
     getAccountInfoRequest: GetAccountInfoRequest
   ): Promise<AccountInfo>;

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -1,6 +1,6 @@
 import { Wallet } from "xpring-common-js";
 import { XpringClientDecorator } from "./xpring-client-decorator";
-import DefaultXpringClient from "./default-xpring-client";
+import LegacyDefaultXpringClient from "./legacy/legacy-default-xpring-client";
 import TransactionStatus from "./transaction-status";
 import ReliableSubmissionXpringClient from "./reliable-submission-xpring-client";
 
@@ -20,7 +20,7 @@ class XpringClient {
    * @param grpcURL The URL of the gRPC instance to connect to.
    */
   public constructor(grpcURL: string) {
-    const defaultXpringClient = DefaultXpringClient.defaultXpringClientWithEndpoint(
+    const defaultXpringClient = LegacyDefaultXpringClient.defaultXpringClientWithEndpoint(
       grpcURL
     );
 

--- a/test/legacy/fakes/fake-legacy-network-client.ts
+++ b/test/legacy/fakes/fake-legacy-network-client.ts
@@ -1,4 +1,4 @@
-import { NetworkClient } from "../../src/network-client";
+import { NetworkClient } from "../../src/legacy/legaacy-network-client";
 import {
   AccountInfo,
   Fee,
@@ -21,7 +21,7 @@ type Response<T> = T | Error;
 /**
  * A list of responses the fake network client will give.
  */
-export class FakeNetworkClientResponses {
+export class FakeLegacyNetworkClientResponses {
   /**
    * A default error.
    */

--- a/test/legacy/fakes/fake-legacy-network-client.ts
+++ b/test/legacy/fakes/fake-legacy-network-client.ts
@@ -1,4 +1,4 @@
-import { NetworkClient } from "../../src/legacy/legaacy-network-client";
+import { LegacyNetworkClient } from "../../../src/legacy/legacy-network-client";
 import {
   AccountInfo,
   Fee,
@@ -30,17 +30,17 @@ export class FakeLegacyNetworkClientResponses {
   /**
    * A default set of responses that will always succeed.
    */
-  public static defaultSuccessfulResponses = new FakeNetworkClientResponses();
+  public static defaultSuccessfulResponses = new FakeLegacyNetworkClientResponses();
 
   /**
    * A default set of responses that will always fail.
    */
-  public static defaultErrorResponses = new FakeNetworkClientResponses(
-    FakeNetworkClientResponses.defaultError,
-    FakeNetworkClientResponses.defaultError,
-    FakeNetworkClientResponses.defaultError,
-    FakeNetworkClientResponses.defaultError,
-    FakeNetworkClientResponses.defaultError
+  public static defaultErrorResponses = new FakeLegacyNetworkClientResponses(
+    FakeLegacyNetworkClientResponses.defaultError,
+    FakeLegacyNetworkClientResponses.defaultError,
+    FakeLegacyNetworkClientResponses.defaultError,
+    FakeLegacyNetworkClientResponses.defaultError,
+    FakeLegacyNetworkClientResponses.defaultError
   );
 
   /**
@@ -55,15 +55,15 @@ export class FakeLegacyNetworkClientResponses {
   public constructor(
     public readonly getAccountInfoResponse: Response<
       AccountInfo
-    > = FakeNetworkClientResponses.defaultAccountInfoResponse(),
+    > = FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
     public readonly getFeeResponse: Response<
       Fee
-    > = FakeNetworkClientResponses.defaultFeeResponse(),
+    > = FakeLegacyNetworkClientResponses.defaultFeeResponse(),
     public readonly submitSignedTransactionResponse: Response<
       SubmitSignedTransactionResponse
-    > = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-    public readonly getLatestValidatedLedgerSequenceResponse: Response<LedgerSequence> = FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
-    public readonly getTransactionStatusResponse: Response<TransactionStatus> = FakeNetworkClientResponses.defaultTransactionStatusResponse()
+    > = FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+    public readonly getLatestValidatedLedgerSequenceResponse: Response<LedgerSequence> = FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
+    public readonly getTransactionStatusResponse: Response<TransactionStatus> = FakeLegacyNetworkClientResponses.defaultTransactionStatusResponse()
   ) {}
 
   /**
@@ -132,9 +132,9 @@ export class FakeLegacyNetworkClientResponses {
 /**
  * A fake network client which stubs network interaction.
  */
-export class FakeNetworkClient implements NetworkClient {
+export class FakeLegacyNetworkClient implements LegacyNetworkClient {
   public constructor(
-    private readonly responses: FakeNetworkClientResponses = FakeNetworkClientResponses.defaultSuccessfulResponses
+    private readonly responses: FakeLegacyNetworkClientResponses = FakeLegacyNetworkClientResponses.defaultSuccessfulResponses
   ) {}
 
   getAccountInfo(

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -35,7 +35,7 @@ const transactionStatusCodeFailure = "tecFAILURE";
 
 const transactionHash = "DEADBEEF";
 
-describe("Default Xpring Client", function(): void {
+describe("Legacy Default Xpring Client", function(): void {
   it("Get Account Balance - successful response", async function() {
     // GIVEN a DefaultXpringClient.
     const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -11,19 +11,19 @@ import {
 
 import chai from "chai";
 import chaiString from "chai-string";
-import DefaultXpringClient, {
-  XpringClientErrorMessages
-} from "../src/default-xpring-client";
+import LegacyDefaultXpringClient, {
+  LegacyXpringClientErrorMessages
+} from "../../src/legacy/legacy-default-xpring-client";
 import {
-  FakeNetworkClient,
-  FakeNetworkClientResponses
-} from "./fakes/fake-network-client";
+  FakeLegacyNetworkClient,
+  FakeLegacyNetworkClientResponses
+} from "./fakes/fake-legacy-network-client";
 import "mocha";
-import TransactionStatus from "../src/transaction-status";
+import TransactionStatus from "../../src/transaction-status";
 
-const fakeSucceedingNetworkClient = new FakeNetworkClient();
-const fakeErroringNetworkClient = new FakeNetworkClient(
-  FakeNetworkClientResponses.defaultErrorResponses
+const fakeSucceedingNetworkClient = new FakeLegacyNetworkClient();
+const fakeErroringNetworkClient = new FakeLegacyNetworkClient(
+  FakeLegacyNetworkClientResponses.defaultErrorResponses
 );
 
 chai.use(chaiString);
@@ -37,8 +37,8 @@ const transactionHash = "DEADBEEF";
 
 describe("Legacy Default Xpring Client", function(): void {
   it("Get Account Balance - successful response", async function() {
-    // GIVEN a DefaultXpringClient.
-    const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);
+    // GIVEN a LegacyDefaultXpringClient.
+    const xpringClient = new LegacyDefaultXpringClient(fakeSucceedingNetworkClient);
 
     // WHEN the balance for an account is requested.
     const balance = await xpringClient.getBalance(testAddress);
@@ -49,50 +49,50 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Get Account Balance - classic address", function(done) {
     // GIVEN a XpringClient and a classic address
-    const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);
+    const xpringClient = new LegacyDefaultXpringClient(fakeSucceedingNetworkClient);
     const classicAddress = "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn";
 
     // WHEN the balance for an account is requested THEN an error to use X-Addresses is thrown.
     xpringClient.getBalance(classicAddress).catch(error => {
       assert.typeOf(error, "Error");
-      assert.equal(error.message, XpringClientErrorMessages.xAddressRequired);
+      assert.equal(error.message, LegacyXpringClientErrorMessages.xAddressRequired);
       done();
     });
   });
 
   it("Get Account Balance - error", function(done) {
     // GIVEN a XpringClient which wraps an erroring network client.
-    const xpringClient = new DefaultXpringClient(fakeErroringNetworkClient);
+    const xpringClient = new LegacyDefaultXpringClient(fakeErroringNetworkClient);
 
     // WHEN a balance is requested THEN an error is propagated.
     xpringClient.getBalance(testAddress).catch(error => {
       assert.typeOf(error, "Error");
-      assert.equal(error, FakeNetworkClientResponses.defaultError);
+      assert.equal(error, FakeLegacyNetworkClientResponses.defaultError);
       done();
     });
   });
 
   it("Get Account Balance - malformed response, no balance", function(done) {
     // GIVEN a XpringClient which wraps a network client with a malformed response.
-    const accountInfoResponse = FakeNetworkClientResponses.defaultAccountInfoResponse();
+    const accountInfoResponse = FakeLegacyNetworkClientResponses.defaultAccountInfoResponse();
     accountInfoResponse.setBalance(undefined);
-    const fakeNetworkClientResponses = new FakeNetworkClientResponses(
+    const fakeNetworkClientResponses = new FakeLegacyNetworkClientResponses(
       accountInfoResponse
     );
-    const fakeNetworkClient = new FakeNetworkClient(fakeNetworkClientResponses);
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient);
+    const fakeNetworkClient = new FakeLegacyNetworkClient(fakeNetworkClientResponses);
+    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient);
 
     // WHEN a balance is requested THEN an error is propagated.
     xpringClient.getBalance(testAddress).catch(error => {
       assert.typeOf(error, "Error");
-      assert.equal(error.message, XpringClientErrorMessages.malformedResponse);
+      assert.equal(error.message, LegacyXpringClientErrorMessages.malformedResponse);
       done();
     });
   });
 
   it("Send XRP Transaction - success with BigInt", async function() {
     // GIVEN a XpringClient, a wallet, and a BigInt denomonated amount.
-    const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);
+    const xpringClient = new LegacyDefaultXpringClient(fakeSucceedingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -107,7 +107,7 @@ describe("Legacy Default Xpring Client", function(): void {
     );
 
     // THEN the transaction hash exists and is the expected hash
-    const expectedTransactionBlob = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
+    const expectedTransactionBlob = FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
     const expectedTransactionHash = Utils.transactionBlobToTransactionHash(
       expectedTransactionBlob
     );
@@ -118,7 +118,7 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Send XRP Transaction - success with number", async function() {
     // GIVEN a XpringClient, a wallet, and a number denominated amount.
-    const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);
+    const xpringClient = new LegacyDefaultXpringClient(fakeSucceedingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -133,7 +133,7 @@ describe("Legacy Default Xpring Client", function(): void {
     );
 
     // THEN the transaction hash exists and is the expected hash
-    const expectedTransactionBlob = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
+    const expectedTransactionBlob = FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
     const expectedTransactionHash = Utils.transactionBlobToTransactionHash(
       expectedTransactionBlob
     );
@@ -144,7 +144,7 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Send XRP Transaction - success with string", async function() {
     // GIVEN a XpringClient, a wallet, and a numeric string denominated amount.
-    const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);
+    const xpringClient = new LegacyDefaultXpringClient(fakeSucceedingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -159,7 +159,7 @@ describe("Legacy Default Xpring Client", function(): void {
     );
 
     // THEN the transaction hash exists and is the expected hash
-    const expectedTransactionBlob = FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
+    const expectedTransactionBlob = FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse().getTransactionBlob();
     const expectedTransactionHash = Utils.transactionBlobToTransactionHash(
       expectedTransactionBlob
     );
@@ -170,7 +170,7 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Send XRP Transaction - failure with invalid string", function(done) {
     // GIVEN a XpringClient, a wallet and an amount that is invalid.
-    const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);
+    const xpringClient = new LegacyDefaultXpringClient(fakeSucceedingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -186,13 +186,13 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Send XRP Transaction - get fee failure", function(done) {
     // GIVEN a XpringClient which will fail to retrieve a fee.
-    const feeFailureResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultError,
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse()
+    const feeFailureResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultError,
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse()
     );
-    const feeFailingNetworkClient = new FakeNetworkClient(feeFailureResponses);
-    const xpringClient = new DefaultXpringClient(feeFailingNetworkClient);
+    const feeFailingNetworkClient = new FakeLegacyNetworkClient(feeFailureResponses);
+    const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -204,7 +204,7 @@ describe("Legacy Default Xpring Client", function(): void {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
-        FakeNetworkClientResponses.defaultError.message
+        FakeLegacyNetworkClientResponses.defaultError.message
       );
       done();
     });
@@ -212,7 +212,7 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Send XRP Transaction - failure with classic address", function(done) {
     // GIVEN a XpringClient, a wallet, and a classic address as the destination.
-    const xpringClient = new DefaultXpringClient(fakeSucceedingNetworkClient);
+    const xpringClient = new LegacyDefaultXpringClient(fakeSucceedingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress = "rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn";
@@ -221,20 +221,20 @@ describe("Legacy Default Xpring Client", function(): void {
     // WHEN the account makes a transaction THEN an error is thrown.
     xpringClient.send(amount, destinationAddress, wallet).catch(error => {
       assert.typeOf(error, "Error");
-      assert.equal(error.message, XpringClientErrorMessages.xAddressRequired);
+      assert.equal(error.message, LegacyXpringClientErrorMessages.xAddressRequired);
       done();
     });
   });
 
   it("Send XRP Transaction - get account info failure", function(done) {
     // GIVEN a XpringClient which will fail to retrieve account info.
-    const feeFailureResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultError,
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse()
+    const feeFailureResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultError,
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse()
     );
-    const feeFailingNetworkClient = new FakeNetworkClient(feeFailureResponses);
-    const xpringClient = new DefaultXpringClient(feeFailingNetworkClient);
+    const feeFailingNetworkClient = new FakeLegacyNetworkClient(feeFailureResponses);
+    const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -246,7 +246,7 @@ describe("Legacy Default Xpring Client", function(): void {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
-        FakeNetworkClientResponses.defaultError.message
+        FakeLegacyNetworkClientResponses.defaultError.message
       );
       done();
     });
@@ -254,14 +254,14 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Send XRP Transaction - get latest ledger sequence failure", function(done) {
     // GIVEN a XpringClient which will fail to retrieve account info.
-    const feeFailureResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeNetworkClientResponses.defaultError
+    const feeFailureResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeLegacyNetworkClientResponses.defaultError
     );
-    const feeFailingNetworkClient = new FakeNetworkClient(feeFailureResponses);
-    const xpringClient = new DefaultXpringClient(feeFailingNetworkClient);
+    const feeFailingNetworkClient = new FakeLegacyNetworkClient(feeFailureResponses);
+    const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -273,7 +273,7 @@ describe("Legacy Default Xpring Client", function(): void {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
-        FakeNetworkClientResponses.defaultError.message
+        FakeLegacyNetworkClientResponses.defaultError.message
       );
       done();
     });
@@ -281,13 +281,13 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Send XRP Transaction - submission failure", function(done) {
     // GIVEN a XpringClient which will to submit a transaction.
-    const feeFailureResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultError
+    const feeFailureResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultError
     );
-    const feeFailingNetworkClient = new FakeNetworkClient(feeFailureResponses);
-    const xpringClient = new DefaultXpringClient(feeFailingNetworkClient);
+    const feeFailingNetworkClient = new FakeLegacyNetworkClient(feeFailureResponses);
+    const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient);
     const wallet = (Wallet.generateRandomWallet() as WalletGenerationResult)
       .wallet;
     const destinationAddress =
@@ -299,7 +299,7 @@ describe("Legacy Default Xpring Client", function(): void {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
-        FakeNetworkClientResponses.defaultError.message
+        FakeLegacyNetworkClientResponses.defaultError.message
       );
       done();
     });
@@ -312,15 +312,15 @@ describe("Legacy Default Xpring Client", function(): void {
     transactionStatusResponse.setTransactionStatusCode(
       transactionStatusCodeFailure
     );
-    const transactionStatusResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+    const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
       transactionStatusResponse
     );
-    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient);
+    const fakeNetworkClient = new FakeLegacyNetworkClient(transactionStatusResponses);
+    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient);
 
     // WHEN the transaction status is retrieved.
     const transactionStatus = await xpringClient.getTransactionStatus(
@@ -338,15 +338,15 @@ describe("Legacy Default Xpring Client", function(): void {
     transactionStatusResponse.setTransactionStatusCode(
       transactionStatusCodeSuccess
     );
-    const transactionStatusResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+    const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
       transactionStatusResponse
     );
-    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient);
+    const fakeNetworkClient = new FakeLegacyNetworkClient(transactionStatusResponses);
+    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient);
 
     // WHEN the transaction status is retrieved.
     const transactionStatus = await xpringClient.getTransactionStatus(
@@ -364,15 +364,15 @@ describe("Legacy Default Xpring Client", function(): void {
     transactionStatusResponse.setTransactionStatusCode(
       transactionStatusCodeFailure
     );
-    const transactionStatusResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+    const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
       transactionStatusResponse
     );
-    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient);
+    const fakeNetworkClient = new FakeLegacyNetworkClient(transactionStatusResponses);
+    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient);
 
     // WHEN the transaction status is retrieved.
     const transactionStatus = await xpringClient.getTransactionStatus(
@@ -390,15 +390,15 @@ describe("Legacy Default Xpring Client", function(): void {
     transactionStatusResponse.setTransactionStatusCode(
       transactionStatusCodeSuccess
     );
-    const transactionStatusResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
+    const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
       transactionStatusResponse
     );
-    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient);
+    const fakeNetworkClient = new FakeLegacyNetworkClient(transactionStatusResponses);
+    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient);
 
     // WHEN the transaction status is retrieved.
     const transactionStatus = await xpringClient.getTransactionStatus(
@@ -411,22 +411,22 @@ describe("Legacy Default Xpring Client", function(): void {
 
   it("Get Transaction Status - Node Error", function(done) {
     // GIVEN a XpringClient which will error when a transaction status is requested.
-    const transactionStatusResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeNetworkClientResponses.defaultLedgerSequenceResponse(),
-      FakeNetworkClientResponses.defaultError
+    const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
+      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+      FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
+      FakeLegacyNetworkClientResponses.defaultError
     );
-    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses);
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient);
+    const fakeNetworkClient = new FakeLegacyNetworkClient(transactionStatusResponses);
+    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient);
 
     // WHEN the transaction status is retrieved THEN an error is thrown.
     xpringClient.getTransactionStatus(transactionHash).catch(error => {
       assert.typeOf(error, "Error");
       assert.equal(
         error.message,
-        FakeNetworkClientResponses.defaultError.message
+        FakeLegacyNetworkClientResponses.defaultError.message
       );
       done();
     });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require ./node_modules/ts-node/register
 --require ./node_modules/source-map-support/register
 --recursive
-test/*.ts
+test/**/*.ts

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,3 +2,4 @@
 --require ./node_modules/source-map-support/register
 --recursive
 test/**/*.ts
+


### PR DESCRIPTION
rippled is going to implement protocol buffer support natively, which is going to use a set of well reviewed protocol buffers. The implementation in rippled is being done here: https://github.com/ripple/rippled/pull/3159.

In order to do the upgrade in place, we will swap out the base decorator with two implementations: 
- `LegacyDefaultXpringClient`: Uses the old protocol buffers
- `DefaultXpringClient`: Uses the new protocol buffers

Once we have a working implementation, the constructor on `XpringClient` will be changed to take a new boolean parameter, `useLegacy`, which will control with base implementation is used. 

I propose doing this upgrade in a few stages:
- [x] [Generate new versions of the protocol buffers](https://github.com/xpring-eng/Xpring-JS/pull/108)
- [x] Migrate existing code to a `legacy` subdirectory and namespace (This PR)
- [ ] Create code that works with the new protocol buffers from the rippled team
- [ ] Add a boolean parameter to switch between implementations
