### PR TITLE
[PayID] Add Skeleton of PayID Client

### DIFF
--- a/src/pay-id-client.ts
+++ b/src/pay-id-client.ts
@@ -16,7 +16,7 @@ export class PayIDClientErrorMessages {
  * A client for Xpring's PayID service.
  *
  * Inputs to this class are always in X-Addresses.
- * @see TODO(keefertaylor): Link proper website here.
+ * @see https://xrpaddress.info/
  *
  * @warning This class is experimental and should not be used in production applications.
  * TODO(keefertaylor): Export this class in index.ts when it's ready for external consumption.
@@ -25,11 +25,11 @@ export default class PayIDClient {
   /**
    * Initialize a new PayID client.
    *
-   * @param remoteURL The remote URL of the service this class will communicate with.
-   * @param authorizationToken An optional token to authorize write requests.
+   * TODO(keefertaylor): Add a remoteURL configuration property when it is used, otherwise the linter is upset about an unused property.
+   *
+   * @param authorizationToken An optional token to authorize write requests. Defaults to undefined.
    */
   public constructor(
-    private readonly _remoteURL: string,
     private readonly authorizationToken: string | undefined = undefined,
   ) {}
 
@@ -37,7 +37,7 @@ export default class PayIDClient {
    * Returns whether this client is able to perform updates on a user's ID to address mapping
    */
   public isAuthorizedForUpdates(): boolean {
-    return this.authorizationToken === undefined
+    return this.authorizationToken !== undefined
   }
 
   /**
@@ -66,7 +66,7 @@ export default class PayIDClient {
     _payID: string,
     _xrpAddress: string,
   ): Promise<boolean> {
-    // TODO(keefertaylor): Implement reads from backend service.
+    // TODO(keefertaylor): Implement writes from backend service.
     return false
   }
 }

--- a/src/pay-id-client.ts
+++ b/src/pay-id-client.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/require-await */
+// TODO(keefertaylor): Enable lint rules when method is implemented.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable max-classes-per-file */
+
+/**
+ * Error messages from PayIDClient.
+ */
+export class PayIDClientErrorMessages {
+  public static readonly unimplemented = 'Unimplemented.'
+}
+
+/**
+ * A client for Xpring's PayID service.
+ *
+ * Inputs to this class are always in X-Addresses.
+ * @see TODO(keefertaylor): Link proper website here.
+ *
+ * @warning This class is experimental and should not be used in production applications.
+ * TODO(keefertaylor): Export this class in index.ts when it's ready for external consumption.
+ */
+export default class PayIDClient {
+  /**
+   * Initialize a new PayID client.
+   *
+   * @param remoteURL The remote URL of the service this class will communicate with.
+   * @param authorizationToken An optional token to authorize write requests.
+   */
+  public constructor(
+    private readonly _remoteURL: string,
+    private readonly authorizationToken: string | undefined = undefined,
+  ) {}
+
+  /**
+   * Returns whether this client is able to perform updates on a user's ID to address mapping
+   */
+  public isAuthorizedForUpdates(): boolean {
+    return this.authorizationToken === undefined
+  }
+
+  /**
+   * Retrieve the XRP Address authorized with a PayID.
+   *
+   * @note The returned value will always be in an X-Address format.
+   *
+   * @param payID The payID to resolve for an address.
+   * @returns An XRP address representing the given PayID if one exists, otherwise undefined.
+   */
+  public async xrpAddressForPayID(_payID: string): Promise<string | undefined> {
+    // TODO(keefertaylor): Implement reads from backend service.
+    return undefined
+  }
+
+  /**
+   * Update a PayID to XRP address mapping.
+   *
+   * @note The input address to this method must be in X-Address format.
+   *
+   * @param payID The payID to update.
+   * @param xrpAddress The new XRP address to associate with the payID.
+   * @returns A boolean indicating success of the operation.
+   */
+  public async updateXRPAddressMapping(
+    _payID: string,
+    _xrpAddress: string,
+  ): Promise<boolean> {
+    // TODO(keefertaylor): Implement reads from backend service.
+    return false
+  }
+}

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -26,7 +26,7 @@ const legacyGRPCURLWeb = 'https://grpchttp.xpring.io'
 const legacyXpringClientWeb = new XpringClient(legacyGRPCURLWeb, false, true)
 
 // A XpringClient that makes requests. Uses rippled's gRPC implementation.
-const rippledURL = '3.14.64.116:50051'
+const rippledURL = 'alpha.test.xrp.xpring.io:50051' //  '3.14.64.116:50051'
 const xpringClient = new XpringClient(rippledURL, true)
 
 // Some amount of XRP to send.

--- a/test/pay-id-client-test.ts
+++ b/test/pay-id-client-test.ts
@@ -1,0 +1,35 @@
+import { assert } from 'chai'
+import PayIDCLient from '../src/pay-id-client'
+
+// A fake remote url for a PayID service.
+const payIDURL = 'http://payid.xpring.io'
+
+// A fake authorization token for the PayID service.
+const payIDAuthorizationToken = 'abc123'
+
+describe('PayID Client', function(): void {
+  it('isAuthorized - authorized client', function() {
+    // GIVEN an authorized payID client.
+    const payIDClient = new PayIDCLient(payIDURL, payIDAuthorizationToken)
+
+    // WHEN the client is asked if it is authorized to update pointers.
+    const isAuthorized = payIDClient.isAuthorizedForUpdates()
+
+    // THEN the client reports that it is.
+    assert.isTrue(isAuthorized)
+  })
+
+  // TODO(keefertaylor): Build out actual unit tests here.
+  it('isAuthorized - unauthorized client', function() {
+    // GIVEN an unauthorized payID client.
+    const payIDClient = new PayIDCLient(payIDURL, undefined)
+
+    // WHEN the client is asked if it is authorized to update pointers.
+    const isAuthorized = payIDClient.isAuthorizedForUpdates()
+
+    // THEN the client reports that it is.
+    assert.isFalse(isAuthorized)
+  })
+
+  // TODO(keefertaylor): Add additional tests for PayID client when functionality is
+})

--- a/test/pay-id-client-test.ts
+++ b/test/pay-id-client-test.ts
@@ -1,35 +1,31 @@
 import { assert } from 'chai'
 import PayIDCLient from '../src/pay-id-client'
 
-// A fake remote url for a PayID service.
-const payIDURL = 'http://payid.xpring.io'
-
 // A fake authorization token for the PayID service.
 const payIDAuthorizationToken = 'abc123'
 
 describe('PayID Client', function(): void {
   it('isAuthorized - authorized client', function() {
     // GIVEN an authorized payID client.
-    const payIDClient = new PayIDCLient(payIDURL, payIDAuthorizationToken)
+    const payIDClient = new PayIDCLient(payIDAuthorizationToken)
 
     // WHEN the client is asked if it is authorized to update pointers.
     const isAuthorized = payIDClient.isAuthorizedForUpdates()
 
-    // THEN the client reports that it is.
+    // THEN the client reports that it is authorized.
     assert.isTrue(isAuthorized)
   })
 
-  // TODO(keefertaylor): Build out actual unit tests here.
   it('isAuthorized - unauthorized client', function() {
     // GIVEN an unauthorized payID client.
-    const payIDClient = new PayIDCLient(payIDURL, undefined)
+    const payIDClient = new PayIDCLient(undefined)
 
     // WHEN the client is asked if it is authorized to update pointers.
     const isAuthorized = payIDClient.isAuthorizedForUpdates()
 
-    // THEN the client reports that it is.
+    // THEN the client reports that it is not authorized.
     assert.isFalse(isAuthorized)
   })
 
-  // TODO(keefertaylor): Add additional tests for PayID client when functionality is
+  // TODO(keefertaylor): Add additional tests for PayID client when functionality is implemented.
 })


### PR DESCRIPTION
## High Level Overview of Change

Add skeleton of PayID client. 

JS: https://github.com/xpring-eng/Xpring-JS/pull/208
Swift: https://github.com/xpring-eng/XpringKit/pull/122
Java: Watch this space

### Context of Change

This change defines a client with a public API that will work with the initial payID service. All methods are unimplemented and throw `unimplemented` errors. 

Note I'm specifically not mentioning this in the CHANGELOG because it's really not ready to be used in any meaningful way and I don't want to call attention to it, yet. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

A new class is introduced. 

## Test Plan

Basic unit tests skeleton included. 
