### PR TITLE
Add tests for multiple failure codes 

### DIFF
--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -17,7 +17,13 @@ import TransactionStatus from '../src/transaction-status'
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
 const transactionStatusCodeSuccess = 'tesSUCCESS'
-const transactionStatusCodeFailure = 'tecFAILURE'
+const transactionStatusFailureCodes = [
+  'tefFAILURE',
+  'tecCLAIM',
+  'telBAD_PUBLIC_KEY',
+  'temBAD_FEE',
+  'terRETRY',
+]
 
 const transactionHash = 'DEADBEEF'
 
@@ -109,27 +115,34 @@ describe('Default Xpring Client', function(): void {
   it('Get Transaction Status - Unvalidated Transaction and Failure Code', async function(): Promise<
     void
   > {
-    // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
-    const transactionStatusResponse = makeGetTxResponse(
-      false,
-      transactionStatusCodeFailure,
-    )
-    const transactionStatusResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
-      transactionStatusResponse,
-    )
-    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses)
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient)
+    // Iterate over different types of transaction status codes which represent failures.
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < transactionStatusFailureCodes.length; i += 1) {
+      // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
+      const transactionStatusCodeFailure = transactionStatusFailureCodes[i]
+      const transactionStatusResponse = makeGetTxResponse(
+        false,
+        transactionStatusCodeFailure,
+      )
+      const transactionStatusResponses = new FakeNetworkClientResponses(
+        FakeNetworkClientResponses.defaultAccountInfoResponse(),
+        FakeNetworkClientResponses.defaultFeeResponse(),
+        FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
+        transactionStatusResponse,
+      )
+      const fakeNetworkClient = new FakeNetworkClient(
+        transactionStatusResponses,
+      )
+      const xpringClient = new DefaultXpringClient(fakeNetworkClient)
 
-    // WHEN the transaction status is retrieved.
-    const transactionStatus = await xpringClient.getTransactionStatus(
-      transactionHash,
-    )
+      // WHEN the transaction status is retrieved.
+      const transactionStatus = await xpringClient.getTransactionStatus(
+        transactionHash,
+      )
 
-    // THEN the status is pending.
-    assert.deepEqual(transactionStatus, TransactionStatus.Pending)
+      // THEN the status is pending.
+      assert.deepEqual(transactionStatus, TransactionStatus.Pending)
+    }
   })
 
   it('Get Transaction Status - Unvalidated Transaction and Success Code', async function(): Promise<
@@ -161,27 +174,35 @@ describe('Default Xpring Client', function(): void {
   it('Get Transaction Status - Validated Transaction and Failure Code', async function(): Promise<
     void
   > {
-    // GIVEN a XpringClient which will return an validated transaction with a failure code.
-    const transactionStatusResponse = makeGetTxResponse(
-      true,
-      transactionStatusCodeFailure,
-    )
-    const transactionStatusResponses = new FakeNetworkClientResponses(
-      FakeNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeNetworkClientResponses.defaultFeeResponse(),
-      FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
-      transactionStatusResponse,
-    )
-    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses)
-    const xpringClient = new DefaultXpringClient(fakeNetworkClient)
+    // Iterate over different types of transaction status codes which represent failures.
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < transactionStatusFailureCodes.length; i += 1) {
+      // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
+      const transactionStatusCodeFailure = transactionStatusFailureCodes[i]
+      // GIVEN a XpringClient which will return an validated transaction with a failure code.
+      const transactionStatusResponse = makeGetTxResponse(
+        true,
+        transactionStatusCodeFailure,
+      )
+      const transactionStatusResponses = new FakeNetworkClientResponses(
+        FakeNetworkClientResponses.defaultAccountInfoResponse(),
+        FakeNetworkClientResponses.defaultFeeResponse(),
+        FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
+        transactionStatusResponse,
+      )
+      const fakeNetworkClient = new FakeNetworkClient(
+        transactionStatusResponses,
+      )
+      const xpringClient = new DefaultXpringClient(fakeNetworkClient)
 
-    // WHEN the transaction status is retrieved.
-    const transactionStatus = await xpringClient.getTransactionStatus(
-      transactionHash,
-    )
+      // WHEN the transaction status is retrieved.
+      const transactionStatus = await xpringClient.getTransactionStatus(
+        transactionHash,
+      )
 
-    // THEN the status is failed.
-    assert.deepEqual(transactionStatus, TransactionStatus.Failed)
+      // THEN the status is failed.
+      assert.deepEqual(transactionStatus, TransactionStatus.Failed)
+    }
   })
 
   it('Get Transaction Status - Validated Transaction and Success Code', async function(): Promise<

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -143,6 +143,7 @@ describe('Default Xpring Client', function(): void {
       // THEN the status is pending.
       assert.deepEqual(transactionStatus, TransactionStatus.Pending)
     }
+    /* eslint-enable no-await-in-loop */
   })
 
   it('Get Transaction Status - Unvalidated Transaction and Success Code', async function(): Promise<
@@ -203,6 +204,7 @@ describe('Default Xpring Client', function(): void {
       // THEN the status is failed.
       assert.deepEqual(transactionStatus, TransactionStatus.Failed)
     }
+    /* eslint-enable no-await-in-loop */
   })
 
   it('Get Transaction Status - Validated Transaction and Success Code', async function(): Promise<

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -25,7 +25,13 @@ chai.use(chaiString)
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
 const transactionStatusCodeSuccess = 'tesSUCCESS'
-const transactionStatusCodeFailure = 'tecFAILURE'
+const transactionStatusFailureCodes = [
+  'tefFAILURE',
+  'tecCLAIM',
+  'telBAD_PUBLIC_KEY',
+  'temBAD_FEE',
+  'terRETRY',
+]
 
 const transactionHash = 'DEADBEEF'
 
@@ -318,31 +324,37 @@ describe('Legacy Default Xpring Client', function(): void {
   })
 
   it('Get Transaction Status - Unvalidated Transaction and Failure Code', async function() {
-    // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
-    const transactionStatusResponse = new TransactionStatusResponse()
-    transactionStatusResponse.setValidated(false)
-    transactionStatusResponse.setTransactionStatusCode(
-      transactionStatusCodeFailure,
-    )
-    const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
-      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
-      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
-      transactionStatusResponse,
-    )
-    const fakeNetworkClient = new FakeLegacyNetworkClient(
-      transactionStatusResponses,
-    )
-    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient)
+    // Iterate over different types of transaction status codes which represent failures.
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < transactionStatusFailureCodes.length; i += 1) {
+      // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
+      const transactionStatusCodeFailure = transactionStatusFailureCodes[i]
+      const transactionStatusResponse = new TransactionStatusResponse()
+      transactionStatusResponse.setValidated(false)
+      transactionStatusResponse.setTransactionStatusCode(
+        transactionStatusCodeFailure,
+      )
+      const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
+        FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+        FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+        FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+        FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
+        transactionStatusResponse,
+      )
+      const fakeNetworkClient = new FakeLegacyNetworkClient(
+        transactionStatusResponses,
+      )
+      const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient)
 
-    // WHEN the transaction status is retrieved.
-    const transactionStatus = await xpringClient.getTransactionStatus(
-      transactionHash,
-    )
+      // WHEN the transaction status is retrieved.
+      const transactionStatus = await xpringClient.getTransactionStatus(
+        transactionHash,
+      )
 
-    // THEN the status is pending.
-    assert.deepEqual(transactionStatus, TransactionStatus.Pending)
+      // THEN the status is pending.
+      assert.deepEqual(transactionStatus, TransactionStatus.Pending)
+    }
+    /* eslint-enable no-await-in-loop */
   })
 
   it('Get Transaction Status - Unvalidated Transaction and Success Code', async function() {
@@ -374,31 +386,37 @@ describe('Legacy Default Xpring Client', function(): void {
   })
 
   it('Get Transaction Status - Validated Transaction and Failure Code', async function() {
-    // GIVEN a XpringClient which will return an validated transaction with a failure code.
-    const transactionStatusResponse = new TransactionStatusResponse()
-    transactionStatusResponse.setValidated(true)
-    transactionStatusResponse.setTransactionStatusCode(
-      transactionStatusCodeFailure,
-    )
-    const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
-      FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
-      FakeLegacyNetworkClientResponses.defaultFeeResponse(),
-      FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
-      FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
-      transactionStatusResponse,
-    )
-    const fakeNetworkClient = new FakeLegacyNetworkClient(
-      transactionStatusResponses,
-    )
-    const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient)
+    // Iterate over different types of transaction status codes which represent failures.
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < transactionStatusFailureCodes.length; i += 1) {
+      // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
+      const transactionStatusCodeFailure = transactionStatusFailureCodes[i]
+      const transactionStatusResponse = new TransactionStatusResponse()
+      transactionStatusResponse.setValidated(true)
+      transactionStatusResponse.setTransactionStatusCode(
+        transactionStatusCodeFailure,
+      )
+      const transactionStatusResponses = new FakeLegacyNetworkClientResponses(
+        FakeLegacyNetworkClientResponses.defaultAccountInfoResponse(),
+        FakeLegacyNetworkClientResponses.defaultFeeResponse(),
+        FakeLegacyNetworkClientResponses.defaultSubmitSignedTransactionResponse(),
+        FakeLegacyNetworkClientResponses.defaultLedgerSequenceResponse(),
+        transactionStatusResponse,
+      )
+      const fakeNetworkClient = new FakeLegacyNetworkClient(
+        transactionStatusResponses,
+      )
+      const xpringClient = new LegacyDefaultXpringClient(fakeNetworkClient)
 
-    // WHEN the transaction status is retrieved.
-    const transactionStatus = await xpringClient.getTransactionStatus(
-      transactionHash,
-    )
+      // WHEN the transaction status is retrieved.
+      const transactionStatus = await xpringClient.getTransactionStatus(
+        transactionHash,
+      )
 
-    // THEN the status is failed.
-    assert.deepEqual(transactionStatus, TransactionStatus.Failed)
+      // THEN the status is failed.
+      assert.deepEqual(transactionStatus, TransactionStatus.Failed)
+    }
+    /* eslint-enable no-await-in-loop */
   })
 
   it('Get Transaction Status - Validated Transaction and Success Code', async function() {


### PR DESCRIPTION
## High Level Overview of Change

@stephengu asked for multiple test cases on failure codes in XpringKit. This PR propagates the same logic here. 

### Context of Change

The rippled server returns [many codes](https://xrpl.org/transaction-results.html) which mean 'failure'. These are all prefixed in different ways. This PR tests all failure prefixes. 

This change was asked for in: https://github.com/xpring-eng/XpringKit/pull/94#pullrequestreview-351145809

### Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After

No change

## Test Plan

N/A
