### PR TITLE
(2/2) Return `Unknown` when transaction status is not a payment transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `getTransactionStatus` will now return `TransactionStatus.unknown` if the transaction hash provided references a transaction that is a partial payment or a non payment transaction. This behavior is only enabled when using the rippled protocol buffer implementation. 
+
 ## 1.3.2 - Feb 05, 2020
 
 This fix release adds a missing export.

--- a/src/default-xpring-client.ts
+++ b/src/default-xpring-client.ts
@@ -111,6 +111,10 @@ class DefaultXpringClient implements XpringClientDecorator {
       transactionHash,
     )
 
+    if (!transactionStatus.isBucketable) {
+      return TransactionStatus.Unknown
+    }
+
     // Return pending if the transaction is not validated.
     if (!transactionStatus.isValidated) {
       return TransactionStatus.Pending

--- a/src/legacy/legacy-default-xpring-client.ts
+++ b/src/legacy/legacy-default-xpring-client.ts
@@ -96,11 +96,11 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
     )
 
     // Return pending if the transaction is not validated.
-    if (!transactionStatus.getValidated()) {
+    if (!transactionStatus.isValidated) {
       return TransactionStatus.Pending
     }
 
-    return transactionStatus.getTransactionStatusCode().startsWith('tes')
+    return transactionStatus.transactionStatusCode.startsWith('tes')
       ? TransactionStatus.Succeeded
       : TransactionStatus.Failed
   }
@@ -212,7 +212,11 @@ class LegacyDefaultXpringClient implements XpringClientDecorator {
     const transactionStatusRequest = this.networkClient.GetTransactionStatusRequest()
     transactionStatusRequest.setTransactionHash(transactionHash)
 
-    return this.networkClient.getTransactionStatus(transactionStatusRequest)
+    const transactionStatus = await this.networkClient.getTransactionStatus(
+      transactionStatusRequest,
+    )
+
+    return RawTransactionStatus.fromTransactionStatus(transactionStatus)
   }
 
   private async getAccountInfo(address: string): Promise<AccountInfo> {

--- a/src/raw-transaction-status.ts
+++ b/src/raw-transaction-status.ts
@@ -1,6 +1,43 @@
+import { TransactionStatus } from './generated/web/legacy/transaction_status_pb'
+import { GetTxResponse } from './generated/web/rpc/v1/tx_pb'
+
 /** Abstraction around raw Transaction Status for compatibility. */
-export default interface RawTransactionStatus {
-  getValidated(): boolean
-  getTransactionStatusCode(): string
-  getLastLedgerSequence(): number
+export default class RawTransactionStatus {
+  /**
+   * Create a RawTransactionStatus from a TransactionStatus legacy protocol buffer.
+   */
+  public static fromTransactionStatus(
+    transactionStatus: TransactionStatus,
+  ): RawTransactionStatus {
+    return new RawTransactionStatus(
+      transactionStatus.getValidated(),
+      transactionStatus.getTransactionStatusCode(),
+      transactionStatus.getLastLedgerSequence(),
+    )
+  }
+
+  /**
+   * Create a RawTransactionStatus from a GetTxResponse protocol buffer.
+   */
+  public static fromGetTxResponse(
+    getTxResponse: GetTxResponse,
+  ): RawTransactionStatus {
+    return new RawTransactionStatus(
+      getTxResponse.getValidated(),
+      getTxResponse
+        .getMeta()
+        ?.getTransactionResult()
+        ?.getResult(),
+      getTxResponse.getTransaction()?.getLastLedgerSequence(),
+    )
+  }
+
+  /**
+   * Note: This constructor is exposed for testing purposes. Clients of this code should favor using a static factory method.
+   */
+  public constructor(
+    public isValidated,
+    public transactionStatusCode,
+    public lastLedgerSequence,
+  ) {}
 }

--- a/src/reliable-submission-xpring-client.ts
+++ b/src/reliable-submission-xpring-client.ts
@@ -43,7 +43,7 @@ class ReliableSubmissionXpringClient implements XpringClientDecorator {
     let rawTransactionStatus = await this.getRawTransactionStatus(
       transactionHash,
     )
-    const lastLedgerSequence = rawTransactionStatus.getLastLedgerSequence()
+    const { lastLedgerSequence } = rawTransactionStatus
     if (lastLedgerSequence === 0) {
       return Promise.reject(
         new Error(
@@ -65,7 +65,7 @@ class ReliableSubmissionXpringClient implements XpringClientDecorator {
     /* eslint-disable no-await-in-loop */
     while (
       latestLedgerSequence <= lastLedgerSequence &&
-      !rawTransactionStatus.getValidated()
+      !rawTransactionStatus.isValidated
     ) {
       await sleep(ledgerCloseTimeMs)
 

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -17,6 +17,7 @@ import {
   Transaction,
   Payment,
 } from '../src/generated/web/rpc/v1/transaction_pb'
+import { RippledFlags } from '../src'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -254,6 +255,7 @@ describe('Default Xpring Client', function(): void {
     meta.setTransactionResult(transactionResult)
 
     const transaction = new Transaction()
+    transaction.clearPayment()
 
     const getTxResponse = new GetTxResponse()
     getTxResponse.setMeta(meta)
@@ -269,7 +271,7 @@ describe('Default Xpring Client', function(): void {
     const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses)
     const xpringClient = new DefaultXpringClient(fakeNetworkClient)
 
-    // WHEN the transaction status is retrieved THEN an error is thrown.
+    // WHEN the transaction status is retrieved
     const transactionStatus = await xpringClient.getTransactionStatus(
       transactionHash,
     )
@@ -288,7 +290,11 @@ describe('Default Xpring Client', function(): void {
     const meta = new Meta()
     meta.setTransactionResult(transactionResult)
 
+    const payment = new Payment()
+
     const transaction = new Transaction()
+    transaction.setFlags(RippledFlags.TF_PARTIAL_PAYMENT)
+    transaction.setPayment(payment)
 
     const getTxResponse = new GetTxResponse()
     getTxResponse.setMeta(meta)

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -13,7 +13,10 @@ import 'mocha'
 import { GetTxResponse } from '../src/generated/node/rpc/v1/tx_pb'
 import { Meta, TransactionResult } from '../src/generated/node/rpc/v1/meta_pb'
 import TransactionStatus from '../src/transaction-status'
-import { Transaction } from '../src/generated/web/rpc/v1/transaction_pb'
+import {
+  Transaction,
+  Payment,
+} from '../src/generated/web/rpc/v1/transaction_pb'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -49,7 +52,10 @@ function makeGetTxResponse(
   const meta = new Meta()
   meta.setTransactionResult(transactionResult)
 
+  const payment = new Payment()
+
   const transaction = new Transaction()
+  transaction.setPayment(payment)
 
   const getTxResponse = new GetTxResponse()
   getTxResponse.setMeta(meta)
@@ -235,6 +241,76 @@ describe('Default Xpring Client', function(): void {
 
     // THEN the status is succeeded.
     assert.deepEqual(transactionStatus, TransactionStatus.Succeeded)
+  })
+
+  it('Get Transaction Status - Unsupported transaction type', async function(): Promise<
+    void
+  > {
+    // GIVEN a XpringClient which will return a non-payment type transaction.
+    const transactionResult = new TransactionResult()
+    transactionResult.setResult(transactionStatusCodeSuccess)
+
+    const meta = new Meta()
+    meta.setTransactionResult(transactionResult)
+
+    const transaction = new Transaction()
+
+    const getTxResponse = new GetTxResponse()
+    getTxResponse.setMeta(meta)
+    getTxResponse.setValidated(true)
+    getTxResponse.setTransaction(transaction)
+
+    const transactionStatusResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
+      getTxResponse,
+    )
+    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses)
+    const xpringClient = new DefaultXpringClient(fakeNetworkClient)
+
+    // WHEN the transaction status is retrieved THEN an error is thrown.
+    const transactionStatus = await xpringClient.getTransactionStatus(
+      transactionHash,
+    )
+
+    // THEN the status is unknown.
+    assert.deepEqual(transactionStatus, TransactionStatus.Unknown)
+  })
+
+  it('Get Transaction Status - Partial payment', async function(): Promise<
+    void
+  > {
+    // GIVEN a XpringClient which will return a payment type transaction with the partial payment flag set.
+    const transactionResult = new TransactionResult()
+    transactionResult.setResult(transactionStatusCodeSuccess)
+
+    const meta = new Meta()
+    meta.setTransactionResult(transactionResult)
+
+    const transaction = new Transaction()
+
+    const getTxResponse = new GetTxResponse()
+    getTxResponse.setMeta(meta)
+    getTxResponse.setValidated(true)
+    getTxResponse.setTransaction(transaction)
+
+    const transactionStatusResponses = new FakeNetworkClientResponses(
+      FakeNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeNetworkClientResponses.defaultFeeResponse(),
+      FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
+      getTxResponse,
+    )
+    const fakeNetworkClient = new FakeNetworkClient(transactionStatusResponses)
+    const xpringClient = new DefaultXpringClient(fakeNetworkClient)
+
+    // WHEN the transaction status is retrieved THEN an error is thrown.
+    const transactionStatus = await xpringClient.getTransactionStatus(
+      transactionHash,
+    )
+
+    // THEN the status is unknown.
+    assert.deepEqual(transactionStatus, TransactionStatus.Unknown)
   })
 
   it('Get Transaction Status - Node Error', function(done): void {

--- a/test/default-xpring-client-test.ts
+++ b/test/default-xpring-client-test.ts
@@ -13,6 +13,7 @@ import 'mocha'
 import { GetTxResponse } from '../src/generated/node/rpc/v1/tx_pb'
 import { Meta, TransactionResult } from '../src/generated/node/rpc/v1/meta_pb'
 import TransactionStatus from '../src/transaction-status'
+import { Transaction } from '../src/generated/web/rpc/v1/transaction_pb'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -48,9 +49,12 @@ function makeGetTxResponse(
   const meta = new Meta()
   meta.setTransactionResult(transactionResult)
 
+  const transaction = new Transaction()
+
   const getTxResponse = new GetTxResponse()
   getTxResponse.setMeta(meta)
   getTxResponse.setValidated(validated)
+  getTxResponse.setTransaction(transaction)
 
   return getTxResponse
 }

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -1,4 +1,5 @@
 /* eslint-disable class-methods-use-this */
+import { Transaction } from '../../src/generated/web/rpc/v1/transaction_pb'
 import { NetworkClient } from '../../src/network-client'
 import {
   GetAccountInfoRequest,
@@ -130,9 +131,12 @@ export class FakeNetworkClientResponses {
     const meta = new Meta()
     meta.setTransactionResult(transactionResult)
 
+    const transaction = new Transaction()
+
     const response = new GetTxResponse()
     response.setValidated(true)
     response.setMeta(meta)
+    response.setTransaction(transaction)
 
     return response
   }

--- a/test/raw-transaction-test.ts
+++ b/test/raw-transaction-test.ts
@@ -1,0 +1,81 @@
+import { assert } from 'chai'
+import RippledFlags from '../src/rippled-flags'
+import { GetTxResponse } from '../src/generated/web/rpc/v1/tx_pb'
+import {
+  Transaction,
+  Payment,
+} from '../src/generated/web/rpc/v1/transaction_pb'
+import { TransactionStatus as LegacyTransactionStatus } from '../src/generated/web/legacy/transaction_status_pb'
+import 'mocha'
+import RawTransactionStatus from '../src/raw-transaction-status'
+
+describe('raw transaction status', function(): void {
+  it('isBucketable - legacy proto', function(): void {
+    // GIVEN a legacy transaction status protocol buffer.
+    const transactionStatus = new LegacyTransactionStatus()
+
+    // WHEN the transaction status is wrapped into a RawTransactionStatus object.
+    const rawTransactionStatus = RawTransactionStatus.fromTransactionStatus(
+      transactionStatus,
+    )
+
+    // THEN the raw transaction status reports it is bucketable.
+    assert.isTrue(rawTransactionStatus.isBucketable)
+  })
+
+  it('isBucketable - non payment', function(): void {
+    // GIVEN a getTxResponse which is not a payment.
+    const transaction = new Transaction()
+    transaction.clearPayment()
+
+    const getTxResponse = new GetTxResponse()
+    getTxResponse.setTransaction(transaction)
+
+    // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
+    const rawTransactionStatus = RawTransactionStatus.fromGetTxResponse(
+      getTxResponse,
+    )
+
+    // THEN the raw transaction status reports it is not bucketable.
+    assert.isFalse(rawTransactionStatus.isBucketable)
+  })
+
+  it('isBucketable - partial payment', function(): void {
+    // GIVEN a getTxResponse which is a payment with the partial payment flags set.
+    const payment = new Payment()
+
+    const transaction = new Transaction()
+    transaction.setPayment(payment)
+    transaction.setFlags(RippledFlags.TF_PARTIAL_PAYMENT)
+
+    const getTxResponse = new GetTxResponse()
+    getTxResponse.setTransaction(transaction)
+
+    // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
+    const rawTransactionStatus = RawTransactionStatus.fromGetTxResponse(
+      getTxResponse,
+    )
+
+    // THEN the raw transaction status reports it is not bucketable.
+    assert.isFalse(rawTransactionStatus.isBucketable)
+  })
+
+  it('isBucketable - payment', function(): void {
+    // GIVEN a getTxResponse which is a payment.
+    const payment = new Payment()
+
+    const transaction = new Transaction()
+    transaction.setPayment(payment)
+
+    const getTxResponse = new GetTxResponse()
+    getTxResponse.setTransaction(transaction)
+
+    // WHEN the raw transaction status is wrapped into a RawTransactionStatus object.
+    const rawTransactionStatus = RawTransactionStatus.fromGetTxResponse(
+      getTxResponse,
+    )
+
+    // THEN the raw transaction status reports it is bucketable.
+    assert.isTrue(rawTransactionStatus.isBucketable)
+  })
+})

--- a/test/reliable-submission-xpring-client-test.ts
+++ b/test/reliable-submission-xpring-client-test.ts
@@ -21,10 +21,12 @@ const fakedRawTransactionStatusLastLedgerSequenceValue = 20
 const fakedRawTransactionStatusValidatedValue = true
 const fakedRawTransactionStatusTransactionStatusCode = transactionStatusCodeSuccess
 const fakedAccountExistsValue = true
+const fakedBucketableValue = true
 const fakedRawTransactionStatusValue = new RawTransactionStatus(
   fakedRawTransactionStatusValidatedValue,
   fakedRawTransactionStatusTransactionStatusCode,
   fakedRawTransactionStatusLastLedgerSequenceValue,
+  fakedBucketableValue,
 )
 
 describe('Reliable Submission Xpring Client', function(): void {
@@ -133,6 +135,7 @@ describe('Reliable Submission Xpring Client', function(): void {
       fakedRawTransactionStatusValidatedValue,
       fakedRawTransactionStatusTransactionStatusCode,
       0,
+      fakedBucketableValue,
     )
     this.fakeXpringClient.getRawTransactionStatusValue = malformedRawTransactionStatus
     const { wallet } = Wallet.generateRandomWallet()!


### PR DESCRIPTION
## High Level Overview of Change

Xpring SDK can only bucket non-partial payment transactions into a TransactionStatus category. The current logic assumes all inputs follow this case. This PR will return an Unknown value if that isn't the case.

### Context of Change

The new rippled protocol buffers give us additional information which lets us make this determination. The legacy protocol buffers will continue the same behavior they always have, since they're more or less in maintenance mode. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

API behavior of `getTransactionStatus` changes. However, it only changes for clients who have opted into the new protocol buffers, which is (at least for now) undocumented / unannounced.

## Test Plan

New unit tests added. 