### PR TITLE
Do not pull latest xpring-common-js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
           name: "Install dependencies"
           command: |
             sudo npm -g i nyc codecov
-            npm i xpring-common-js@latest
             npm rebuild
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
           name: "Install dependencies"
           command: |
             sudo npm -g i nyc codecov
+            npm i
             npm rebuild
 
       - save_cache:


### PR DESCRIPTION
## High Level Overview of Change

Fix install script. Two weird things we were doing:
- not running `npm i`
- always pulling the latest xpring-common-js

These are previous oversights and bad tooling. Now that we're making breaking changes in xpring-common-js these misconfigurations have come to light. 

### Context of Change

Build is broken at head on master. 
### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
CI Passes. 

## Test Plan

CI
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
