### PR TITLE
Add bearerToken to ILP Web Network Client

### DIFF
--- a/src/grpc-ilp-network-client.web.ts
+++ b/src/grpc-ilp-network-client.web.ts
@@ -1,3 +1,4 @@
+import { Metadata } from 'grpc-web'
 import { IlpNetworkClient } from './ilp-network-client'
 import { GetBalanceRequest } from './generated/web/ilp/get_balance_request_pb'
 import { GetBalanceResponse } from './generated/web/ilp/get_balance_response_pb'
@@ -28,10 +29,14 @@ class GrpcIlpNetworkClientWeb implements IlpNetworkClient {
     this.paymentClient = new IlpOverHttpServiceClient(grpcURL, null, null)
   }
 
-  getBalance(request: GetBalanceRequest): Promise<GetBalanceResponse> {
+  getBalance(
+    request: GetBalanceRequest,
+    bearerToken?: string,
+  ): Promise<GetBalanceResponse> {
     return new Promise((resolve, reject): void => {
-      // FIXME should metadata be undefined?
-      this.balanceClient.getBalance(request, undefined, (error, response) => {
+      const metaData: Metadata = { Authorization: bearerToken || '' }
+
+      this.balanceClient.getBalance(request, metaData, (error, response) => {
         if (error != null || response === null) {
           reject(error)
           return
@@ -41,10 +46,14 @@ class GrpcIlpNetworkClientWeb implements IlpNetworkClient {
     })
   }
 
-  send(request: SendPaymentRequest): Promise<SendPaymentResponse> {
+  send(
+    request: SendPaymentRequest,
+    bearerToken?: string,
+  ): Promise<SendPaymentResponse> {
     return new Promise((resolve, reject): void => {
-      // FIXME should metadata be undefined?
-      this.paymentClient.sendMoney(request, undefined, (error, response) => {
+      const metaData: Metadata = { Authorization: bearerToken || '' }
+
+      this.paymentClient.sendMoney(request, metaData, (error, response) => {
         if (error != null || response === null) {
           reject(error)
           return

--- a/src/ilp-network-client.ts
+++ b/src/ilp-network-client.ts
@@ -8,7 +8,8 @@ export interface IlpNetworkClient {
    * Retrieve the balance for the given address.
    *
    * @param request the details required for fetching the balance
-   * @param bearerToken
+   * @param bearerToken Optional auth token. If using node network client, bearerToken must be supplied, otherwise
+   *        it will be picked up from a cookie.
    * @returns A {@link GetBalanceResponse} with balance information of the specified account
    */
   getBalance(
@@ -21,6 +22,8 @@ export interface IlpNetworkClient {
    *
    * @param request the details of which account to send from, which payment pointer to receive to, and the amount to
    * send
+   * @param bearerToken Optional auth token. If using node network client, bearerToken must be supplied, otherwise
+   *        it will be picked up from a cookie.
    * @returns A promise which resolves to a `SendPaymentResponse` of the original amount, the amount sent
    *        in the senders denomination, and the amount that was delivered to the recipient in their denomination, as
    *        well as if the payment was successful


### PR DESCRIPTION
## High Level Overview of Change

Added the ability to include a `bearerToken` in `GrpcIlpNetworkClientWeb` so that gRPC requests from browsers can send an `authorization` header to authenticate to Hermes.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

Our first phase of development of the ILP wallet in xpring.io requires client-side JS to send an auth token as a header in gRPC requests to Hermes (see https://docs.google.com/document/d/1uXSeEvDBEuJj-helmCMVOD16VctvJ008N9g9eEZQhAI/edit). This should allow us to do that.

In my original PR (https://github.com/xpring-eng/Xpring-JS/pull/213), only the node network client had the capability to include an auth header.  My assumption was that requests coming from the browser would propagate an auth cookie and that there would be no need to pass a token through the SDK.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->
`GrpcIlpNetworkClientWeb.getBalance` and `GrpcIlpNetworkClientWeb.send` originally did not have a bearerToken passed in.  Now they do, and in each method, an auth header is included in the gRPC request like so:
```javascript
const metaData: Metadata = { Authorization: bearerToken || '' }
this.paymentClient.sendMoney(request, metaData, (error, response) => { ...
```
## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->
@theotherian has built this locally and tested it out in our wallet UI
<!--
## Future Tasks
For future tasks related to PR.
-->
