### PR TITLE
Do not hardcode transaction hash

### DIFF
--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -173,9 +173,7 @@ class DefaultXpringClient implements XpringClientDecorator {
   ): Promise<RawTransactionStatus> {
     const getTxRequest = new GetTxRequest()
     getTxRequest.setHash(
-      Utils.toBytes(
-        'AB5BB249FC614539CEF6CCE29B5C25DA3C278EF3933BE0583FEFF089067208C9',
-      ),
+      Utils.toBytes(transactionHash),
     )
 
     const getTxResponse = await this.networkClient.getTx(getTxRequest)


### PR DESCRIPTION
## High Level Overview of Change

This should not be hard coded. 

### Context of Change

Our unit tests are failing because we can't update the Tx hash (we flushed history from the remote node). This is hardcoded and it should not me. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Code obviously broken / Code not broken 

## Test Plan
CI Passes
