### PR TITLE
Polyfill BigInt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add an additional boolean parameter to `XpringClient`'s constructor which allows toggling between protocol buffer implementations.
+- Switch BigInt to use the big-integer polyfill lib.
 
 ### Fixed
-- Implement `XpringClient`'s `getBalance` method using rippled's protocol buffers. 
-- Implement `XpringClient`'s `getRawTransactionStatus` method using rippled's protocol buffers. 
+- Implement `XpringClient`'s `getBalance` method using rippled's protocol buffers.
+- Implement `XpringClient`'s `getRawTransactionStatus` method using rippled's protocol buffers.
 - Implement `XpringClient`'s `getTransactionStatus` method using rippled's protocol buffers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1031,6 +1031,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
@@ -3327,6 +3332,486 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "grpc-tools": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.8.1.tgz",
+      "integrity": "sha512-CvZLshEDbum8ZtB8r3bn6JsrHs3L7S1jf7PTa02nZSLmcLTKbiXH5UYrte06Kh7SdzFmkxPMaOsys2rCs+HRjA==",
+      "dev": true,
+      "requires": {
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -6965,15 +7450,6 @@
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
-      }
-    },
-    "ts-protoc-gen": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.12.0.tgz",
-      "integrity": "sha512-V7jnICJxKqalBrnJSMTW5tB9sGi48gOC325bfcM7TDNUItVOlaMM//rQmuo49ybipk/SyJTnWXgtJnhHCevNJw==",
-      "dev": true,
-      "requires": {
-        "google-protobuf": "^3.6.1"
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   },
   "dependencies": {
     "grpc": "1.24.2",
-    "xpring-common-js": "2.0.1"
+    "xpring-common-js": "2.0.1",
+    "big-integer": "^1.6.48"
   },
   "nyc": {
     "extension": [

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -1,5 +1,6 @@
 import { Utils, Wallet } from 'xpring-common-js'
 import { XRPDropsAmount } from 'xpring-common-js/build/generated/rpc/v1/amount_pb'
+import bigInt, { BigInteger } from 'big-integer'
 import { XpringClientDecorator } from './xpring-client-decorator'
 import TransactionStatus from './transaction-status'
 import RawTransactionStatus from './raw-transaction-status'
@@ -95,9 +96,9 @@ class DefaultXpringClient implements XpringClientDecorator {
    * Retrieve the balance for the given address.
    *
    * @param address The X-Address to retrieve a balance for.
-   * @returns A `BigInt` representing the number of drops of XRP in the account.
+   * @returns A `BigInteger` representing the number of drops of XRP in the account.
    */
-  public async getBalance(address: string): Promise<BigInt> {
+  public async getBalance(address: string): Promise<BigInteger> {
     const classicAddress = Utils.decodeXAddress(address)
     if (!classicAddress) {
       return Promise.reject(
@@ -121,7 +122,7 @@ class DefaultXpringClient implements XpringClientDecorator {
     if (!balance) {
       throw new Error(XpringClientErrorMessages.malformedResponse)
     }
-    return BigInt(balance)
+    return bigInt(balance.getDrops())
   }
 
   /**
@@ -150,13 +151,13 @@ class DefaultXpringClient implements XpringClientDecorator {
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
-   * @param drops A `BigInt`, number or numeric string representing the number of drops to send.
+   * @param drops A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async send(
-    amount: BigInt | number | string,
+    amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
   ): Promise<string> {

--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -1,4 +1,5 @@
 import { Signer, Utils, Wallet } from 'xpring-common-js'
+import bigInt, { BigInteger } from 'big-integer'
 import { AccountInfo } from '../../generated/legacy/account_info_pb'
 import { GetAccountInfoRequest } from '../../generated/legacy/get_account_info_request_pb'
 import { GetFeeRequest } from '../../generated/legacy/get_fee_request_pb'
@@ -60,9 +61,9 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
    * Retrieve the balance for the given address.
    *
    * @param address The X-Address to retrieve a balance for.
-   * @returns A `BigInt` representing the number of drops of XRP in the account.
+   * @returns A `BigInteger` representing the number of drops of XRP in the account.
    */
-  public async getBalance(address: string): Promise<BigInt> {
+  public async getBalance(address: string): Promise<BigInteger> {
     if (!Utils.isValidXAddress(address)) {
       return Promise.reject(
         new Error(LegacyXpringClientErrorMessages.xAddressRequired),
@@ -77,7 +78,7 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
         )
       }
 
-      return BigInt(balance.getDrops())
+      return bigInt(balance.getDrops())
     })
   }
 
@@ -107,13 +108,13 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
-   * @param drops A `BigInt`, number or numeric string representing the number of drops to send.
+   * @param drops A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async send(
-    amount: BigInt | number | string,
+    amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
   ): Promise<string> {
@@ -235,16 +236,19 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
   }
 
   /**
-   * Convert a polymorphic numeric value into a BigInt.
+   * Convert a polymorphic numeric value into a BigInteger.
    *
    * @param value The value to convert.
-   * @returns A BigInt representing the input value.
+   * @returns A BigInteger representing the input value.
    */
-  private static toBigInt(value: string | number | BigInt): BigInt {
-    if (typeof value === 'string' || typeof value === 'number') {
-      return BigInt(value)
+  private static toBigInt(value: string | number | BigInteger): BigInteger {
+    if (typeof value === 'string') {
+      return bigInt(value)
     }
-    // Value is already a BigInt.
+    if (typeof value === 'number') {
+      return bigInt(value)
+    }
+    // Value is already a BigInteger.
     return value
   }
 }

--- a/src/reliable-submission-xpring-client.ts
+++ b/src/reliable-submission-xpring-client.ts
@@ -1,4 +1,5 @@
 import { Wallet } from 'xpring-common-js'
+import { BigInteger } from 'big-integer'
 import { XpringClientDecorator } from './xpring-client-decorator'
 import RawTransactionStatus from './raw-transaction-status'
 
@@ -12,7 +13,7 @@ async function sleep(milliseconds: number): Promise<void> {
 class ReliableSubmissionXpringClient implements XpringClientDecorator {
   public constructor(private readonly decoratedClient: XpringClientDecorator) {}
 
-  public async getBalance(address: string): Promise<BigInt> {
+  public async getBalance(address: string): Promise<BigInteger> {
     return this.decoratedClient.getBalance(address)
   }
 
@@ -23,7 +24,7 @@ class ReliableSubmissionXpringClient implements XpringClientDecorator {
   }
 
   public async send(
-    amount: string | number | BigInt,
+    amount: string | number | BigInteger,
     destination: string,
     sender: Wallet,
   ): Promise<string> {

--- a/src/xpring-client-decorator.ts
+++ b/src/xpring-client-decorator.ts
@@ -1,4 +1,5 @@
 import { Wallet } from 'xpring-common-js'
+import { BigInteger } from 'big-integer'
 import TransactionStatus from './transaction-status'
 import RawTransactionStatus from './raw-transaction-status'
 
@@ -8,10 +9,10 @@ export interface XpringClientDecorator {
    * Retrieve the balance for the given address.
    *
    * @param address The X-Address to retrieve a balance for.
-   * @returns A `BigInt` representing the number of drops of XRP in the account.
+   * @returns A `BigInteger` representing the number of drops of XRP in the account.
    */
 
-  getBalance(address: string): Promise<BigInt>
+  getBalance(address: string): Promise<BigInteger>
 
   /**
    * Retrieve the transaction status for a given transaction hash.
@@ -24,13 +25,13 @@ export interface XpringClientDecorator {
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
-   * @param drops A `BigInt`, number or numeric string representing the number of drops to send.
+   * @param drops A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   send(
-    amount: BigInt | number | string,
+    amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
   ): Promise<string>

--- a/src/xpring-client.ts
+++ b/src/xpring-client.ts
@@ -1,4 +1,5 @@
 import { Wallet } from 'xpring-common-js'
+import { BigInteger } from 'big-integer'
 import { XpringClientDecorator } from './xpring-client-decorator'
 import LegacyDefaultXpringClient from './legacy/legacy-default-xpring-client'
 import TransactionStatus from './transaction-status'
@@ -33,9 +34,9 @@ class XpringClient {
    * Retrieve the balance for the given address.
    *
    * @param address The X-Address to retrieve a balance for.
-   * @returns A `BigInt` representing the number of drops of XRP in the account.
+   * @returns A `BigInteger` representing the number of drops of XRP in the account.
    */
-  public async getBalance(address: string): Promise<BigInt> {
+  public async getBalance(address: string): Promise<BigInteger> {
     return this.decoratedClient.getBalance(address)
   }
 
@@ -54,13 +55,13 @@ class XpringClient {
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
-   * @param drops A `BigInt`, number or numeric string representing the number of drops to send.
+   * @param drops A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async send(
-    amount: BigInt | number | string,
+    amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
   ): Promise<string> {

--- a/test/fakes/fake-xpring-client.ts
+++ b/test/fakes/fake-xpring-client.ts
@@ -1,18 +1,19 @@
 import { TransactionStatus as RawTransactionStatus } from 'xpring-common-js'
+import { BigInteger } from 'big-integer'
 import { XpringClientDecorator } from '../../src/xpring-client-decorator'
 import TransactionStatus from '../../src/transaction-status'
 import { Wallet } from '../../src/index'
 
 class FakeXpringClient implements XpringClientDecorator {
   public constructor(
-    public getBalanceValue: BigInt,
+    public getBalanceValue: BigInteger,
     public getTransactionStatusValue: TransactionStatus,
     public sendValue: string,
     public getLastValidatedLedgerSequenceValue: number,
     public getRawTransactionStatusValue: RawTransactionStatus,
   ) {}
 
-  public async getBalance(_address: string): Promise<BigInt> {
+  public async getBalance(_address: string): Promise<BigInteger> {
     return Promise.resolve(this.getBalanceValue)
   }
 
@@ -23,7 +24,7 @@ class FakeXpringClient implements XpringClientDecorator {
   }
 
   public async send(
-    _amount: BigInt | number | string,
+    _amount: BigInteger | number | string,
     _destination: string,
     _sender: Wallet,
   ): Promise<string> {

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -1,5 +1,6 @@
 import { Wallet } from 'xpring-common-js'
 import { assert } from 'chai'
+import bigInt from 'big-integer'
 import XpringClient from '../src/xpring-client'
 import TransactionStatus from '../src/transaction-status'
 
@@ -25,7 +26,7 @@ const rippledURL = '3.14.64.116:50051'
 const xpringClient = new XpringClient(rippledURL, true)
 
 // Some amount of XRP to send.
-const amount = BigInt('1')
+const amount = bigInt('1')
 
 describe('Xpring JS Integration Tests', function(): void {
   it('Get Account Balance - Legacy Shim', async function(): Promise<void> {

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -1,4 +1,5 @@
 import chai, { assert } from 'chai'
+import bigInt from 'big-integer'
 
 import {
   Utils,
@@ -101,14 +102,14 @@ describe('Legacy Default Xpring Client', function(): void {
     })
   })
 
-  it('Send XRP Transaction - success with BigInt', async function() {
-    // GIVEN a XpringClient, a wallet, and a BigInt denomonated amount.
+  it('Send XRP Transaction - success with BigInteger', async function() {
+    // GIVEN a XpringClient, a wallet, and a BigInteger denomonated amount.
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
     const { wallet } = Wallet.generateRandomWallet() as WalletGenerationResult
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const amount = BigInt('10')
+    const amount = bigInt('10')
 
     // WHEN the account makes a transaction.
     const transactionHash = await xpringClient.send(
@@ -208,7 +209,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
     const { wallet } = Wallet.generateRandomWallet() as WalletGenerationResult
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const amount = BigInt('10')
+    const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
@@ -228,7 +229,7 @@ describe('Legacy Default Xpring Client', function(): void {
     )
     const { wallet } = Wallet.generateRandomWallet() as WalletGenerationResult
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
-    const amount = BigInt('10')
+    const amount = bigInt('10')
 
     // WHEN the account makes a transaction THEN an error is thrown.
     xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
@@ -254,7 +255,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
     const { wallet } = Wallet.generateRandomWallet() as WalletGenerationResult
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const amount = BigInt('10')
+    const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
@@ -281,7 +282,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
     const { wallet } = Wallet.generateRandomWallet() as WalletGenerationResult
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const amount = BigInt('10')
+    const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
@@ -307,7 +308,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
     const { wallet } = Wallet.generateRandomWallet() as WalletGenerationResult
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const amount = BigInt('10')
+    const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
     xpringClient.send(amount, destinationAddress, wallet).catch((error) => {

--- a/test/reliable-submission-xpring-client-test.ts
+++ b/test/reliable-submission-xpring-client-test.ts
@@ -4,6 +4,7 @@ import {
   Wallet,
   WalletGenerationResult,
 } from 'xpring-common-js'
+import bigInt from 'big-integer'
 import FakeXpringClient from './fakes/fake-xpring-client'
 import ReliableSubmissionXpringClient from '../src/reliable-submission-xpring-client'
 import TransactionStatus from '../src/transaction-status'
@@ -16,7 +17,7 @@ const transactionHash = 'DEADBEEF'
 
 const { wallet } = Wallet.generateRandomWallet() as WalletGenerationResult
 
-const fakedGetBalanceValue = BigInt(10)
+const fakedGetBalanceValue = bigInt(10)
 const fakedTransactionStatusValue = TransactionStatus.Succeeded
 const fakedSendValue = transactionHash
 const fakedLastLedgerSequenceValue = 10


### PR DESCRIPTION
Had to rebase this https://github.com/xpring-eng/Xpring-JS/pull/143 (same code here)

## High Level Overview of Change
BigInt is still not supported on the latest version of Safari. This PR remedies that problem by using [bit-integer ](https://www.npmjs.com/package/big-integer). Big-integer acts as a thin wrapper over the native implementation when BigInt exists and polyfills it where it doesn't

### Context of Change
This removes the native BigInts and switches to the polyfill version. In addition I removed the `Lib` settings in the tsconfig back to the defaults as it is no longer required

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After
No more BigInt only big-integer.

## Test Plan
Tests pass and npm link version in safari wallet works (working safari screenshot below)

<img width="1791" alt="Screen Shot 2020-01-21 at 6 31 21 PM" src="https://user-images.githubusercontent.com/4524823/73200030-02bf7d80-4104-11ea-80bb-1ceeb982dcd2.png">
