### PR TITLE
Improves accountExists method to discern error codes

### DIFF
--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -1,5 +1,6 @@
 import { Signer, Utils, Wallet } from 'xpring-common-js'
 import bigInt, { BigInteger } from 'big-integer'
+import grpc from 'grpc'
 import { XpringClientDecorator } from './xpring-client-decorator'
 import TransactionStatus from './transaction-status'
 import RawTransactionStatus from './raw-transaction-status'
@@ -299,7 +300,10 @@ class DefaultXpringClient implements XpringClientDecorator {
       await this.getBalance(address)
       return true
     } catch (e) {
-      return false
+      if ('code' in e && e.code === grpc.status.NOT_FOUND) {
+        return false
+      }
+      throw e // error code other than NOT_FOUND should re-throw error
     }
   }
 }

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -300,7 +300,10 @@ class DefaultXpringClient implements XpringClientDecorator {
       await this.getBalance(address)
       return true
     } catch (e) {
-      if ('code' in e && e.code === grpc.status.NOT_FOUND) {
+      if (
+        Object.prototype.hasOwnProperty.call(e, 'code') &&
+        e.code === grpc.status.NOT_FOUND
+      ) {
         return false
       }
       throw e // error code other than NOT_FOUND should re-throw error

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -300,10 +300,7 @@ class DefaultXpringClient implements XpringClientDecorator {
       await this.getBalance(address)
       return true
     } catch (e) {
-      if (
-        Object.prototype.hasOwnProperty.call(e, 'code') &&
-        e.code === grpc.status.NOT_FOUND
-      ) {
+      if (e.code && e.code === grpc.status.NOT_FOUND) {
         return false
       }
       throw e // error code other than NOT_FOUND should re-throw error

--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -1,6 +1,7 @@
 import { Signer, Utils, Wallet } from 'xpring-common-js'
 
 import bigInt, { BigInteger } from 'big-integer'
+import grpc from 'grpc'
 import { AccountInfo } from '../generated/web/legacy/account_info_pb'
 import { XRPAmount } from '../generated/web/legacy/xrp_amount_pb'
 
@@ -244,7 +245,10 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
       await this.getBalance(address)
       return true
     } catch (e) {
-      return false
+      if ('code' in e && e.code === grpc.status.NOT_FOUND) {
+        return false
+      }
+      throw e // error code other than NOT_FOUND should re-throw error
     }
   }
 }

--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -245,10 +245,7 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
       await this.getBalance(address)
       return true
     } catch (e) {
-      if (
-        Object.prototype.hasOwnProperty.call(e, 'code') &&
-        e.code === grpc.status.NOT_FOUND
-      ) {
+      if (e.code && e.code === grpc.status.NOT_FOUND) {
         return false
       }
       throw e // error code other than NOT_FOUND should re-throw error

--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -245,7 +245,10 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
       await this.getBalance(address)
       return true
     } catch (e) {
-      if ('code' in e && e.code === grpc.status.NOT_FOUND) {
+      if (
+        Object.prototype.hasOwnProperty.call(e, 'code') &&
+        e.code === grpc.status.NOT_FOUND
+      ) {
         return false
       }
       throw e // error code other than NOT_FOUND should re-throw error

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -439,8 +439,7 @@ describe('Default Xpring Client', function(): void {
   })
 
   it('Check if account exists - failing network request w/ NOT_FOUND error', async function() {
-    // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
-    // a property 'code' with value grpc.status.NOT_FOUND.
+    // GIVEN a XpringClient with a network client that will report accounts as not found
     const notFoundError = new FakeGRPCError(
       'FakeGRPCError: account not found',
       grpc.status.NOT_FOUND,
@@ -453,16 +452,15 @@ describe('Default Xpring Client', function(): void {
     )
     const xpringClient = new DefaultXpringClient(fakeErroringNetworkClient)
 
-    // WHEN accountExists encounters this Error while calling getBalance
+    // WHEN Account existence is checked
     const exists = await xpringClient.accountExists(testAddress)
 
-    // THEN accountExists returns false
+    // THEN the account is reported not to exist
     assert.equal(exists, false)
   })
 
   it('Check if account exists - failing network request w/ CANCELLED error', function(done) {
-    // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
-    // a property 'code' with value grpc.status.CANCELLED.
+    // GIVEN a XpringClient with a network client that reports grpc operation as cancelled
     const cancelledError = new FakeGRPCError(
       'FakeGRPCError: operation was cancelled',
       grpc.status.CANCELLED,
@@ -475,8 +473,8 @@ describe('Default Xpring Client', function(): void {
     )
     const xpringClient = new DefaultXpringClient(fakeErroringNetworkClient)
 
-    // WHEN accountExists encounters this Error while calling getBalance
-    // THEN accountExists should re-throw the error (cannot conclude account doesn't exist)
+    // WHEN Account existence is checked
+    // THEN an error is re-thrown (cannot conclude account doesn't exist)
     xpringClient.accountExists(testAddress).catch((error) => {
       assert.typeOf(error, 'Error')
       assert.equal(error.code, grpc.status.CANCELLED)

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -3,6 +3,7 @@ import { assert } from 'chai'
 import bigInt from 'big-integer'
 import grpc from 'grpc'
 import { Utils, Wallet } from 'xpring-common-js'
+import FakeGRPCError from './fakes/fake-grpc-error'
 import DefaultXpringClient, {
   XpringClientErrorMessages,
 } from '../src/default-xpring-client'
@@ -32,23 +33,6 @@ const fakeSucceedingNetworkClient = new FakeNetworkClient()
 const fakeErroringNetworkClient = new FakeNetworkClient(
   FakeNetworkClientResponses.defaultErrorResponses,
 )
-
-/**
- * Convenience class for creating more specific Error objects to mimick grpc error responses.
- */
-class FakeServiceError extends Error {
-  /**
-   * Construct a new FakeServiceError.
-   *
-   * @param message The text details of the error.
-   * @param code The grpc.status code.
-   */
-  constructor(public message: string, public code: grpc.status) {
-    super(message)
-    this.message = message
-    this.code = code
-  }
-}
 
 /**
  * Convenience function which allows construction of `getTxResponse` objects.
@@ -457,8 +441,8 @@ describe('Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ NOT_FOUND error', async function() {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.NOT_FOUND.
-    const errorWithCode5 = new FakeServiceError(
-      'FakeServiceError: account not found',
+    const errorWithCode5 = new FakeGRPCError(
+      'FakeGRPCError: account not found',
       grpc.status.NOT_FOUND,
     )
     const fakeNetworkClientResponses = new FakeNetworkClientResponses(
@@ -479,8 +463,8 @@ describe('Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ CANCELLED error', function(done) {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.CANCELLED.
-    const errorWithCode1 = new FakeServiceError(
-      'FakeServiceError: operation was cancelled',
+    const errorWithCode1 = new FakeGRPCError(
+      'FakeGRPCError: operation was cancelled',
       grpc.status.CANCELLED,
     )
     const fakeNetworkClientResponses = new FakeNetworkClientResponses(

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -441,12 +441,12 @@ describe('Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ NOT_FOUND error', async function() {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.NOT_FOUND.
-    const errorWithCode5 = new FakeGRPCError(
+    const notFoundError = new FakeGRPCError(
       'FakeGRPCError: account not found',
       grpc.status.NOT_FOUND,
     )
     const fakeNetworkClientResponses = new FakeNetworkClientResponses(
-      errorWithCode5, // getAccountInfoResponse
+      notFoundError, // getAccountInfoResponse
     )
     const fakeErroringNetworkClient = new FakeNetworkClient(
       fakeNetworkClientResponses,
@@ -463,12 +463,12 @@ describe('Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ CANCELLED error', function(done) {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.CANCELLED.
-    const errorWithCode1 = new FakeGRPCError(
+    const cancelledError = new FakeGRPCError(
       'FakeGRPCError: operation was cancelled',
       grpc.status.CANCELLED,
     )
     const fakeNetworkClientResponses = new FakeNetworkClientResponses(
-      errorWithCode1, // getAccountInfoResponse
+      cancelledError, // getAccountInfoResponse
     )
     const fakeErroringNetworkClient = new FakeNetworkClient(
       fakeNetworkClientResponses,

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -494,7 +494,7 @@ describe('Default Xpring Client', function(): void {
     // WHEN accountExists encounters this Error while calling getBalance
     // THEN accountExists should re-throw the error (cannot conclude account doesn't exist)
     xpringClient.accountExists(testAddress).catch((error) => {
-      assert.typeOf(error, 'FakeServiceError')
+      assert.typeOf(error, 'Error')
       assert.equal(error.code, grpc.status.CANCELLED)
       done()
     })

--- a/test/fakes/fake-grpc-error.ts
+++ b/test/fakes/fake-grpc-error.ts
@@ -1,6 +1,7 @@
 import grpc from 'grpc'
+
 /**
- * Convenience class for creating more specific Error objects to mimick grpc error responses.
+ * Convenience class for creating more specific Error objects to mimick gRPC error responses.
  */
 export default class FakeGRPCError extends Error {
   /**

--- a/test/fakes/fake-grpc-error.ts
+++ b/test/fakes/fake-grpc-error.ts
@@ -1,0 +1,18 @@
+import grpc from 'grpc'
+/**
+ * Convenience class for creating more specific Error objects to mimick grpc error responses.
+ */
+export default class FakeGRPCError extends Error {
+  /**
+   * Construct a new FakeServiceError.
+   *
+   * @param message The text details of the error.
+   * @param code The grpc.status code.
+   */
+  constructor(
+    public readonly message: string,
+    public readonly code: grpc.status,
+  ) {
+    super(message)
+  }
+}

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -146,7 +146,8 @@ describe('Xpring JS Integration Tests', function(): void {
     assert.equal(doesExist, true)
   })
 
-  // Omitting false-case tests for LegacyNode and LegacyWeb
+  // Tests for account existence on the legacy shim are intentionally omitted as the legacy shim does have the
+  // required granularity of information.
 
   it('Check if Account Exists - false - rippled', async function(): Promise<
     void

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -138,13 +138,9 @@ describe('Xpring JS Integration Tests', function(): void {
 
   it('Check if Account Exists - rippled', async function(): Promise<void> {
     this.timeout(timeoutMs)
-    const coinbase = 'XVYUQ3SdUcVnaTNVanDYo1NamrUukPUPeoGMnmvkEExbtrj'
-    try {
-      const doesExist = await xpringClient.accountExists(coinbase)
-      console.log(doesExist)
-    } catch (e) {
-      assert.equal(e.name, 'ServiceError')
-      assert.equal(true, false)
-    }
+
+    const doesExist = await xpringClient.accountExists(recipientAddress)
+
+    assert.equal(doesExist, true)
   })
 })

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -146,27 +146,7 @@ describe('Xpring JS Integration Tests', function(): void {
     assert.equal(doesExist, true)
   })
 
-  it('Check if Account Exists - false - Legacy Node Shim', async function(): Promise<
-    void
-  > {
-    this.timeout(timeoutMs)
-
-    const coinbaseMainnet = 'XVYUQ3SdUcVnaTNVanDYo1NamrUukPUPeoGMnmvkEExbtrj' // valid address but should NOT show up on testnet
-    const doesExist = await legacyXpringClientNode.accountExists(
-      coinbaseMainnet,
-    )
-    assert.equal(doesExist, false)
-  })
-
-  it('Check if Account Exists - false - Legacy Web Shim', async function(): Promise<
-    void
-  > {
-    this.timeout(timeoutMs)
-
-    const coinbaseMainnet = 'XVYUQ3SdUcVnaTNVanDYo1NamrUukPUPeoGMnmvkEExbtrj' // valid address but should NOT show up on testnet
-    const doesExist = await legacyXpringClientWeb.accountExists(coinbaseMainnet)
-    assert.equal(doesExist, false)
-  })
+  // Omitting false-case tests for LegacyNode and LegacyWeb
 
   it('Check if Account Exists - false - rippled', async function(): Promise<
     void

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -138,8 +138,13 @@ describe('Xpring JS Integration Tests', function(): void {
 
   it('Check if Account Exists - rippled', async function(): Promise<void> {
     this.timeout(timeoutMs)
-
-    const doesExist = await xpringClient.accountExists(recipientAddress)
-    assert.equal(doesExist, true)
+    const coinbase = 'XVYUQ3SdUcVnaTNVanDYo1NamrUukPUPeoGMnmvkEExbtrj'
+    try {
+      const doesExist = await xpringClient.accountExists(coinbase)
+      console.log(doesExist)
+    } catch (e) {
+      assert.equal(e.name, 'ServiceError')
+      assert.equal(true, false)
+    }
   })
 })

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -114,7 +114,7 @@ describe('Xpring JS Integration Tests', function(): void {
     assert.exists(result)
   })
 
-  it('Check if Account Exists - Legacy Node Shim', async function(): Promise<
+  it('Check if Account Exists - true - Legacy Node Shim', async function(): Promise<
     void
   > {
     this.timeout(timeoutMs)
@@ -125,7 +125,7 @@ describe('Xpring JS Integration Tests', function(): void {
     assert.equal(doesExist, true)
   })
 
-  it('Check if Account Exists - Legacy Web Shim', async function(): Promise<
+  it('Check if Account Exists - true - Legacy Web Shim', async function(): Promise<
     void
   > {
     this.timeout(timeoutMs)
@@ -136,11 +136,45 @@ describe('Xpring JS Integration Tests', function(): void {
     assert.equal(doesExist, true)
   })
 
-  it('Check if Account Exists - rippled', async function(): Promise<void> {
+  it('Check if Account Exists - true - rippled', async function(): Promise<
+    void
+  > {
     this.timeout(timeoutMs)
 
     const doesExist = await xpringClient.accountExists(recipientAddress)
 
     assert.equal(doesExist, true)
+  })
+
+  it('Check if Account Exists - false - Legacy Node Shim', async function(): Promise<
+    void
+  > {
+    this.timeout(timeoutMs)
+
+    const coinbaseMainnet = 'XVYUQ3SdUcVnaTNVanDYo1NamrUukPUPeoGMnmvkEExbtrj' // valid address but should NOT show up on testnet
+    const doesExist = await legacyXpringClientNode.accountExists(
+      coinbaseMainnet,
+    )
+    assert.equal(doesExist, false)
+  })
+
+  it('Check if Account Exists - false - Legacy Web Shim', async function(): Promise<
+    void
+  > {
+    this.timeout(timeoutMs)
+
+    const coinbaseMainnet = 'XVYUQ3SdUcVnaTNVanDYo1NamrUukPUPeoGMnmvkEExbtrj' // valid address but should NOT show up on testnet
+    const doesExist = await legacyXpringClientWeb.accountExists(coinbaseMainnet)
+    assert.equal(doesExist, false)
+  })
+
+  it('Check if Account Exists - false - rippled', async function(): Promise<
+    void
+  > {
+    this.timeout(timeoutMs)
+
+    const coinbaseMainnet = 'XVYUQ3SdUcVnaTNVanDYo1NamrUukPUPeoGMnmvkEExbtrj' // valid address but should NOT show up on testnet
+    const doesExist = await xpringClient.accountExists(coinbaseMainnet)
+    assert.equal(doesExist, false)
   })
 })

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -487,8 +487,7 @@ describe('Legacy Default Xpring Client', function(): void {
   })
 
   it('Check if account exists - failing network request w/ NOT_FOUND error', async function() {
-    // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
-    // a property 'code' with value grpc.status.NOT_FOUND.
+    // GIVEN a XpringClient with a network client that will report accounts as not found
     const notFoundError = new FakeGRPCError(
       'FakeGRPCError: account not found',
       grpc.status.NOT_FOUND,
@@ -503,16 +502,15 @@ describe('Legacy Default Xpring Client', function(): void {
       fakeErroringNetworkClient,
     )
 
-    // WHEN accountExists encounters this Error while calling getBalance
+    // WHEN Account existence is checked
     const exists = await xpringClient.accountExists(testAddress)
 
-    // THEN accountExists returns false
+    // THEN the account is reported not to exist
     assert.equal(exists, false)
   })
 
   it('Check if account exists - failing network request w/ CANCELLED error', function(done) {
-    // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
-    // a property 'code' with value grpc.status.CANCELLED.
+    // GIVEN a XpringClient with a network client that reports grpc operation as cancelled
     const cancelledError = new FakeGRPCError(
       'FakeGRPCError: operation was cancelled',
       grpc.status.CANCELLED,
@@ -527,8 +525,8 @@ describe('Legacy Default Xpring Client', function(): void {
       fakeErroringNetworkClient,
     )
 
-    // WHEN accountExists encounters this Error while calling getBalance
-    // THEN accountExists should re-throw the error (cannot conclude account doesn't exist)
+    // WHEN Account existence is checked
+    // THEN an error is re-thrown (cannot conclude account doesn't exist)
     xpringClient.accountExists(testAddress).catch((error) => {
       assert.typeOf(error, 'Error')
       assert.equal(error.code, grpc.status.CANCELLED)

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -489,12 +489,12 @@ describe('Legacy Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ NOT_FOUND error', async function() {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.NOT_FOUND.
-    const errorWithCode5 = new FakeGRPCError(
+    const notFoundError = new FakeGRPCError(
       'FakeGRPCError: account not found',
       grpc.status.NOT_FOUND,
     )
     const fakeNetworkClientResponses = new FakeLegacyNetworkClientResponses(
-      errorWithCode5, // getAccountInfoResponse
+      notFoundError, // getAccountInfoResponse
     )
     const fakeErroringNetworkClient = new FakeLegacyNetworkClient(
       fakeNetworkClientResponses,
@@ -513,12 +513,12 @@ describe('Legacy Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ CANCELLED error', function(done) {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.CANCELLED.
-    const errorWithCode1 = new FakeGRPCError(
+    const cancelledError = new FakeGRPCError(
       'FakeGRPCError: operation was cancelled',
       grpc.status.CANCELLED,
     )
     const fakeNetworkClientResponses = new FakeLegacyNetworkClientResponses(
-      errorWithCode1, // getAccountInfoResponse
+      cancelledError, // getAccountInfoResponse
     )
     const fakeErroringNetworkClient = new FakeLegacyNetworkClient(
       fakeNetworkClientResponses,

--- a/test/legacy/legacy-default-xpring-client-test.ts
+++ b/test/legacy/legacy-default-xpring-client-test.ts
@@ -8,6 +8,7 @@ import { TransactionStatus as TransactionStatusResponse } from '../../src/genera
 import LegacyDefaultXpringClient, {
   LegacyXpringClientErrorMessages,
 } from '../../src/legacy/legacy-default-xpring-client'
+import FakeGRPCError from '../fakes/fake-grpc-error'
 import {
   FakeLegacyNetworkClient,
   FakeLegacyNetworkClientResponses,
@@ -34,23 +35,6 @@ const transactionStatusFailureCodes = [
 ]
 
 const transactionHash = 'DEADBEEF'
-
-/**
- * Convenience class for creating more specific Error objects to mimick grpc error responses.
- */
-class FakeServiceError extends Error {
-  /**
-   * Construct a new FakeServiceError.
-   *
-   * @param message The text details of the error.
-   * @param code The grpc.status code.
-   */
-  constructor(public message: string, public code: grpc.status) {
-    super(message)
-    this.message = message
-    this.code = code
-  }
-}
 
 describe('Legacy Default Xpring Client', function(): void {
   it('Get Account Balance - successful response', async function() {
@@ -505,8 +489,8 @@ describe('Legacy Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ NOT_FOUND error', async function() {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.NOT_FOUND.
-    const errorWithCode5 = new FakeServiceError(
-      'FakeServiceError: account not found',
+    const errorWithCode5 = new FakeGRPCError(
+      'FakeGRPCError: account not found',
       grpc.status.NOT_FOUND,
     )
     const fakeNetworkClientResponses = new FakeLegacyNetworkClientResponses(
@@ -529,8 +513,8 @@ describe('Legacy Default Xpring Client', function(): void {
   it('Check if account exists - failing network request w/ CANCELLED error', function(done) {
     // GIVEN a XpringClient which wraps an erroring network client that returns an Error containing
     // a property 'code' with value grpc.status.CANCELLED.
-    const errorWithCode1 = new FakeServiceError(
-      'FakeServiceError: operation was cancelled',
+    const errorWithCode1 = new FakeGRPCError(
+      'FakeGRPCError: operation was cancelled',
       grpc.status.CANCELLED,
     )
     const fakeNetworkClientResponses = new FakeLegacyNetworkClientResponses(


### PR DESCRIPTION
## High Level Overview of Change
accountExists method in XpringClient was treating any exception raised as a "false" conclusion (account does not exist).  This PR updates the method to conclude false only if a grpc.status.NOT_FOUND error code is in the exception.  Other codes will cause the exception to be re-thrown.  Unit and integration tests also updated to test ability to distinguish error codes.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After
Before: accountExists could have returned misleading false-negatives. 
After: will propagate exceptions that it's not qualified to interpret.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
