### PR TITLE
Abstraction around raw transaction status

### DIFF
--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -7,7 +7,8 @@ import { GetTransactionStatusRequest } from "../../generated/legacy/get_transact
 import { Payment } from "../../generated/legacy/payment_pb";
 import { SubmitSignedTransactionRequest } from "../../generated/legacy/submit_signed_transaction_request_pb";
 import { Transaction } from "../../generated/legacy/transaction_pb";
-import { TransactionStatus as RawTransactionStatus } from "../../generated/legacy/transaction_status_pb";
+import { TransactionStatus as RawTransactionStatusResponse } from "../../generated/legacy/transaction_status_pb";
+import RawTransactionStatus from "../raw-transaction-status";
 import { XRPAmount } from "../../generated/legacy/xrp_amount_pb";
 import { LegacyNetworkClient } from "./legacy-network-client";
 import LegacyGRPCNetworkClient from "./legacy-grpc-network-client";
@@ -187,7 +188,9 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
                   );
                   if (!transactionHash) {
                     return Promise.reject(
-                      new Error(LegacyXpringClientErrorMessages.malformedResponse)
+                      new Error(
+                        LegacyXpringClientErrorMessages.malformedResponse
+                      )
                     );
                   }
                   return Promise.resolve(transactionHash);

--- a/src/raw-transaction-status.ts
+++ b/src/raw-transaction-status.ts
@@ -1,0 +1,6 @@
+/** Abstraction around raw Transaction Status for compatibility. */
+export default interface RawTransactionStatus {
+  getValidated(): boolean;
+  getTransactionStatusCode(): string;
+  getLastLedgerSequence(): number;
+}

--- a/src/reliable-submission-xpring-client.ts
+++ b/src/reliable-submission-xpring-client.ts
@@ -1,8 +1,6 @@
 import { XpringClientDecorator } from "./xpring-client-decorator";
-import {
-  TransactionStatus as RawTransactionStatus,
-  Wallet
-} from "xpring-common-js";
+import { Wallet } from "xpring-common-js";
+import RawTransactionStatus from "./raw-transaction-status";
 
 /* global BigInt */
 /* eslint-disable @typescript-eslint/no-magic-numbers */

--- a/src/xpring-client-decorator.ts
+++ b/src/xpring-client-decorator.ts
@@ -1,8 +1,6 @@
 import TransactionStatus from "./transaction-status";
-import {
-  TransactionStatus as RawTransactionStatus,
-  Wallet
-} from "xpring-common-js";
+import { Wallet } from "xpring-common-js";
+import RawTransactionStatus from "./raw-transaction-status";
 
 /** A decorator interface for XpringClients. */
 export interface XpringClientDecorator {


### PR DESCRIPTION
`XpringClientDecorator` will share a definition across the legacy protocol buffers (from `xpring-common-protocol-buffers`) and the rippled protocol buffers. 

This PR creates an abstraction that wraps the return type from this method in an interface. This will allow us to create a bridge layer between the old and new protocol buffers during the migration.

# Background

rippled is going to implement protocol buffer support natively, which is going to use a set of well reviewed protocol buffers. The implementation in rippled is being done here: https://github.com/ripple/rippled/pull/3159.

In order to do the upgrade in place, we will swap out the base decorator with two implementations: 
- `LegacyDefaultXpringClient`: Uses the old protocol buffers
- `DefaultXpringClient`: Uses the new protocol buffers

Once we have a working implementation, the constructor on `XpringClient` will be changed to take a new boolean parameter, `useLegacy`, which will control with base implementation is used. 

# Status
- [x] [Generate new versions of the protocol buffers](https://github.com/xpring-eng/Xpring-JS/pull/108)
- [x] [Migrate existing code to a `legacy` subdirectory and namespace](https://github.com/xpring-eng/Xpring-JS/pull/109)
- [ ] Create code that works with the new protocol buffers from the rippled team
   - [x] Create a new `NetworkClient` with fakes (this PR)
   - [ ] Create a new `DefaultXpringClient` with tests
   - [ ] Read only calls for new `DefaultXpringClient`
   - [ ] Write calls fro `DeafultXpringClient`
- [ ] Add a boolean parameter to switch between implementations