### PR TITLE
Export the TransactionStatus enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Export the `TransactionStatus` enum so client libraries can consume it. 
+
 ## 1.3.1 - Jan 30, 2020
 
 This release fixes an incorrectly formatted package-lock.json that was published in the 1.3.0 release.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,5 @@ export {
   WalletGenerationResult,
   Utils,
 } from 'xpring-common-js'
+export { default as TransactionStatus } from './transaction-status'
 export { default as XpringClient } from './xpring-client'


### PR DESCRIPTION
## High Level Overview of Change

`TransactionStatus` is returned from a public API in `XpringClient` but isn't exported from the library so that clients can consume it. 

### Context of Change

I need this to build functionality in [Xpring SDK Demos](http://github.com/xpring-eng/xpring-js) and presumably other people would like this too. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After
N/A

## Test Plan
CI