### PR TITLE
Upgrade for breaking changes in rippled protocol buffers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = xpring-common-protocol-buffers
 	url = http://github.com/xpring-eng/xpring-common-protocol-buffers
 	branch = master
-[submodule "rippled"]
-	path = rippled
-	url = http://github.com/ripple/rippled
-	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = xpring-common-protocol-buffers
 	url = http://github.com/xpring-eng/xpring-common-protocol-buffers
 	branch = master
-[submodule "rippled"]
-	path = rippled
-	url = http://github.com/ripple/rippled
-	branch = develop
 [submodule "hermes-ilp"]
 	path = hermes-ilp
 	url = https://github.com/xpring-eng/hermes-ilp

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "hermes-ilp"]
 	path = hermes-ilp
 	url = https://github.com/xpring-eng/hermes-ilp
+[submodule "rippled"]
+	path = rippled
+	url = http://github.com/ripple/rippled
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = xpring-common-protocol-buffers
 	url = http://github.com/xpring-eng/xpring-common-protocol-buffers
 	branch = master
+[submodule "rippled"]
+	path = rippled
+	url = http://github.com/cjcobb23/rippled
+	branch = master

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,7 @@
     },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+
+    "mochaExplorer.files": "test/*.ts"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1064,9 +1064,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2847,9 +2847,9 @@
       "dev": true
     },
     "google-protobuf": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.2.tgz",
-      "integrity": "sha512-T4fin7lcYLUPj2ChUZ4DvfuuHtg3xi1621qeRZt2J7SvOQusOzq+sDT4vbotWTCjUXJoR36CA016LlhtPy80uQ=="
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.4.tgz",
+      "integrity": "sha512-lL6b04rDirurUBOgsY2+LalI6Evq8eH5TcNzi7TYQ3BsIWelT0KSOQSBsXuavEkNf+odQU6c0lgz3UsZXeNX9Q=="
     },
     "graceful-fs": {
       "version": "4.2.1",
@@ -6527,6 +6527,16 @@
       "requires": {
         "base-x": "3.0.7",
         "create-hash": "^1.1.2"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
+          "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
       }
     },
     "ripple-binary-codec": {
@@ -6551,44 +6561,21 @@
       }
     },
     "ripple-keypairs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-0.11.1.tgz",
-      "integrity": "sha512-xdakxb+/4yo3TWA2ZImEma3g9OZrvoVRMDC9A2dfk6V+tBsDWug1p53bfmSnfTaue7kf2O5ejq2bfmYG8W08FA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.0.0.tgz",
+      "integrity": "sha512-MQ3d6fU3D+Cqu5ma4dfkfa+KakN2sKpVVVN0FeJyAYPVIGXu8Rcvd1g028TdwYAZcSYk0tGn5UhHxd0gUG3T8g==",
       "requires": {
-        "babel-runtime": "^5.8.20",
-        "bn.js": "^3.1.1",
+        "bn.js": "^5.1.1",
         "brorand": "^1.0.5",
         "elliptic": "^6.5.2",
         "hash.js": "^1.0.3",
-        "ripple-address-codec": "^2.0.1"
+        "ripple-address-codec": "^4.0.0"
       },
       "dependencies": {
-        "babel-runtime": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-          "requires": {
-            "core-js": "^1.0.0"
-          }
-        },
         "bn.js": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-3.3.0.tgz",
-          "integrity": "sha1-ETjld4if3Je72rUYRPIZDfwK49c="
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "ripple-address-codec": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-2.0.1.tgz",
-          "integrity": "sha1-7dvjp5YNLgLFwcdPuan6DS37ZXE=",
-          "requires": {
-            "hash.js": "^1.0.3",
-            "x-address-codec": "^0.7.0"
-          }
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+          "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
         }
       }
     },
@@ -7795,38 +7782,23 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "x-address-codec": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/x-address-codec/-/x-address-codec-0.7.2.tgz",
-      "integrity": "sha1-Ki97sAJ4UgvRNzOnlZoFRD1oAuA=",
-      "requires": {
-        "base-x": "^1.0.1"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
-          "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
-        }
-      }
-    },
     "xhr2": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.0.tgz",
       "integrity": "sha512-BDtiD0i2iKPK/S8OAZfpk6tyzEDnKKSjxWHcMBVmh+LuqJ8A32qXTyOx+TVOg2dKvq6zGBq2sgKPkEeRs1qTRA=="
     },
     "xpring-common-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-3.0.2.tgz",
-      "integrity": "sha512-h0Dv+z65YfyXFyBTUySIBYWQI56/MrpdpXj+fQAO0YDy/+33CbBedJBb8uslOUKZHjmyb8W4WSI9v6uCb4rAQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-4.0.0.tgz",
+      "integrity": "sha512-E5bZJ/j1QS0h9Tl++bL52BV/r2/gF40uil8nTCPbVUrG8ZyLHVGBmLMzVzX55WD08fLXdk+z9Tx5zHVreR7hdQ==",
       "requires": {
         "bip32": "2.0.5",
         "bip39": "^3.0.2",
-        "google-protobuf": "3.11.2",
+        "google-protobuf": "3.11.4",
         "grpc-web": "1.0.7",
         "ripple-address-codec": "4.1.0",
         "ripple-binary-codec": "0.2.6",
-        "ripple-keypairs": "^0.11.0"
+        "ripple-keypairs": "^1.0.0"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "grpc": "^1.24.2",
     "grpc-web": "1.0.7",
     "xhr2": "0.2.0",
-    "xpring-common-js": "^3.0.2"
+    "xpring-common-js": "4.0.0"
   },
   "nyc": {
     "extension": [

--- a/scripts/regenerate_protos.sh
+++ b/scripts/regenerate_protos.sh
@@ -13,6 +13,7 @@ OUT_DIR_WEB="./src/generated/web"
 OUT_DIR_NODE="./src/generated/node"
 
 PROTO_PATH="./rippled/src/ripple/proto/"
+PROTO_SRC_FILES=$PROTO_PATH/org/xrpl/rpc/v1/*.proto
 
 mkdir -p $OUT_DIR_WEB
 mkdir -p $OUT_DIR_NODE
@@ -22,7 +23,7 @@ $PWD/node_modules/grpc-tools/bin/protoc \
     --js_out=import_style=commonjs,binary:$OUT_DIR_WEB \
     --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:$OUT_DIR_WEB \
     --proto_path $PROTO_PATH \
-    ./rippled/src/ripple/proto/rpc/v1/*.proto
+    $PROTO_SRC_FILES
 
 # Generate node code.
 $PWD/node_modules/grpc-tools/bin/protoc \
@@ -30,14 +31,14 @@ $PWD/node_modules/grpc-tools/bin/protoc \
     --grpc_out=$OUT_DIR_NODE \
     --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` \
     --proto_path $PROTO_PATH \
-    ./rippled/src/ripple/proto/rpc/v1/*.proto
+    $PROTO_SRC_FILES
 
 # Generate node typescript declaration files.
 $PWD/node_modules/grpc-tools/bin/protoc \
     --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts \
     --ts_out=$OUT_DIR_NODE \
     --proto_path=$PROTO_PATH \
-    ./rippled/src/ripple/proto/rpc/v1/*.proto
+    $PROTO_SRC_FILES
 
 ##########################################################################
 # Regenerate legacy protocol buffers.

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -141,16 +141,16 @@ class DefaultXpringClient implements XpringClientDecorator {
    * Send the given amount of XRP from the source wallet to the destination address.
    *
    * @param drops A `BigInteger`, number or numeric string representing the number of drops to send.
-   * @param destination A destination address to send the drops to.
+   * @param destinationAddress A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async send(
-    amount: BigInteger | number | string,
-    destination: string,
+    drops: BigInteger | number | string,
+    destinationAddress: string,
     sender: Wallet,
   ): Promise<string> {
-    if (!Utils.isValidXAddress(destination)) {
+    if (!Utils.isValidXAddress(destinationAddress)) {
       throw new Error(XpringClientErrorMessages.xAddressRequired)
     }
 
@@ -159,26 +159,26 @@ class DefaultXpringClient implements XpringClientDecorator {
       throw new Error(XpringClientErrorMessages.xAddressRequired)
     }
 
-    const normalizedAmount = amount.toString()
+    const normalizedDrops = drops.toString()
 
     const fee = await this.getMinimumFee()
     const accountData = await this.getAccountData(classicAddress.address)
     const lastValidatedLedgerSequence = await this.getLastValidatedLedgerSequence()
 
     const xrpDropsAmount = new XRPDropsAmount()
-    xrpDropsAmount.setDrops(normalizedAmount)
+    xrpDropsAmount.setDrops(normalizedDrops)
 
     const currencyAmount = new CurrencyAmount()
     currencyAmount.setXrpAmount(xrpDropsAmount)
 
-    const amount2 = new Amount()
-    amount2.setValue(currencyAmount)
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
 
-    const destinationAccount = new AccountAddress()
-    destinationAccount.setAddress(destination)
+    const destinationAccountAddress = new AccountAddress()
+    destinationAccountAddress.setAddress(destinationAddress)
 
-    const destination2 = new Destination()
-    destination2.setValue(destinationAccount)
+    const destination = new Destination()
+    destination.setValue(destinationAccountAddress)
 
     const account = new AccountAddress()
     account.setAddress(sender.getAddress())
@@ -187,8 +187,8 @@ class DefaultXpringClient implements XpringClientDecorator {
     account2.setValue(account)
 
     const payment = new Payment()
-    payment.setDestination(destination2)
-    payment.setAmount(amount2)
+    payment.setDestination(destination)
+    payment.setAmount(amount)
 
     const lastLedgerSequence = new LastLedgerSequence()
     lastLedgerSequence.setValue(

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -1,4 +1,4 @@
-import { Utils, Wallet } from 'xpring-common-js'
+import { Signer, Utils, Wallet } from 'xpring-common-js'
 import bigInt, { BigInteger } from 'big-integer'
 import { XpringClientDecorator } from './xpring-client-decorator'
 import TransactionStatus from './transaction-status'
@@ -6,21 +6,9 @@ import RawTransactionStatus from './raw-transaction-status'
 import GRPCNetworkClient from './grpc-network-client'
 import GRPCNetworkClientWeb from './grpc-network-client.web'
 import { NetworkClient } from './network-client'
-<<<<<<< HEAD
-import {
-  Payment,
-  Transaction,
-} from './generated/web/org/xrpl/rpc/v1/transaction_pb'
-import {
-  // GetTransactionRequest,
-  GetTransactionResponse,
-} from './generated/web/org/xrpl/rpc/v1/get_transaction_pb'
 import { GetFeeResponse } from './generated/web/org/xrpl/rpc/v1/get_fee_pb'
-=======
-import { GetFeeResponse } from './generated/web/rpc/v1/fee_pb'
->>>>>>> origin/master
+import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/account_pb'
 import {
-  AccountAddress,
   CurrencyAmount,
   XRPDropsAmount,
 } from './generated/web/org/xrpl/rpc/v1/amount_pb'
@@ -34,6 +22,10 @@ import {
   LastLedgerSequence,
   SigningPublicKey,
 } from './generated/node/org/xrpl/rpc/v1/common_pb'
+import {
+  Payment,
+  Transaction,
+} from './generated/web/org/xrpl/rpc/v1/transaction_pb'
 
 /** A margin to pad the current ledger sequence with when submitting transactions. */
 const maxLedgerVersionOffset = 10
@@ -55,47 +47,6 @@ export class XpringClientErrorMessages {
 }
 
 /**
-<<<<<<< HEAD
- * A private wrapper class which conforms `GetTxResponse` to the `RawTransaction` interface.
- */
-class GetTransactionResponseWrapper implements RawTransactionStatus {
-  public constructor(
-    private readonly getTransactionResponse: GetTransactionResponse,
-  ) {}
-
-  public getValidated(): boolean {
-    return this.getTransactionResponse.getValidated()
-  }
-
-  public getTransactionStatusCode(): string {
-    const meta = this.getTransactionResponse.getMeta()
-    if (!meta) {
-      throw new Error(XpringClientErrorMessages.malformedResponse)
-    }
-
-    const transactionResult = meta.getTransactionResult()
-    if (!transactionResult) {
-      throw new Error(XpringClientErrorMessages.malformedResponse)
-    }
-
-    return transactionResult.getResult()
-  }
-
-  public getLastLedgerSequence(): number {
-    const value = this.getTransactionResponse
-      .getTransaction()
-      ?.getLastLedgerSequence()
-      ?.getValue()
-    if (!value) {
-      throw new Error(XpringClientErrorMessages.malformedResponse)
-    }
-    return value
-  }
-}
-
-/**
-=======
->>>>>>> origin/master
  * DefaultXpringClient is a client which interacts with the Xpring platform.
  */
 class DefaultXpringClient implements XpringClientDecorator {
@@ -257,11 +208,10 @@ class DefaultXpringClient implements XpringClientDecorator {
 
     transaction.setSigningPublicKey(signingPublicKey)
 
-    const signedTransaction = new Uint8Array([1, 2, 3, 4])
-    // Signer.signTransaction(transaction, sender)
-    // if (!signedTransaction) {
-    //   throw new Error(XpringClientErrorMessages.malformedResponse)
-    // }
+    const signedTransaction = Signer.signTransaction(transaction, sender)
+    if (!signedTransaction) {
+      throw new Error(XpringClientErrorMessages.malformedResponse)
+    }
 
     const submitTransactionRequest = this.networkClient.SubmitTransactionRequest()
     submitTransactionRequest.setSignedTransaction(signedTransaction)
@@ -286,11 +236,7 @@ class DefaultXpringClient implements XpringClientDecorator {
 
     const getTxResponse = await this.networkClient.getTransaction(getTxRequest)
 
-<<<<<<< HEAD
-    return new GetTransactionResponseWrapper(getTxResponse)
-=======
-    return RawTransactionStatus.fromGetTxResponse(getTxResponse)
->>>>>>> origin/master
+    return RawTransactionStatus.fromGetTransactionResponse(getTxResponse)
   }
 
   private async getMinimumFee(): Promise<XRPDropsAmount> {

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -180,11 +180,11 @@ class DefaultXpringClient implements XpringClientDecorator {
     const destination = new Destination()
     destination.setValue(destinationAccountAddress)
 
-    const account = new AccountAddress()
-    account.setAddress(sender.getAddress())
+    const senderAccountAddress = new AccountAddress()
+    senderAccountAddress.setAddress(sender.getAddress())
 
-    const account2 = new Account()
-    account2.setValue(account)
+    const account = new Account()
+    account.setValue(senderAccountAddress)
 
     const payment = new Payment()
     payment.setDestination(destination)
@@ -200,7 +200,7 @@ class DefaultXpringClient implements XpringClientDecorator {
     signingPublicKey.setValue(signingPublicKeyBytes)
 
     const transaction = new Transaction()
-    transaction.setAccount(account2)
+    transaction.setAccount(account)
     transaction.setFee(fee)
     transaction.setSequence(accountData.getSequence())
     transaction.setPayment(payment)

--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -2,17 +2,23 @@ import { credentials } from 'grpc'
 import {
   GetAccountInfoRequest,
   GetAccountInfoResponse,
-} from './generated/node/rpc/v1/account_info_pb'
-import { GetFeeRequest, GetFeeResponse } from './generated/node/rpc/v1/fee_pb'
-import { GetTxRequest, GetTxResponse } from './generated/node/rpc/v1/tx_pb'
+} from './generated/node/org/xrpl/rpc/v1/get_account_info_pb'
+import {
+  GetFeeRequest,
+  GetFeeResponse,
+} from './generated/node/org/xrpl/rpc/v1/get_fee_pb'
+import {
+  GetTransactionRequest,
+  GetTransactionResponse,
+} from './generated/node/org/xrpl/rpc/v1/get_transaction_pb'
 import {
   SubmitTransactionRequest,
   SubmitTransactionResponse,
-} from './generated/node/rpc/v1/submit_pb'
-import { XRPLedgerAPIServiceClient } from './generated/node/rpc/v1/xrp_ledger_grpc_pb'
+} from './generated/node/org/xrpl/rpc/v1/submit_pb'
+import { XRPLedgerAPIServiceClient } from './generated/node/org/xrpl/rpc/v1/xrp_ledger_grpc_pb'
 
 import { NetworkClient } from './network-client'
-import { AccountAddress } from './generated/node/rpc/v1/amount_pb'
+import { AccountAddress } from './generated/node/org/xrpl/rpc/v1/amount_pb'
 import isNode from './utils'
 
 /**
@@ -58,9 +64,11 @@ class GRPCNetworkClient implements NetworkClient {
     })
   }
 
-  public async getTx(request: GetTxRequest): Promise<GetTxResponse> {
+  public async getTransaction(
+    request: GetTransactionRequest,
+  ): Promise<GetTransactionResponse> {
     return new Promise((resolve, reject): void => {
-      this.grpcClient.getTx(request, (error, response): void => {
+      this.grpcClient.getTransaction(request, (error, response): void => {
         if (error != null || response == null) {
           reject(error)
           return
@@ -93,8 +101,8 @@ class GRPCNetworkClient implements NetworkClient {
     return new GetAccountInfoRequest()
   }
 
-  public GetTxRequest(): GetTxRequest {
-    return new GetTxRequest()
+  public GetTransactionRequest(): GetTransactionRequest {
+    return new GetTransactionRequest()
   }
 
   public GetFeeRequest(): GetFeeRequest {

--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -18,7 +18,7 @@ import {
 import { XRPLedgerAPIServiceClient } from './generated/node/org/xrpl/rpc/v1/xrp_ledger_grpc_pb'
 
 import { NetworkClient } from './network-client'
-import { AccountAddress } from './generated/node/org/xrpl/rpc/v1/amount_pb'
+import { AccountAddress } from './generated/node/org/xrpl/rpc/v1/account_pb'
 import isNode from './utils'
 
 /**

--- a/src/grpc-network-client.web.ts
+++ b/src/grpc-network-client.web.ts
@@ -1,17 +1,23 @@
 import {
   GetAccountInfoRequest,
   GetAccountInfoResponse,
-} from './generated/web/rpc/v1/account_info_pb'
-import { GetFeeRequest, GetFeeResponse } from './generated/web/rpc/v1/fee_pb'
-import { GetTxRequest, GetTxResponse } from './generated/web/rpc/v1/tx_pb'
+} from './generated/web/org/xrpl/rpc/v1/get_account_info_pb'
+import {
+  GetFeeRequest,
+  GetFeeResponse,
+} from './generated/web/org/xrpl/rpc/v1/get_fee_pb'
+import {
+  GetTransactionRequest,
+  GetTransactionResponse,
+} from './generated/web/org/xrpl/rpc/v1/get_transaction_pb'
 import {
   SubmitTransactionRequest,
   SubmitTransactionResponse,
-} from './generated/web/rpc/v1/submit_pb'
-import { XRPLedgerAPIServiceClient } from './generated/web/rpc/v1/xrp_ledger_grpc_web_pb'
+} from './generated/web/org/xrpl/rpc/v1/submit_pb'
+import { XRPLedgerAPIServiceClient } from './generated/web/org/xrpl/rpc/v1/xrp_ledger_grpc_web_pb'
 
 import { NetworkClient } from './network-client'
-import { AccountAddress } from './generated/web/rpc/v1/amount_pb'
+import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/amount_pb'
 import isNode from './utils'
 
 /**
@@ -60,9 +66,11 @@ class GRPCNetworkClient implements NetworkClient {
     })
   }
 
-  public async getTx(request: GetTxRequest): Promise<GetTxResponse> {
+  public async getTransaction(
+    request: GetTransactionRequest,
+  ): Promise<GetTransactionResponse> {
     return new Promise((resolve, reject): void => {
-      this.grpcClient.getTx(request, {}, (error, response): void => {
+      this.grpcClient.getTransaction(request, {}, (error, response): void => {
         if (error != null || response == null) {
           reject(error)
           return
@@ -99,8 +107,8 @@ class GRPCNetworkClient implements NetworkClient {
     return new GetAccountInfoRequest()
   }
 
-  public GetTxRequest(): GetTxRequest {
-    return new GetTxRequest()
+  public GetTransactionRequest(): GetTransactionRequest {
+    return new GetTransactionRequest()
   }
 
   public GetFeeRequest(): GetFeeRequest {

--- a/src/grpc-network-client.web.ts
+++ b/src/grpc-network-client.web.ts
@@ -17,7 +17,7 @@ import {
 import { XRPLedgerAPIServiceClient } from './generated/web/org/xrpl/rpc/v1/xrp_ledger_grpc_web_pb'
 
 import { NetworkClient } from './network-client'
-import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/amount_pb'
+import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/account_pb'
 import isNode from './utils'
 
 /**

--- a/src/network-client.ts
+++ b/src/network-client.ts
@@ -14,7 +14,7 @@ import {
   SubmitTransactionRequest,
   SubmitTransactionResponse,
 } from './generated/web/org/xrpl/rpc/v1/submit_pb'
-import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/amount_pb'
+import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/account_pb'
 
 /**
  * The network client interface provides a wrapper around network calls to the Xpring Platform.

--- a/src/network-client.ts
+++ b/src/network-client.ts
@@ -1,14 +1,20 @@
 import {
   GetAccountInfoRequest,
   GetAccountInfoResponse,
-} from './generated/web/rpc/v1/account_info_pb'
-import { GetFeeRequest, GetFeeResponse } from './generated/web/rpc/v1/fee_pb'
-import { GetTxRequest, GetTxResponse } from './generated/web/rpc/v1/tx_pb'
+} from './generated/web/org/xrpl/rpc/v1/get_account_info_pb'
+import {
+  GetFeeRequest,
+  GetFeeResponse,
+} from './generated/web/org/xrpl/rpc/v1/get_fee_pb'
+import {
+  GetTransactionRequest,
+  GetTransactionResponse,
+} from './generated/web/org/xrpl/rpc/v1/get_transaction_pb'
 import {
   SubmitTransactionRequest,
   SubmitTransactionResponse,
-} from './generated/web/rpc/v1/submit_pb'
-import { AccountAddress } from './generated/web/rpc/v1/amount_pb'
+} from './generated/web/org/xrpl/rpc/v1/submit_pb'
+import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/amount_pb'
 
 /**
  * The network client interface provides a wrapper around network calls to the Xpring Platform.
@@ -18,13 +24,15 @@ export interface NetworkClient {
     request: GetAccountInfoRequest,
   ): Promise<GetAccountInfoResponse>
   getFee(request: GetFeeRequest): Promise<GetFeeResponse>
-  getTx(request: GetTxRequest): Promise<GetTxResponse>
+  getTransaction(
+    request: GetTransactionRequest,
+  ): Promise<GetTransactionResponse>
   submitTransaction(
     request: SubmitTransactionRequest,
   ): Promise<SubmitTransactionResponse>
   AccountAddress(): AccountAddress
   GetAccountInfoRequest(): GetAccountInfoRequest
-  GetTxRequest(): GetTxRequest
+  GetTransactionRequest(): GetTransactionRequest
   GetFeeRequest(): GetFeeRequest
   SubmitTransactionRequest(): SubmitTransactionRequest
 }

--- a/src/raw-transaction-status.ts
+++ b/src/raw-transaction-status.ts
@@ -1,5 +1,5 @@
 import { TransactionStatus } from './generated/web/legacy/transaction_status_pb'
-import { GetTxResponse } from './generated/web/rpc/v1/tx_pb'
+import { GetTransactionResponse } from './generated/web/org/xrpl/rpc/v1/get_transaction_pb'
 import RippledFlags from './rippled-flags'
 
 /** Abstraction around raw Transaction Status for compatibility. */
@@ -19,10 +19,12 @@ export default class RawTransactionStatus {
   }
 
   /**
-   * Create a RawTransactionStatus from a GetTxResponse protocol buffer.
+   * Create a RawTransactionStatus from a GetTransactionResponse protocol buffer.
    */
-  static fromGetTxResponse(getTxResponse: GetTxResponse): RawTransactionStatus {
-    const transaction = getTxResponse.getTransaction()
+  static fromGetTransactionResponse(
+    getTransactionResponse: GetTransactionResponse,
+  ): RawTransactionStatus {
+    const transaction = getTransactionResponse.getTransaction()
     if (!transaction) {
       throw new Error(
         'Malformed input, `getTxResponse` did not contain a transaction.',
@@ -30,7 +32,7 @@ export default class RawTransactionStatus {
     }
 
     const isPayment = transaction.hasPayment()
-    const flags = transaction.getFlags()
+    const flags = transaction.getFlags()?.getValue() ?? 0
 
     const isPartialPayment = RippledFlags.checkFlag(
       RippledFlags.TF_PARTIAL_PAYMENT,
@@ -40,12 +42,12 @@ export default class RawTransactionStatus {
     const isFullPayment = isPayment && !isPartialPayment
 
     return new RawTransactionStatus(
-      getTxResponse.getValidated(),
-      getTxResponse
+      getTransactionResponse.getValidated(),
+      getTransactionResponse
         .getMeta()
         ?.getTransactionResult()
         ?.getResult(),
-      getTxResponse.getTransaction()?.getLastLedgerSequence(),
+      getTransactionResponse.getTransaction()?.getLastLedgerSequence(),
       isFullPayment,
     )
   }

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -16,7 +16,7 @@ import {
   TransactionResult,
 } from '../src/generated/node/org/xrpl/rpc/v1/meta_pb'
 import TransactionStatus from '../src/transaction-status'
-import { Transaction } from '../src/generated/web/rpc/v1/transaction_pb'
+import { Transaction } from '../src/generated/web/org/xrpl/rpc/v1/transaction_pb'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -37,12 +37,12 @@ const fakeErroringNetworkClient = new FakeNetworkClient(
 )
 
 /**
- * Convenience function which allows construction of `getTxResponse` objects.
+ * Convenience function which allows construction of `getTransactionResponse` objects.
  *
  * @param validated Whether the txResponse is validated.
  * @param resultCode The result code.
  */
-function makeGetTxResponse(
+function makeGetTransactionResponse(
   validated: boolean,
   resultCode: string,
 ): GetTransactionResponse {
@@ -52,18 +52,14 @@ function makeGetTxResponse(
   const meta = new Meta()
   meta.setTransactionResult(transactionResult)
 
-<<<<<<< HEAD
-  const getTxResponse = new GetTransactionResponse()
-=======
   const transaction = new Transaction()
 
-  const getTxResponse = new GetTxResponse()
->>>>>>> origin/master
-  getTxResponse.setMeta(meta)
-  getTxResponse.setValidated(validated)
-  getTxResponse.setTransaction(transaction)
+  const getTransactionResponse = new GetTransactionResponse()
+  getTransactionResponse.setMeta(meta)
+  getTransactionResponse.setValidated(validated)
+  getTransactionResponse.setTransaction(transaction)
 
-  return getTxResponse
+  return getTransactionResponse
 }
 
 describe('Default Xpring Client', function(): void {
@@ -131,7 +127,7 @@ describe('Default Xpring Client', function(): void {
     for (let i = 0; i < transactionStatusFailureCodes.length; i += 1) {
       // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
       const transactionStatusCodeFailure = transactionStatusFailureCodes[i]
-      const transactionStatusResponse = makeGetTxResponse(
+      const transactionStatusResponse = makeGetTransactionResponse(
         false,
         transactionStatusCodeFailure,
       )
@@ -161,7 +157,7 @@ describe('Default Xpring Client', function(): void {
     void
   > {
     // GIVEN a XpringClient which will return an unvalidated transaction with a success code.
-    const transactionStatusResponse = makeGetTxResponse(
+    const transactionStatusResponse = makeGetTransactionResponse(
       false,
       transactionStatusCodeSuccess,
     )
@@ -192,7 +188,7 @@ describe('Default Xpring Client', function(): void {
       // GIVEN a XpringClient which will return an unvalidated transaction with a failure code.
       const transactionStatusCodeFailure = transactionStatusFailureCodes[i]
       // GIVEN a XpringClient which will return an validated transaction with a failure code.
-      const transactionStatusResponse = makeGetTxResponse(
+      const transactionStatusResponse = makeGetTransactionResponse(
         true,
         transactionStatusCodeFailure,
       )
@@ -222,7 +218,7 @@ describe('Default Xpring Client', function(): void {
     void
   > {
     // GIVEN a XpringClient which will return an validated transaction with a success code.
-    const transactionStatusResponse = makeGetTxResponse(
+    const transactionStatusResponse = makeGetTransactionResponse(
       true,
       transactionStatusCodeSuccess,
     )

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -10,8 +10,11 @@ import {
   FakeNetworkClientResponses,
 } from './fakes/fake-network-client'
 import 'mocha'
-import { GetTxResponse } from '../src/generated/node/rpc/v1/tx_pb'
-import { Meta, TransactionResult } from '../src/generated/node/rpc/v1/meta_pb'
+import { GetTransactionResponse } from '../src/generated/node/org/xrpl/rpc/v1/get_transaction_pb'
+import {
+  Meta,
+  TransactionResult,
+} from '../src/generated/node/org/xrpl/rpc/v1/meta_pb'
 import TransactionStatus from '../src/transaction-status'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
@@ -41,14 +44,14 @@ const fakeErroringNetworkClient = new FakeNetworkClient(
 function makeGetTxResponse(
   validated: boolean,
   resultCode: string,
-): GetTxResponse {
+): GetTransactionResponse {
   const transactionResult = new TransactionResult()
   transactionResult.setResult(resultCode)
 
   const meta = new Meta()
   meta.setTransactionResult(transactionResult)
 
-  const getTxResponse = new GetTxResponse()
+  const getTxResponse = new GetTransactionResponse()
   getTxResponse.setMeta(meta)
   getTxResponse.setValidated(validated)
 

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import { Transaction } from '../../src/generated/web/rpc/v1/transaction_pb'
+import { Transaction } from '../../src/generated/web/org/xrpl/rpc/v1/transaction_pb'
 import { NetworkClient } from '../../src/network-client'
 import {
   GetAccountInfoRequest,
@@ -21,10 +21,9 @@ import {
 import { AccountRoot } from '../../src/generated/web/org/xrpl/rpc/v1/ledger_objects_pb'
 import {
   XRPDropsAmount,
-  AccountAddress,
   CurrencyAmount,
 } from '../../src/generated/web/org/xrpl/rpc/v1/amount_pb'
-
+import { AccountAddress } from '../../src/generated/web/org/xrpl/rpc/v1/account_pb'
 import {
   Meta,
   TransactionResult,
@@ -144,7 +143,7 @@ export class FakeNetworkClientResponses {
 
     const transaction = new Transaction()
 
-    const response = new GetTxResponse()
+    const response = new GetTransactionResponse()
     response.setValidated(true)
     response.setMeta(meta)
     response.setTransaction(transaction)

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -15,7 +15,7 @@ const wallet = Wallet.generateWalletFromSeed('snYP7oArxKepd3GPDcrjMsJYiJeJB')!
 
 // A hash of a successfully validated transaction.
 const transactionHash =
-  '4E732C5748DE722C7598CEB76350FCD6269ACBE5D641A5BCF0721150EF6E2C9F'
+  '24E31668208A3165E6C702CDA66425808EAD670EABCBFA6C4403FFA93500D486'
 
 // A XpringClient that makes requests. Uses the legacy protocol buffer implementation.
 const legacyGRPCURLNode = 'grpc.xpring.tech:80'

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -113,4 +113,33 @@ describe('Xpring JS Integration Tests', function(): void {
     const result = await xpringClient.send(amount, recipientAddress, wallet)
     assert.exists(result)
   })
+
+  it('Check if Account Exists - Legacy Node Shim', async function(): Promise<
+    void
+  > {
+    this.timeout(timeoutMs)
+
+    const doesExist = await legacyXpringClientNode.accountExists(
+      recipientAddress,
+    )
+    assert.equal(doesExist, true)
+  })
+
+  it('Check if Account Exists - Legacy Web Shim', async function(): Promise<
+    void
+  > {
+    this.timeout(timeoutMs)
+
+    const doesExist = await legacyXpringClientWeb.accountExists(
+      recipientAddress,
+    )
+    assert.equal(doesExist, true)
+  })
+
+  it('Check if Account Exists - rippled', async function(): Promise<void> {
+    this.timeout(timeoutMs)
+
+    const doesExist = await xpringClient.accountExists(recipientAddress)
+    assert.equal(doesExist, true)
+  })
 })

--- a/test/raw-transaction-test.ts
+++ b/test/raw-transaction-test.ts
@@ -1,13 +1,14 @@
 import { assert } from 'chai'
 import RippledFlags from '../src/rippled-flags'
-import { GetTxResponse } from '../src/generated/web/rpc/v1/tx_pb'
+import { GetTransactionResponse } from '../src/generated/web/org/xrpl/rpc/v1/get_transaction_pb'
 import {
   Transaction,
   Payment,
-} from '../src/generated/web/rpc/v1/transaction_pb'
+} from '../src/generated/web/org/xrpl/rpc/v1/transaction_pb'
 import { TransactionStatus as LegacyTransactionStatus } from '../src/generated/web/legacy/transaction_status_pb'
 import 'mocha'
 import RawTransactionStatus from '../src/raw-transaction-status'
+import { Flags } from '../src/generated/web/org/xrpl/rpc/v1/common_pb'
 
 describe('raw transaction status', function(): void {
   it('isFullPayment - legacy proto', function(): void {
@@ -28,11 +29,11 @@ describe('raw transaction status', function(): void {
     const transaction = new Transaction()
     transaction.clearPayment()
 
-    const getTxResponse = new GetTxResponse()
+    const getTxResponse = new GetTransactionResponse()
     getTxResponse.setTransaction(transaction)
 
     // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
-    const rawTransactionStatus = RawTransactionStatus.fromGetTxResponse(
+    const rawTransactionStatus = RawTransactionStatus.fromGetTransactionResponse(
       getTxResponse,
     )
 
@@ -44,15 +45,18 @@ describe('raw transaction status', function(): void {
     // GIVEN a getTxResponse which is a payment with the partial payment flags set.
     const payment = new Payment()
 
+    const flags = new Flags()
+    flags.setValue(RippledFlags.TF_PARTIAL_PAYMENT)
+
     const transaction = new Transaction()
     transaction.setPayment(payment)
-    transaction.setFlags(RippledFlags.TF_PARTIAL_PAYMENT)
+    transaction.setFlags(flags)
 
-    const getTxResponse = new GetTxResponse()
+    const getTxResponse = new GetTransactionResponse()
     getTxResponse.setTransaction(transaction)
 
     // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
-    const rawTransactionStatus = RawTransactionStatus.fromGetTxResponse(
+    const rawTransactionStatus = RawTransactionStatus.fromGetTransactionResponse(
       getTxResponse,
     )
 
@@ -67,11 +71,11 @@ describe('raw transaction status', function(): void {
     const transaction = new Transaction()
     transaction.setPayment(payment)
 
-    const getTxResponse = new GetTxResponse()
+    const getTxResponse = new GetTransactionResponse()
     getTxResponse.setTransaction(transaction)
 
     // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
-    const rawTransactionStatus = RawTransactionStatus.fromGetTxResponse(
+    const rawTransactionStatus = RawTransactionStatus.fromGetTransactionResponse(
       getTxResponse,
     )
 


### PR DESCRIPTION
## High Level Overview of Change

Update to be compatible with breaking protocol buffer changes in rippled.  Breaking changes were introduced in  https://github.com/ripple/rippled/pull/3254. .

### Context of Change

No logic changes are introduced. This change does not touch the public API. 

Changes for protocol buffer compatibility and upgrade xpring-common-js to a version that has compatibility wiht the new protocol buffers

Changes in the protocol buffers are:
- Change folder / package location of files
- Use numeric strings instead of numbers to prevent overflows when working with 64 bit integers.
- Introduce new layers of abstraction internally.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

Compatible with latest rippled. 

## Test Plan
 CI
