### PR TITLE
[Cleanup] Fix and remove TODOs from rippled protocol buffer migration

### DIFF
--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -17,11 +17,6 @@ import isNode from './utils'
 import { Payment, Transaction } from './generated/web/rpc/v1/transaction_pb'
 import { AccountRoot } from './generated/web/rpc/v1/ledger_objects_pb'
 
-// TODO(keefertaylor): Re-enable this rule when this class is fully implemented.
-/* eslint-disable @typescript-eslint/require-await */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable class-methods-use-this */
-
 /** A margin to pad the current ledger sequence with when submitting transactions. */
 const maxLedgerVersionOffset = 10
 
@@ -248,8 +243,6 @@ class DefaultXpringClient implements XpringClientDecorator {
     return new GetTxResponseWrapper(getTxResponse)
   }
 
-  // TODO Keefer implement method and remove tslint ignore and fix tsconfig nounusedlocals
-  // tslint:disable-next-line
   private async getMinimumFee(): Promise<XRPDropsAmount> {
     const getFeeResponse = await this.getFee()
 
@@ -266,7 +259,6 @@ class DefaultXpringClient implements XpringClientDecorator {
     return minimumFee
   }
 
-  // TODO(keefertaylor): Add tests for this method once send is hooked up.
   private async getFee(): Promise<GetFeeResponse> {
     const getFeeRequest = this.networkClient.GetFeeRequest()
     return this.networkClient.getFee(getFeeRequest)

--- a/src/network-client.ts
+++ b/src/network-client.ts
@@ -27,5 +27,4 @@ export interface NetworkClient {
   GetTxRequest(): GetTxRequest
   GetFeeRequest(): GetFeeRequest
   SubmitTransactionRequest(): SubmitTransactionRequest
-  // TODO(keefertaylor): Add last ledger validated sequence.
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitAny": false,
 
     // Additional Checks
-    "noUnusedLocals": false, // TODO KEEFER make this TRUE after implementing getMinimumFee in Xpring-Client
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## High Level Overview of Change

Post rippled protocol buffer transition cleanup:
- Remove TSLint disabled rules
- Enable no unused locals rule
- Remove defunct TODO about adding last ledger sequence (this field is provided by the Fee RPC)
- Remove defunct TODO about testing fee retrieval, this is tested in [the send unit tests](https://github.com/xpring-eng/Xpring-JS/blob/master/test/default-xpring-client-test.ts#L318) and [integration tests](https://github.com/xpring-eng/Xpring-JS/blob/master/test/integration-test.ts)

### Context of Change

I recently implemented a large refactor which moved this library to using native rippled protocol buffers. I added some TODOs to fix these things. I'm cleaning them up now so my reviewers continue to trust me in the future. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After

Before: Code messy, littered with linting rules one-offs and ugly. 
After: Code exhibits a zen like appearance

## Test Plan

Continuous integration will report on this PR/.
