### PR TITLE
[Draft] - Refactor to use own generated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `XpringClient`'s `getBalance` method using rippled's protocol buffers.
 - Implement `XpringClient`'s `getRawTransactionStatus` method using rippled's protocol buffers.
 - Implement `XpringClient`'s `getTransactionStatus` method using rippled's protocol buffers.
+
+### Refactor
+- Switch Xpring-JS to use it's own generated types instead of XpringCommonJS's Types

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,2 @@
-export {
-  AccountInfo,
-  SubmitSignedTransactionResponse,
-  XRPAmount,
-  Wallet,
-  Utils,
-} from 'xpring-common-js'
+export { Wallet, Utils } from 'xpring-common-js'
 export { default as XpringClient } from './xpring-client'

--- a/src/legacy/legacy-network-client.ts
+++ b/src/legacy/legacy-network-client.ts
@@ -1,15 +1,13 @@
-import {
-  AccountInfo,
-  Fee,
-  GetAccountInfoRequest,
-  GetFeeRequest,
-  SubmitSignedTransactionRequest,
-  SubmitSignedTransactionResponse,
-  GetLatestValidatedLedgerSequenceRequest,
-  LedgerSequence,
-  GetTransactionStatusRequest,
-  TransactionStatus,
-} from 'xpring-common-js'
+import { AccountInfo } from '../generated/legacy/account_info_pb'
+import { Fee } from '../generated/legacy/fee_pb'
+import { GetAccountInfoRequest } from '../generated/legacy/get_account_info_request_pb'
+import { GetFeeRequest } from '../generated/legacy/get_fee_request_pb'
+import { SubmitSignedTransactionRequest } from '../generated/legacy/submit_signed_transaction_request_pb'
+import { SubmitSignedTransactionResponse } from '../generated/legacy/submit_signed_transaction_response_pb'
+import { GetLatestValidatedLedgerSequenceRequest } from '../generated/legacy/get_latest_validated_ledger_sequence_request_pb'
+import { LedgerSequence } from '../generated/legacy/ledger_sequence_pb'
+import { GetTransactionStatusRequest } from '../generated/legacy/get_transaction_status_request_pb'
+import { TransactionStatus } from '../generated/legacy/transaction_status_pb'
 
 /**
  * The network client interface provides a wrapper around network calls to the Xpring Platform.

--- a/test/fakes/fake-xpring-client.ts
+++ b/test/fakes/fake-xpring-client.ts
@@ -1,4 +1,4 @@
-import { TransactionStatus as RawTransactionStatus } from 'xpring-common-js'
+import { TransactionStatus as RawTransactionStatus } from '../../src/generated/legacy/transaction_status_pb'
 import { XpringClientDecorator } from '../../src/xpring-client-decorator'
 import TransactionStatus from '../../src/transaction-status'
 import { Wallet } from '../../src/index'

--- a/test/legacy/fakes/fake-legacy-network-client.ts
+++ b/test/legacy/fakes/fake-legacy-network-client.ts
@@ -1,16 +1,14 @@
-import {
-  AccountInfo,
-  Fee,
-  GetAccountInfoRequest,
-  GetFeeRequest,
-  SubmitSignedTransactionResponse,
-  SubmitSignedTransactionRequest,
-  XRPAmount,
-  GetLatestValidatedLedgerSequenceRequest,
-  LedgerSequence,
-  GetTransactionStatusRequest,
-  TransactionStatus,
-} from 'xpring-common-js'
+import { AccountInfo } from '../../../src/generated/legacy/account_info_pb'
+import { Fee } from '../../../src/generated/legacy/fee_pb'
+import { GetAccountInfoRequest } from '../../../src/generated/legacy/get_account_info_request_pb'
+import { GetFeeRequest } from '../../../src/generated/legacy/get_fee_request_pb'
+import { SubmitSignedTransactionRequest } from '../../../src/generated/legacy/submit_signed_transaction_request_pb'
+import { SubmitSignedTransactionResponse } from '../../../src/generated/legacy/submit_signed_transaction_response_pb'
+import { GetLatestValidatedLedgerSequenceRequest } from '../../../src/generated/legacy/get_latest_validated_ledger_sequence_request_pb'
+import { LedgerSequence } from '../../../src/generated/legacy/ledger_sequence_pb'
+import { GetTransactionStatusRequest } from '../../../src/generated/legacy/get_transaction_status_request_pb'
+import { TransactionStatus } from '../../../src/generated/legacy/transaction_status_pb'
+import { XRPAmount } from '../../../src/generated/legacy/xrp_amount_pb'
 import { LegacyNetworkClient } from '../../../src/legacy/legacy-network-client'
 
 /**

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -1,12 +1,7 @@
 import chai, { assert } from 'chai'
-
-import {
-  Utils,
-  Wallet,
-  TransactionStatus as TransactionStatusResponse,
-} from 'xpring-common-js'
-
+import { Utils, Wallet } from 'xpring-common-js'
 import chaiString from 'chai-string'
+import { TransactionStatus as TransactionStatusResponse } from '../../src/generated/legacy/transaction_status_pb'
 import LegacyDefaultXpringClient, {
   LegacyXpringClientErrorMessages,
 } from '../../src/legacy/legacy-default-xpring-client'

--- a/test/reliable-submission-xpring-client-test.ts
+++ b/test/reliable-submission-xpring-client-test.ts
@@ -1,8 +1,6 @@
 import { assert } from 'chai'
-import {
-  TransactionStatus as RawTransactionStatus,
-  Wallet,
-} from 'xpring-common-js'
+import { Wallet } from 'xpring-common-js'
+import { TransactionStatus as RawTransactionStatus } from '../src/generated/legacy/transaction_status_pb'
 import FakeXpringClient from './fakes/fake-xpring-client'
 import ReliableSubmissionXpringClient from '../src/reliable-submission-xpring-client'
 import TransactionStatus from '../src/transaction-status'


### PR DESCRIPTION
## High Level Overview of Change
Use our own generated types instead of relying on Xpring-Common-JS to export the types that we require.

### Context of Change
We are currently generating the same data twice in our dependency as well as Xpring-Common-JS. I would like to move to eventually combine Xpring-Common-JS into Xpring-JS and only have one library. I think this is a good first step to doing this. I would love to hear more feedback on if you guys think this a good idea or not.

### Type of Change
- [X] Refactor (non-breaking change that only restructures code)

## Before / After
We no longer depend on the exported types from Xpring-Common-JS

## Test Plan
CI passes

## Future Tasks
Potentially merge Xpring-Common-JS in to Xpring-JS