### PR TITLE
Upgrade xpring-common-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7600,9 +7600,9 @@
       }
     },
     "xpring-common-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-2.0.0.tgz",
-      "integrity": "sha512-xQ645MR9Um9fwlWeYfV90b/tbLEx2bm2Ydv9W6iTqNEVqVPQbnO+9Ijz5lTJgZSlN8ZyaEOAnr5RLOoZdumxrw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-2.0.1.tgz",
+      "integrity": "sha512-wm7h0euQDJCuwcmemaOlW7AH6SNDaD0aaDNUkMrfg4IHRGuElQr5WFCGDfD+vdHJMB5wajuiN+gJDambWeLc+Q==",
       "requires": {
         "@types/google-protobuf": "^3.7.2",
         "bip32": "2.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -970,15 +970,15 @@
       }
     },
     "bip32": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.4.tgz",
-      "integrity": "sha512-ioPytarPDIrWckWMuK4RNUtvwhvWEc2fvuhnO0WEwu732k5OLjUXv4rXi2c/KJHw9ZMNQMkYRJrBw81RujShGQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.5.tgz",
+      "integrity": "sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==",
       "requires": {
         "@types/node": "10.12.18",
         "bs58check": "^2.1.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "tiny-secp256k1": "^1.1.0",
+        "tiny-secp256k1": "^1.1.3",
         "typeforce": "^1.11.5",
         "wif": "^2.0.6"
       }
@@ -1564,9 +1564,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decimal.js": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-5.0.8.tgz",
-      "integrity": "sha1-tIw/t9c6LU1JQOCzjxzSHbWzZ84="
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -3068,9 +3068,9 @@
       }
     },
     "grpc-tools": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.8.1.tgz",
-      "integrity": "sha512-CvZLshEDbum8ZtB8r3bn6JsrHs3L7S1jf7PTa02nZSLmcLTKbiXH5UYrte06Kh7SdzFmkxPMaOsys2rCs+HRjA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.8.0.tgz",
+      "integrity": "sha512-GzYHjPQ/sbV/DmnNRksapMlLj26Tvq2Qppmzjmd+lHYZNeWM1feiGsYCduzJLyy295P+3uYIPy2/w/1thAnOow==",
       "dev": true,
       "requires": {
         "node-pre-gyp": "^0.12.0"
@@ -6354,35 +6354,23 @@
       }
     },
     "ripple-binary-codec": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-0.2.5.tgz",
-      "integrity": "sha512-wCXrdANutgSTzsYFUfifmNYu6j03+1aZhyVXoQr8tKYujqvbLBseJp8ltZwrXGEa43aqQqPn4DBxdQWjEGX0Bg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-0.2.6.tgz",
+      "integrity": "sha512-k0efyjpcde7p+rJ9PXW9tJSYsUDdlC9Z9xU7OPM7fJiHVKlR1E7nfu0jqw9vVXtTG3tujqKeEgtcb8yaa7rMXA==",
       "requires": {
         "babel-runtime": "^6.6.1",
-        "bn.js": "^4.11.3",
+        "bn.js": "^5.1.1",
         "create-hash": "^1.1.2",
-        "decimal.js": "^5.0.8",
+        "decimal.js": "^10.2.0",
         "inherits": "^2.0.1",
         "lodash": "^4.17.15",
-        "ripple-address-codec": "^3.0.4"
+        "ripple-address-codec": "^4.0.0"
       },
       "dependencies": {
-        "base-x": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "ripple-address-codec": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-3.0.4.tgz",
-          "integrity": "sha512-GFk1BgavW+9oy5Z1Cp6YAGMfB51QdbeuhOo0Zir+s+S40F5vHtVZYu6zZE1eOAX92A5kygPuBRX4APH2v8Yhmg==",
-          "requires": {
-            "base-x": "3.0.4",
-            "create-hash": "^1.1.2"
-          }
+        "bn.js": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+          "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
         }
       }
     },
@@ -7612,16 +7600,16 @@
       }
     },
     "xpring-common-js": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-1.1.15.tgz",
-      "integrity": "sha512-MyUUF8hq1WXWJFNwnUmPbHH4PRybvt7lYSd3sF82zY/wdQ6zx6/bm97lT/Kymk54ZW2SkBCeIoPa0RDcOb8+7Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-2.0.0.tgz",
+      "integrity": "sha512-xQ645MR9Um9fwlWeYfV90b/tbLEx2bm2Ydv9W6iTqNEVqVPQbnO+9Ijz5lTJgZSlN8ZyaEOAnr5RLOoZdumxrw==",
       "requires": {
         "@types/google-protobuf": "^3.7.2",
-        "bip32": "2.0.4",
+        "bip32": "2.0.5",
         "bip39": "^3.0.2",
         "google-protobuf": "3.11.2",
         "ripple-address-codec": "4.0.0",
-        "ripple-binary-codec": "0.2.5",
+        "ripple-binary-codec": "0.2.6",
         "ripple-keypairs": "^0.11.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-prettier": "3.1.2",
     "grpc_tools_node_protoc_ts": "2.5.9",
-    "grpc-tools": "^1.8.0",
+    "grpc-tools": "1.8.0",
     "mocha": "7.0.0",
     "mocha-lcov-reporter": "1.3.0",
     "nyc": "15.0.0",
@@ -56,8 +56,8 @@
     "typescript-eslint-parser": "22.0.0"
   },
   "dependencies": {
-    "xpring-common-js": "1.1.15",
-    "grpc": "^1.24.2"
+    "xpring-common-js": "2.0.0",
+    "grpc": "1.24.2"
   },
   "nyc": {
     "extension": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript-eslint-parser": "22.0.0"
   },
   "dependencies": {
-    "xpring-common-js": "2.0.0",
+    "xpring-common-js": "2.0.1",
     "grpc": "1.24.2"
   },
   "nyc": {

--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -159,7 +159,7 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
 
               var signedTransaction;
               try {
-                signedTransaction = Signer.signTransaction(transaction, sender);
+                signedTransaction = Signer.signLegacyTransaction(transaction, sender);
               } catch (signingError) {
                 const signingErrorMessage =
                   LegacyXpringClientErrorMessages.signingFailure +


### PR DESCRIPTION
## High Level Overview of Change

Upgrade xpring-common-js to version 2.0.1.

### Context of Change

rippled implemented protocol buffer support natively, which uses a new and incompatible set of protocol buffers. The implementation in rippled was completed in: https://github.com/ripple/rippled/pull/3159.

xpring-common-js now supports legacy protocol buffers and rippled protocol buffers in version 2.0.0+. Upgrade the library and migrate to the new methods.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After

Method name `signTransaction` was renamed to `signLegacyTransaction` in v2.0.0+ of xpring-common-js

## Test Plan

CI runs unit and integration tests, which continue to pass. 

<!--
## Future Tasks
For future tasks related to PR.
-->
