### PR TITLE
Update `.mocharc.js` to glob subfolders

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,6 +8,7 @@ module.exports = {
   extension: [
     'ts'
   ],
+  spec: 'test/**/*-test.ts',
 
   // Do not look for mocha opts file
   opts: false,

--- a/test/PayID/pay-id-admin-client-test.ts
+++ b/test/PayID/pay-id-admin-client-test.ts
@@ -19,7 +19,6 @@ describe('Pay ID Admin Client', function(): void {
     payIDAdminClient
       .addOrUpdateXRPAddressMapping(payID, xrpAddress)
       .catch((error) => {
-        assert.typeOf(error, PayIDError.name)
         assert.equal(
           (error as PayIDError).errorType,
           PayIDErrorType.Unimplemented,
@@ -39,7 +38,6 @@ describe('Pay ID Admin Client', function(): void {
     payIDAdminClient
       .removeXRPAddressMapping(payID, xrpAddress)
       .catch((error) => {
-        assert.typeOf(error, PayIDError.name)
         assert.equal(
           (error as PayIDError).errorType,
           PayIDErrorType.Unimplemented,

--- a/test/PayID/pay-id-client-test.ts
+++ b/test/PayID/pay-id-client-test.ts
@@ -11,7 +11,6 @@ describe('Pay ID Client', function(): void {
 
     // WHEN an XRPAddress is requested THEN an unimplemented error is thrown.
     payIDClient.xrpAddressForPayID(payID).catch((error) => {
-      assert.typeOf(error, PayIDError.name)
       assert.equal(
         (error as PayIDError).errorType,
         PayIDErrorType.Unimplemented,


### PR DESCRIPTION
## High Level Overview of Change

PayID tests are in `test/pay-id-client-test` which isn't automatically picked up by mocha. Update the mocha config to run these tests.

Fix failures in tests which now run.

### Context of Change

The functionality of Xpring SDK is rapidly expanding to XRP, ILP and PayID. I've started sub-foldering source files and tests to disambiguate. PayID is in a new subfolder.

For some reason, the `assert.typeOf` call always returns `Error` rather than a `PayIDError`. I'm not sure why this is. The following asserts about `PayIDErrorCode` being set correctly cover this case though, so I'm deferring for now. Reviewers can let me know if there's a more elegant way to do this. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Tests run properly

## Test Plan

CI
