### PR TITLE
Add submodule checkout command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,11 @@ The library should build and pass all tests.
 $ git clone https://github.com/xpring-eng/xpring-js.git
 $ cd xpring-js
 
+# Pull Submdoules 
+$ git submodule update --init --recursive
+
 # Install dependencies
-npm i
+$ npm i
 
 # Run tests.
 $ npm test


### PR DESCRIPTION
## High Level Overview of Change

CONTRIBUTING.md is missing submodule step. 

### Context of Change

Xpring-JS consumes protocol buffers from submodules. These submodules need to get pulled down when the repo is cloned. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

N/A
## Test Plan

N/A