### PR TITLE
Network Clients on rippled protocol buffers

### DIFF
--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -1,0 +1,82 @@
+import {
+  GetAccountInfoRequest,
+  GetAccountInfoResponse
+} from "../generated/rpc/v1/account_info_pb";
+import { GetFeeRequest, GetFeeResponse } from "../generated/rpc/v1/fee_pb";
+import { GetTxRequest, GetTxResponse } from "../generated/rpc/v1/tx_pb";
+import {
+  SubmitTransactionRequest,
+  SubmitTransactionResponse
+} from "../generated/rpc/v1/submit_pb";
+import { XRPLedgerAPIServiceClient } from "../generated/rpc/v1/xrp_ledger_grpc_pb";
+
+import { NetworkClient } from "./network-client";
+import { credentials } from "grpc";
+
+/**
+ * A GRPC Based network client.
+ */
+class GRPCNetworkClient implements NetworkClient {
+  private readonly grpcClient: XRPLedgerAPIServiceClient;
+
+  public constructor(grpcURL: string) {
+    this.grpcClient = new XRPLedgerAPIServiceClient(
+      grpcURL,
+      credentials.createInsecure()
+    );
+  }
+
+  public async getAccountInfo(
+    request: GetAccountInfoRequest
+  ): Promise<GetAccountInfoResponse> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.getAccountInfo(request, (error, response): void => {
+        if (error != null || response == null) {
+          reject(error);
+          return;
+        }
+        resolve(response);
+      });
+    });
+  }
+
+  public async getFee(request: GetFeeRequest): Promise<GetFeeResponse> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.getFee(request, (error, response): void => {
+        if (error != null || response == null) {
+          reject(error);
+          return;
+        }
+        resolve(response);
+      });
+    });
+  }
+
+  public async getTx(request: GetTxRequest): Promise<GetTxResponse> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.getTx(request, (error, response): void => {
+        if (error != null || response == null) {
+          reject(error);
+          return;
+        }
+        resolve(response);
+      });
+    });
+  }
+
+  public async submitTransaction(
+    request: SubmitTransactionRequest
+  ): Promise<SubmitTransactionResponse> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.submitTransaction(request, (error, response): void => {
+        if (error != null || response == null) {
+          reject(error);
+          return;
+        }
+        resolve(response);
+      });
+    });
+  }
+}
+
+export default GRPCNetworkClient;

--- a/src/legacy/legacy-network-client.ts
+++ b/src/legacy/legacy-network-client.ts
@@ -12,15 +12,6 @@ import {
 } from "xpring-common-js";
 
 /**
- * An error that can occur when making a request.
- */
-export interface LegacyNetworkServiceError {
-  message: string;
-  code: number;
-  metadata: object;
-}
-
-/**
  * The network client interface provides a wrapper around network calls to the Xpring Platform.
  */
 export interface LegacyNetworkClient {

--- a/src/network-client.ts
+++ b/src/network-client.ts
@@ -1,0 +1,26 @@
+import {
+  GetAccountInfoRequest,
+  GetAccountInfoResponse
+} from "../generated/rpc/v1/account_info_pb";
+import { GetFeeRequest, GetFeeResponse } from "../generated/rpc/v1/fee_pb";
+import { GetTxRequest, GetTxResponse } from "../generated/rpc/v1/tx_pb";
+import {
+  SubmitTransactionRequest,
+  SubmitTransactionResponse
+} from "../generated/rpc/v1/submit_pb";
+
+/**
+ * The network client interface provides a wrapper around network calls to the Xpring Platform.
+ */
+export interface NetworkClient {
+  getAccountInfo(
+    request: GetAccountInfoRequest
+  ): Promise<GetAccountInfoResponse>;
+  getFee(request: GetFeeRequest): Promise<GetFeeResponse>;
+  getTx(request: GetTxRequest): Promise<GetTxResponse>;
+  submitTransaction(
+    request: SubmitTransactionRequest
+  ): Promise<SubmitTransactionResponse>;
+
+  // TODO(keefertaylor): Add last ledger validated sequence.
+}

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -1,0 +1,145 @@
+import { NetworkClient } from "../../src/network-client";
+import {
+  GetAccountInfoRequest,
+  GetAccountInfoResponse
+} from "../../generated/rpc/v1/account_info_pb";
+import { GetFeeRequest, GetFeeResponse } from "../../generated/rpc/v1/fee_pb";
+import { GetTxRequest, GetTxResponse } from "../..//generated/rpc/v1/tx_pb";
+import {
+  SubmitTransactionRequest,
+  SubmitTransactionResponse
+} from "../../generated/rpc/v1/submit_pb";
+
+/**
+ * A response for a request to retrieve type T. Either an instance of T, or an error.
+ */
+type Response<T> = T | Error;
+
+/**
+ * A list of responses the fake network client will give.
+ */
+export class FakeNetworkClientResponses {
+  /**
+   * A default error.
+   */
+  public static defaultError = new Error("fake network client failure");
+
+  /**
+   * A default set of responses that will always succeed.
+   */
+  public static defaultSuccessfulResponses = new FakeNetworkClientResponses();
+
+  /**
+   * A default set of responses that will always fail.
+   */
+  public static defaultErrorResponses = new FakeNetworkClientResponses(
+    FakeNetworkClientResponses.defaultError,
+    FakeNetworkClientResponses.defaultError,
+    FakeNetworkClientResponses.defaultError,
+    FakeNetworkClientResponses.defaultError
+  );
+
+  /**
+   * Construct a new set of responses.
+   *
+   * @param getAccountInfoResponse The response or error that will be returned from the getAccountInfo request. Default is the default account info response.
+   * @param getFeeResponse The response or error that will be returned from the getFee request. Defaults to the default fee response.
+   * @param submitTransactionResponse The response or error that will be returned from the submitTransaction request. Defaults to the default submit transaction response.
+   * @param getTxResponse The response or error that will be returned from the getTransactionStatus request. Defaults to the default transaction status response.
+   */
+  public constructor(
+    public readonly getAccountInfoResponse: Response<
+    GetAccountInfoResponse
+    > = FakeNetworkClientResponses.defaultAccountInfoResponse(),
+    public readonly getFeeResponse: Response<
+    GetFeeResponse
+    > = FakeNetworkClientResponses.defaultFeeResponse(),
+    public readonly submitransactionResponse: Response<
+    SubmitTransactionResponse
+    > = FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
+    public readonly getTransactionStatusResponse: Response<
+    GetTxResponse
+    > = FakeNetworkClientResponses.defaultGetTxResponse()
+  ) {}
+
+  /**
+   * Construct a default AccountInfoResponse.
+   */
+  public static defaultAccountInfoResponse(): GetAccountInfoResponse {
+    return new GetAccountInfoResponse();
+  }
+
+  /**
+   * Construct a default FeeResponse.
+   */
+  public static defaultFeeResponse(): GetFeeResponse {
+    return new GetFeeResponse();
+  }
+
+  /**
+   * Construct a default SubmitTransactionResponse.
+   */
+  public static defaultSubmitTransactionResponse(): SubmitTransactionResponse {
+    return new SubmitTransactionResponse();
+  }
+
+  /**
+   * Construct a default getTx response.
+   */
+  public static defaultGetTxResponse(): GetTxResponse {
+    return new GetTxResponse();
+  }
+}
+
+/**
+ * A fake network client which stubs network interaction.
+ */
+export class FakeNetworkClient implements NetworkClient {
+  public constructor(
+    private readonly responses: FakeNetworkClientResponses = FakeNetworkClientResponses.defaultSuccessfulResponses
+  ) {}
+
+  getAccountInfo(
+    _accountInfoRequest: GetAccountInfoRequest
+  ): Promise<GetAccountInfoResponse> {
+    const accountInfoResponse = this.responses.getAccountInfoResponse;
+    if (accountInfoResponse instanceof Error) {
+      return Promise.reject(accountInfoResponse);
+    }
+
+    return Promise.resolve(accountInfoResponse);
+  }
+
+  getFee(_feeRequest: GetFeeRequest): Promise<GetFeeResponse> {
+    const feeResponse = this.responses.getFeeResponse;
+    if (feeResponse instanceof Error) {
+      return Promise.reject(feeResponse);
+    }
+
+    return Promise.resolve(feeResponse);
+  }
+
+  submitTransaction(
+    _submitSignedTransactionRequest: SubmitTransactionRequest
+  ): Promise<SubmitTransactionResponse> {
+    const submitTransactionResponse = this.responses
+      .submitransactionResponse;
+    if (submitTransactionResponse instanceof Error) {
+      return Promise.reject(submitTransactionResponse);
+    }
+
+    return Promise.resolve(submitTransactionResponse);
+  }
+
+  getTx(
+    _getTransactionStatusRequest: GetTxRequest
+  ): Promise<GetTxResponse> {
+    const transactionStatusResponse = this.responses
+      .getTransactionStatusResponse;
+    if (transactionStatusResponse instanceof Error) {
+      return Promise.reject(transactionStatusResponse);
+    }
+
+    return Promise.resolve(transactionStatusResponse);
+  }
+}


### PR DESCRIPTION
Create a new `NetworkClient` interface, `GRPCNetworkClient` which implements `NetworkClient` and a `FakeNetworkClient` for testing. 

These classes are just light syntactical wrappers around the underlying gRPC implementation which give us: 
- A facade abstraction, if we ever wanted to move off of gRPC
- Promise based callbacks on gRPC
- Testability through a Fake

# Background

rippled is going to implement protocol buffer support natively, which is going to use a set of well reviewed protocol buffers. The implementation in rippled is being done here: https://github.com/ripple/rippled/pull/3159.

In order to do the upgrade in place, we will swap out the base decorator with two implementations: 
- `LegacyDefaultXpringClient`: Uses the old protocol buffers
- `DefaultXpringClient`: Uses the new protocol buffers

Once we have a working implementation, the constructor on `XpringClient` will be changed to take a new boolean parameter, `useLegacy`, which will control with base implementation is used. 

# Status
- [x] [Generate new versions of the protocol buffers](https://github.com/xpring-eng/Xpring-JS/pull/108)
- [x] [Migrate existing code to a `legacy` subdirectory and namespace](https://github.com/xpring-eng/Xpring-JS/pull/109)
- [ ] Create code that works with the new protocol buffers from the rippled team
   - [x] Create a new `NetworkClient` with fakes (this PR)
   - [ ] Create a new `DefaultXpringClient` with tests
   - [ ] Read only calls for new `DefaultXpringClient`
   - [ ] Write calls fro `DeafultXpringClient`
- [ ] Add a boolean parameter to switch between implementations
