### PR TITLE
(1/2) Expose `getAccountTransactionHistory` RPC in Network Client

### DIFF
--- a/src/grpc-network-client.ts
+++ b/src/grpc-network-client.ts
@@ -8,18 +8,21 @@ import {
   GetFeeResponse,
 } from './generated/node/org/xrpl/rpc/v1/get_fee_pb'
 import {
-  GetTransactionRequest,
-  GetTransactionResponse,
-} from './generated/node/org/xrpl/rpc/v1/get_transaction_pb'
-import {
   SubmitTransactionRequest,
   SubmitTransactionResponse,
 } from './generated/node/org/xrpl/rpc/v1/submit_pb'
 import { XRPLedgerAPIServiceClient } from './generated/node/org/xrpl/rpc/v1/xrp_ledger_grpc_pb'
-
 import { NetworkClient } from './network-client'
 import { AccountAddress } from './generated/node/org/xrpl/rpc/v1/account_pb'
 import isNode from './utils'
+import {
+  GetAccountTransactionHistoryRequest,
+  GetAccountTransactionHistoryResponse,
+} from './generated/node/org/xrpl/rpc/v1/get_account_transaction_history_pb'
+import {
+  GetTransactionRequest,
+  GetTransactionResponse,
+} from './generated/node/org/xrpl/rpc/v1/get_transaction_pb'
 
 /**
  * A GRPC Based network client.
@@ -92,6 +95,23 @@ class GRPCNetworkClient implements NetworkClient {
     })
   }
 
+  public async getTransactionHistory(
+    request: GetAccountTransactionHistoryRequest,
+  ): Promise<GetAccountTransactionHistoryResponse> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.getAccountTransactionHistory(
+        request,
+        (error, response): void => {
+          if (error != null || response == null) {
+            reject(error)
+            return
+          }
+          resolve(response)
+        },
+      )
+    })
+  }
+
   /* eslint-disable class-methods-use-this */
   public AccountAddress(): AccountAddress {
     return new AccountAddress()
@@ -111,6 +131,10 @@ class GRPCNetworkClient implements NetworkClient {
 
   public SubmitTransactionRequest(): SubmitTransactionRequest {
     return new SubmitTransactionRequest()
+  }
+
+  public GetAccountTransactionHistoryRequest(): GetAccountTransactionHistoryRequest {
+    return new GetAccountTransactionHistoryRequest()
   }
   /* eslint-enable class-methods-use-this */
 }

--- a/src/grpc-network-client.web.ts
+++ b/src/grpc-network-client.web.ts
@@ -19,6 +19,10 @@ import { XRPLedgerAPIServiceClient } from './generated/web/org/xrpl/rpc/v1/xrp_l
 import { NetworkClient } from './network-client'
 import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/account_pb'
 import isNode from './utils'
+import {
+  GetAccountTransactionHistoryRequest,
+  GetAccountTransactionHistoryResponse,
+} from './generated/web/org/xrpl/rpc/v1/get_account_transaction_history_pb'
 
 /**
  * A GRPC Based network client.
@@ -98,6 +102,24 @@ class GRPCNetworkClient implements NetworkClient {
     })
   }
 
+  public async getTransactionHistory(
+    request: GetAccountTransactionHistoryRequest,
+  ): Promise<GetAccountTransactionHistoryResponse> {
+    return new Promise((resolve, reject): void => {
+      this.grpcClient.getAccountTransactionHistory(
+        request,
+        {},
+        (error, response): void => {
+          if (error != null || response == null) {
+            reject(error)
+            return
+          }
+          resolve(response)
+        },
+      )
+    })
+  }
+
   /* eslint-disable class-methods-use-this */
   public AccountAddress(): AccountAddress {
     return new AccountAddress()
@@ -117,6 +139,10 @@ class GRPCNetworkClient implements NetworkClient {
 
   public SubmitTransactionRequest(): SubmitTransactionRequest {
     return new SubmitTransactionRequest()
+  }
+
+  public GetAccountTransactionHistoryRequest(): GetAccountTransactionHistoryRequest {
+    return new GetAccountTransactionHistoryRequest()
   }
   /* eslint-enable class-methods-use-this */
 }

--- a/src/network-client.ts
+++ b/src/network-client.ts
@@ -15,6 +15,10 @@ import {
   SubmitTransactionResponse,
 } from './generated/web/org/xrpl/rpc/v1/submit_pb'
 import { AccountAddress } from './generated/web/org/xrpl/rpc/v1/account_pb'
+import {
+  GetAccountTransactionHistoryRequest,
+  GetAccountTransactionHistoryResponse,
+} from './generated/web/org/xrpl/rpc/v1/get_account_transaction_history_pb'
 
 /**
  * The network client interface provides a wrapper around network calls to the Xpring Platform.
@@ -30,9 +34,14 @@ export interface NetworkClient {
   submitTransaction(
     request: SubmitTransactionRequest,
   ): Promise<SubmitTransactionResponse>
+  getTransactionHistory(
+    request: GetAccountTransactionHistoryRequest,
+  ): Promise<GetAccountTransactionHistoryResponse>
+
   AccountAddress(): AccountAddress
   GetAccountInfoRequest(): GetAccountInfoRequest
   GetTransactionRequest(): GetTransactionRequest
   GetFeeRequest(): GetFeeRequest
   SubmitTransactionRequest(): SubmitTransactionRequest
+  GetAccountTransactionHistoryRequest(): GetAccountTransactionHistoryRequest
 }

--- a/test/fakes/fake-network-client.ts
+++ b/test/fakes/fake-network-client.ts
@@ -29,6 +29,10 @@ import {
   TransactionResult,
 } from '../../src/generated/web/org/xrpl/rpc/v1/meta_pb'
 import { Balance } from '../../src/generated/node/org/xrpl/rpc/v1/common_pb'
+import {
+  GetAccountTransactionHistoryRequest,
+  GetAccountTransactionHistoryResponse,
+} from '../../src/generated/web/org/xrpl/rpc/v1/get_account_transaction_history_pb'
 
 /**
  * A response for a request to retrieve type T. Either an instance of T, or an error.
@@ -57,6 +61,7 @@ export class FakeNetworkClientResponses {
     FakeNetworkClientResponses.defaultError,
     FakeNetworkClientResponses.defaultError,
     FakeNetworkClientResponses.defaultError,
+    FakeNetworkClientResponses.defaultError,
   )
 
   /**
@@ -65,7 +70,8 @@ export class FakeNetworkClientResponses {
    * @param getAccountInfoResponse The response or error that will be returned from the getAccountInfo request. Default is the default account info response.
    * @param getFeeResponse The response or error that will be returned from the getFee request. Defaults to the default fee response.
    * @param submitTransactionResponse The response or error that will be returned from the submitTransaction request. Defaults to the default submit transaction response.
-   * @param getTxResponse The response or error that will be returned from the getTransactionStatus request. Defaults to the default transaction status response.
+   * @param getTransactionStatusResponse The response or error that will be returned from the getTransactionStatus request. Defaults to the default transaction status response.
+   * @param getTransactionHistoryResponse The response or error that will be returned from teh getTransactionHistory request. Default to the default transaction history response.
    */
   public constructor(
     public readonly getAccountInfoResponse: Response<
@@ -79,7 +85,10 @@ export class FakeNetworkClientResponses {
     > = FakeNetworkClientResponses.defaultSubmitTransactionResponse(),
     public readonly getTransactionStatusResponse: Response<
       GetTransactionResponse
-    > = FakeNetworkClientResponses.defaultGetTxResponse(),
+    > = FakeNetworkClientResponses.defaultGetTransactionResponse(),
+    public readonly getTransactionHistoryResponse: Response<
+      GetAccountTransactionHistoryResponse
+    > = FakeNetworkClientResponses.defaultGetTransactionHistoryResponse(),
   ) {}
 
   /**
@@ -132,9 +141,9 @@ export class FakeNetworkClientResponses {
   }
 
   /**
-   * Construct a default getTx response.
+   * Construct a default getTransactionResponse.
    */
-  public static defaultGetTxResponse(): GetTransactionResponse {
+  public static defaultGetTransactionResponse(): GetTransactionResponse {
     const transactionResult = new TransactionResult()
     transactionResult.setResult('tesSUCCESS')
 
@@ -148,6 +157,14 @@ export class FakeNetworkClientResponses {
     response.setMeta(meta)
     response.setTransaction(transaction)
 
+    return response
+  }
+
+  /**
+   * Construct a default getTransactionHistoryResponse.
+   */
+  public static defaultGetTransactionHistoryResponse(): GetAccountTransactionHistoryResponse {
+    const response = new GetAccountTransactionHistoryResponse()
     return response
   }
 }
@@ -203,6 +220,18 @@ export class FakeNetworkClient implements NetworkClient {
     return Promise.resolve(transactionStatusResponse)
   }
 
+  getTransactionHistory(
+    _GetAccountTransactionHistoryRequestetAccountTransactionHistoryRequest: GetAccountTransactionHistoryRequest,
+  ): Promise<GetAccountTransactionHistoryResponse> {
+    const transactionHistoryResponse = this.responses
+      .getTransactionHistoryResponse
+    if (transactionHistoryResponse instanceof Error) {
+      return Promise.reject(transactionHistoryResponse)
+    }
+
+    return Promise.resolve(transactionHistoryResponse)
+  }
+
   public AccountAddress(): AccountAddress {
     return new AccountAddress()
   }
@@ -221,5 +250,9 @@ export class FakeNetworkClient implements NetworkClient {
 
   public SubmitTransactionRequest(): SubmitTransactionRequest {
     return new SubmitTransactionRequest()
+  }
+
+  public GetAccountTransactionHistoryRequest(): GetAccountTransactionHistoryRequest {
+    return new GetAccountTransactionHistoryRequest()
   }
 }


### PR DESCRIPTION
## High Level Overview of Change

rippled recently implemented a new RPC to get transaction history. Expose this RPC via network client. 

Analogs:
JS: https://github.com/xpring-eng/Xpring-JS/pull/211
Swift: https://github.com/xpring-eng/XpringKit/pull/123
Java: N/A (we do this differently in Java)

### Context of Change

This is a required change for to implement transaction history in the SDK. This functionality isn't yet exposed anywhere. 


Note that we're deferring putting transaction history into legacy and thus changes to those files are ignored. 


### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

Clients of gRPC (internal classes) can make account history RPCs

## Test Plan

CI