### PR TITLE
Refactor `RawTransactionStatus` to be a class rather than an interface

### DIFF
--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -96,11 +96,11 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
     )
 
     // Return pending if the transaction is not validated.
-    if (!transactionStatus.getValidated()) {
+    if (!transactionStatus.isValidated) {
       return TransactionStatus.Pending
     }
 
-    return transactionStatus.getTransactionStatusCode().startsWith('tes')
+    return transactionStatus.transactionStatusCode.startsWith('tes')
       ? TransactionStatus.Succeeded
       : TransactionStatus.Failed
   }
@@ -212,7 +212,11 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
     const transactionStatusRequest = this.networkClient.GetTransactionStatusRequest()
     transactionStatusRequest.setTransactionHash(transactionHash)
 
-    return this.networkClient.getTransactionStatus(transactionStatusRequest)
+    const transactionStatus = await this.networkClient.getTransactionStatus(
+      transactionStatusRequest,
+    )
+
+    return RawTransactionStatus.fromTransactionStatus(transactionStatus)
   }
 
   private async getAccountInfo(address: string): Promise<AccountInfo> {

--- a/src/raw-transaction-status.ts
+++ b/src/raw-transaction-status.ts
@@ -6,7 +6,7 @@ export default class RawTransactionStatus {
   /**
    * Create a RawTransactionStatus from a TransactionStatus legacy protocol buffer.
    */
-  public static fromTransactionStatus(
+  static fromTransactionStatus(
     transactionStatus: TransactionStatus,
   ): RawTransactionStatus {
     return new RawTransactionStatus(
@@ -19,9 +19,7 @@ export default class RawTransactionStatus {
   /**
    * Create a RawTransactionStatus from a GetTxResponse protocol buffer.
    */
-  public static fromGetTxResponse(
-    getTxResponse: GetTxResponse,
-  ): RawTransactionStatus {
+  static fromGetTxResponse(getTxResponse: GetTxResponse): RawTransactionStatus {
     return new RawTransactionStatus(
       getTxResponse.getValidated(),
       getTxResponse
@@ -35,7 +33,7 @@ export default class RawTransactionStatus {
   /**
    * Note: This constructor is exposed for testing purposes. Clients of this code should favor using a static factory method.
    */
-  public constructor(
+  constructor(
     public isValidated,
     public transactionStatusCode,
     public lastLedgerSequence,

--- a/src/raw-transaction-status.ts
+++ b/src/raw-transaction-status.ts
@@ -1,6 +1,43 @@
+import { TransactionStatus } from './generated/web/legacy/transaction_status_pb'
+import { GetTxResponse } from './generated/web/rpc/v1/tx_pb'
+
 /** Abstraction around raw Transaction Status for compatibility. */
-export default interface RawTransactionStatus {
-  getValidated(): boolean
-  getTransactionStatusCode(): string
-  getLastLedgerSequence(): number
+export default class RawTransactionStatus {
+  /**
+   * Create a RawTransactionStatus from a TransactionStatus legacy protocol buffer.
+   */
+  public static fromTransactionStatus(
+    transactionStatus: TransactionStatus,
+  ): RawTransactionStatus {
+    return new RawTransactionStatus(
+      transactionStatus.getValidated(),
+      transactionStatus.getTransactionStatusCode(),
+      transactionStatus.getLastLedgerSequence(),
+    )
+  }
+
+  /**
+   * Create a RawTransactionStatus from a GetTxResponse protocol buffer.
+   */
+  public static fromGetTxResponse(
+    getTxResponse: GetTxResponse,
+  ): RawTransactionStatus {
+    return new RawTransactionStatus(
+      getTxResponse.getValidated(),
+      getTxResponse
+        .getMeta()
+        ?.getTransactionResult()
+        ?.getResult(),
+      getTxResponse.getTransaction()?.getLastLedgerSequence(),
+    )
+  }
+
+  /**
+   * Note: This constructor is exposed for testing purposes. Clients of this code should favor using a static factory method.
+   */
+  public constructor(
+    public isValidated,
+    public transactionStatusCode,
+    public lastLedgerSequence,
+  ) {}
 }

--- a/src/reliable-submission-xpring-client.ts
+++ b/src/reliable-submission-xpring-client.ts
@@ -43,7 +43,7 @@ class ReliableSubmissionXpringClient implements XpringClientDecorator {
     let rawTransactionStatus = await this.getRawTransactionStatus(
       transactionHash,
     )
-    const lastLedgerSequence = rawTransactionStatus.getLastLedgerSequence()
+    const { lastLedgerSequence } = rawTransactionStatus
     if (lastLedgerSequence === 0) {
       return Promise.reject(
         new Error(
@@ -65,7 +65,7 @@ class ReliableSubmissionXpringClient implements XpringClientDecorator {
     /* eslint-disable no-await-in-loop */
     while (
       latestLedgerSequence <= lastLedgerSequence &&
-      !rawTransactionStatus.getValidated()
+      !rawTransactionStatus.isValidated
     ) {
       await sleep(ledgerCloseTimeMs)
 


### PR DESCRIPTION
## High Level Overview of Change

In order to bucket transaction statuses as `unknown` we need to have additional derived fields in the `RawTransactionStatus` object.

### Context of Change

Recall that there are two sets of protocol buffers (one from xpring-common-protocol-buffers, "legacy") and a new set from rippled. `RawTransactionStatus` is a wrapper class that provides a bridge between these two protocol buffer implementations. 

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

No change in behavior

## Test Plan

CI
<!--
## Future Tasks
For future tasks related to PR.
-->
