### PR TITLE
Handle undefined wallet generation results

### DIFF
--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -103,7 +103,11 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -111,7 +115,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const transactionHash = await xpringClient.send(
       amount,
       destinationAddress,
-      wallet,
+      walletGenerationResult.wallet,
     )
 
     // THEN the transaction hash exists and is the expected hash
@@ -129,7 +133,11 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 10
 
@@ -137,7 +145,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const transactionHash = await xpringClient.send(
       amount,
       destinationAddress,
-      wallet,
+      walletGenerationResult.wallet,
     )
 
     // THEN the transaction hash exists and is the expected hash
@@ -155,7 +163,11 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = '10'
 
@@ -163,7 +175,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const transactionHash = await xpringClient.send(
       amount,
       destinationAddress,
-      wallet,
+      walletGenerationResult.wallet,
     )
 
     // THEN the transaction hash exists and is the expected hash
@@ -181,15 +193,21 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 'not_a_number'
 
     // WHEN the account makes a transaction THEN an error is propagated.
-    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
-      assert.typeOf(error, 'Error')
-      done()
-    })
+    xpringClient
+      .send(amount, destinationAddress, walletGenerationResult.wallet)
+      .catch((error) => {
+        assert.typeOf(error, 'Error')
+        done()
+      })
   })
 
   it('Send XRP Transaction - get fee failure', function(done) {
@@ -203,19 +221,25 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
-      assert.typeOf(error, 'Error')
-      assert.equal(
-        error.message,
-        FakeLegacyNetworkClientResponses.defaultError.message,
-      )
-      done()
-    })
+    xpringClient
+      .send(amount, destinationAddress, walletGenerationResult.wallet)
+      .catch((error) => {
+        assert.typeOf(error, 'Error')
+        assert.equal(
+          error.message,
+          FakeLegacyNetworkClientResponses.defaultError.message,
+        )
+        done()
+      })
   })
 
   it('Send XRP Transaction - failure with classic address', function(done) {
@@ -223,19 +247,25 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
     const amount = bigInt('10')
 
     // WHEN the account makes a transaction THEN an error is thrown.
-    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
-      assert.typeOf(error, 'Error')
-      assert.equal(
-        error.message,
-        LegacyXpringClientErrorMessages.xAddressRequired,
-      )
-      done()
-    })
+    xpringClient
+      .send(amount, destinationAddress, walletGenerationResult.wallet)
+      .catch((error) => {
+        assert.typeOf(error, 'Error')
+        assert.equal(
+          error.message,
+          LegacyXpringClientErrorMessages.xAddressRequired,
+        )
+        done()
+      })
   })
 
   it('Send XRP Transaction - get account info failure', function(done) {
@@ -249,19 +279,25 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
-      assert.typeOf(error, 'Error')
-      assert.equal(
-        error.message,
-        FakeLegacyNetworkClientResponses.defaultError.message,
-      )
-      done()
-    })
+    xpringClient
+      .send(amount, destinationAddress, walletGenerationResult.wallet)
+      .catch((error) => {
+        assert.typeOf(error, 'Error')
+        assert.equal(
+          error.message,
+          FakeLegacyNetworkClientResponses.defaultError.message,
+        )
+        done()
+      })
   })
 
   it('Send XRP Transaction - get latest ledger sequence failure', function(done) {
@@ -276,19 +312,25 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
-      assert.typeOf(error, 'Error')
-      assert.equal(
-        error.message,
-        FakeLegacyNetworkClientResponses.defaultError.message,
-      )
-      done()
-    })
+    xpringClient
+      .send(amount, destinationAddress, walletGenerationResult.wallet)
+      .catch((error) => {
+        assert.typeOf(error, 'Error')
+        assert.equal(
+          error.message,
+          FakeLegacyNetworkClientResponses.defaultError.message,
+        )
+        done()
+      })
   })
 
   it('Send XRP Transaction - submission failure', function(done) {
@@ -302,19 +344,25 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const { wallet } = Wallet.generateRandomWallet()
+    const walletGenerationResult = Wallet.generateRandomWallet()
+    if (walletGenerationResult === undefined) {
+      assert.fail('Wallet is undefined', 'Wallet to be defined')
+      return
+    }
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
-      assert.typeOf(error, 'Error')
-      assert.equal(
-        error.message,
-        FakeLegacyNetworkClientResponses.defaultError.message,
-      )
-      done()
-    })
+    xpringClient
+      .send(amount, destinationAddress, walletGenerationResult.wallet)
+      .catch((error) => {
+        assert.typeOf(error, 'Error')
+        assert.equal(
+          error.message,
+          FakeLegacyNetworkClientResponses.defaultError.message,
+        )
+        done()
+      })
   })
 
   it('Get Transaction Status - Unvalidated Transaction and Failure Code', async function() {

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -103,11 +103,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -115,7 +111,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const transactionHash = await xpringClient.send(
       amount,
       destinationAddress,
-      walletGenerationResult.wallet,
+      wallet,
     )
 
     // THEN the transaction hash exists and is the expected hash
@@ -133,11 +129,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 10
 
@@ -145,7 +137,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const transactionHash = await xpringClient.send(
       amount,
       destinationAddress,
-      walletGenerationResult.wallet,
+      wallet,
     )
 
     // THEN the transaction hash exists and is the expected hash
@@ -163,11 +155,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = '10'
 
@@ -175,7 +163,7 @@ describe('Legacy Default Xpring Client', function(): void {
     const transactionHash = await xpringClient.send(
       amount,
       destinationAddress,
-      walletGenerationResult.wallet,
+      wallet,
     )
 
     // THEN the transaction hash exists and is the expected hash
@@ -193,21 +181,15 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 'not_a_number'
 
     // WHEN the account makes a transaction THEN an error is propagated.
-    xpringClient
-      .send(amount, destinationAddress, walletGenerationResult.wallet)
-      .catch((error) => {
-        assert.typeOf(error, 'Error')
-        done()
-      })
+    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
+      assert.typeOf(error, 'Error')
+      done()
+    })
   })
 
   it('Send XRP Transaction - get fee failure', function(done) {
@@ -221,25 +203,19 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient
-      .send(amount, destinationAddress, walletGenerationResult.wallet)
-      .catch((error) => {
-        assert.typeOf(error, 'Error')
-        assert.equal(
-          error.message,
-          FakeLegacyNetworkClientResponses.defaultError.message,
-        )
-        done()
-      })
+    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
+      assert.typeOf(error, 'Error')
+      assert.equal(
+        error.message,
+        FakeLegacyNetworkClientResponses.defaultError.message,
+      )
+      done()
+    })
   })
 
   it('Send XRP Transaction - failure with classic address', function(done) {
@@ -247,25 +223,19 @@ describe('Legacy Default Xpring Client', function(): void {
     const xpringClient = new LegacyDefaultXpringClient(
       fakeSucceedingNetworkClient,
     )
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
     const amount = bigInt('10')
 
     // WHEN the account makes a transaction THEN an error is thrown.
-    xpringClient
-      .send(amount, destinationAddress, walletGenerationResult.wallet)
-      .catch((error) => {
-        assert.typeOf(error, 'Error')
-        assert.equal(
-          error.message,
-          LegacyXpringClientErrorMessages.xAddressRequired,
-        )
-        done()
-      })
+    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
+      assert.typeOf(error, 'Error')
+      assert.equal(
+        error.message,
+        LegacyXpringClientErrorMessages.xAddressRequired,
+      )
+      done()
+    })
   })
 
   it('Send XRP Transaction - get account info failure', function(done) {
@@ -279,25 +249,19 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient
-      .send(amount, destinationAddress, walletGenerationResult.wallet)
-      .catch((error) => {
-        assert.typeOf(error, 'Error')
-        assert.equal(
-          error.message,
-          FakeLegacyNetworkClientResponses.defaultError.message,
-        )
-        done()
-      })
+    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
+      assert.typeOf(error, 'Error')
+      assert.equal(
+        error.message,
+        FakeLegacyNetworkClientResponses.defaultError.message,
+      )
+      done()
+    })
   })
 
   it('Send XRP Transaction - get latest ledger sequence failure', function(done) {
@@ -312,25 +276,19 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient
-      .send(amount, destinationAddress, walletGenerationResult.wallet)
-      .catch((error) => {
-        assert.typeOf(error, 'Error')
-        assert.equal(
-          error.message,
-          FakeLegacyNetworkClientResponses.defaultError.message,
-        )
-        done()
-      })
+    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
+      assert.typeOf(error, 'Error')
+      assert.equal(
+        error.message,
+        FakeLegacyNetworkClientResponses.defaultError.message,
+      )
+      done()
+    })
   })
 
   it('Send XRP Transaction - submission failure', function(done) {
@@ -344,25 +302,19 @@ describe('Legacy Default Xpring Client', function(): void {
       feeFailureResponses,
     )
     const xpringClient = new LegacyDefaultXpringClient(feeFailingNetworkClient)
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xpringClient
-      .send(amount, destinationAddress, walletGenerationResult.wallet)
-      .catch((error) => {
-        assert.typeOf(error, 'Error')
-        assert.equal(
-          error.message,
-          FakeLegacyNetworkClientResponses.defaultError.message,
-        )
-        done()
-      })
+    xpringClient.send(amount, destinationAddress, wallet).catch((error) => {
+      assert.typeOf(error, 'Error')
+      assert.equal(
+        error.message,
+        FakeLegacyNetworkClientResponses.defaultError.message,
+      )
+      done()
+    })
   })
 
   it('Get Transaction Status - Unvalidated Transaction and Failure Code', async function() {

--- a/test/reliable-submission-xpring-client-test.ts
+++ b/test/reliable-submission-xpring-client-test.ts
@@ -94,17 +94,13 @@ describe('Reliable Submission Xpring Client', function(): void {
         fakedRawTransactionStatusLastLedgerSequenceValue + 1
       this.fakeXpringClient.latestLedgerSequence = latestLedgerSequence
     }, 200)
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
 
     // WHEN a reliable send is submitted
     const transactionHash = await this.reliableSubmissionClient.send(
       '1',
       testAddress,
-      walletGenerationResult.wallet,
+      wallet,
     )
 
     // THEN the function returns
@@ -119,17 +115,13 @@ describe('Reliable Submission Xpring Client', function(): void {
     setTimeout(() => {
       fakedRawTransactionStatusValue.setValidated(true)
     }, 200)
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
 
     // WHEN a reliable send is submitted
     const transactionHash = await this.reliableSubmissionClient.send(
       '1',
       testAddress,
-      walletGenerationResult.wallet,
+      wallet,
     )
 
     // THEN the function returns
@@ -144,15 +136,11 @@ describe('Reliable Submission Xpring Client', function(): void {
     const malformedRawTransactionStatus = new RawTransactionStatus()
     malformedRawTransactionStatus.setLastLedgerSequence(0)
     this.fakeXpringClient.getRawTransactionStatusValue = malformedRawTransactionStatus
-    const walletGenerationResult = Wallet.generateRandomWallet()
-    if (walletGenerationResult === undefined) {
-      assert.fail('Wallet is undefined', 'Wallet to be defined')
-      return
-    }
+    const { wallet } = Wallet.generateRandomWallet()!
 
     // WHEN `send` is called THEN the promise is rejected.
     this.reliableSubmissionClient
-      .send('1', testAddress, walletGenerationResult.wallet)
+      .send('1', testAddress, wallet)
       .then(() => {})
       .catch(() => done())
   })


### PR DESCRIPTION
## High Level Overview of Change
There was an issue in our tests where we were not checking for undefined on the walletGenerationResults. We were already doing this inside of Reliable Send Client tests.

### Context of Change
Mocha test were not building properly with the VSCode Mocha Extension

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After
Test work with Keefer's VSCode Mocha Extension
https://marketplace.visualstudio.com/items?itemName=maty.vscode-mocha-sidebar

## Test Plan
CI mocha panel works
