### PR TITLE
Align sendPayment API

### DIFF
--- a/src/default-ilp-client.ts
+++ b/src/default-ilp-client.ts
@@ -57,24 +57,24 @@ class DefaultIlpClient implements IlpClientDecorator {
    * Send the given amount of XRP from the source wallet to the destination address.
    *
    * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
-   * @param paymentPointer the payment pointer to receive funds
-   * @param sender the ILP account sending the funds
+   * @param destinationPaymentPointer the payment pointer to receive funds
+   * @param senderAccountId the ILP account sending the funds
    * @param bearerToken Optional auth token. If using node network client, bearerToken must be supplied, otherwise
    *        it will be picked up from a cookie.
    * @returns A promise which resolves to a `SendPaymentResponse` of the original amount, the amount sent
    *        in the senders denomination, and the amount that was delivered to the recipient in their denomination, as
    *        well as if the payment was successful
    */
-  public async send(
+  public async sendPayment(
     amount: BigInteger | number | string,
-    paymentPointer: string,
-    sender: string,
+    destinationPaymentPointer: string,
+    senderAccountId: string,
     bearerToken?: string,
   ): Promise<SendPaymentResponse> {
     const request = this.networkClient.SendPaymentRequest()
-    request.setDestinationPaymentPointer(paymentPointer)
+    request.setDestinationPaymentPointer(destinationPaymentPointer)
     request.setAmount(Number(amount))
-    request.setAccountId(sender)
+    request.setAccountId(senderAccountId)
     return this.networkClient.send(request, bearerToken)
   }
 }

--- a/src/ilp-client-decorator.ts
+++ b/src/ilp-client-decorator.ts
@@ -17,18 +17,18 @@ export interface IlpClientDecorator {
    * Send the given amount of XRP from the source wallet to the destination address.
    *
    * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
-   * @param paymentPointer the payment pointer to receive funds
-   * @param sender the ILP account sending the funds
+   * @param destinationPaymentPointer the payment pointer to receive funds
+   * @param senderAccountId the ILP account sending the funds
    * @param bearerToken Optional auth token. If using node network client, bearerToken must be supplied, otherwise
    *        it will be picked up from a cookie.
    * @returns A promise which resolves to a `SendPaymentResponse` of the original amount, the amount sent
    *        in the senders denomination, and the amount that was delivered to the recipient in their denomination, as
    *        well as if the payment was successful
    */
-  send(
+  sendPayment(
     amount: BigInteger | number | string,
-    paymentPointer: string,
-    sender: string,
+    destinationPaymentPointer: string,
+    senderAccountId: string,
     bearerToken?: string,
   ): Promise<SendPaymentResponse>
 }

--- a/src/ilp-client.ts
+++ b/src/ilp-client.ts
@@ -33,24 +33,24 @@ class IlpClient {
    * Send the given amount of XRP from the source wallet to the destination address.
    *
    * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
-   * @param paymentPointer the payment pointer to receive funds
-   * @param sender the ILP account sending the funds
+   * @param destinationPaymentPointer the payment pointer to receive funds
+   * @param senderAccountId the ILP account sending the funds
    * @param bearerToken Optional auth token. If using node network client, bearerToken must be supplied, otherwise
    *        it will be picked up from a cookie.
    * @returns A promise which resolves to a `SendPaymentResponse` of the original amount, the amount sent
    *        in the senders denomination, and the amount that was delivered to the recipient in their denomination, as
    *        well as if the payment was successful
    */
-  public async send(
+  public async sendPayment(
     amount: BigInteger | number | string,
-    paymentPointer: string,
-    sender: string,
+    destinationPaymentPointer: string,
+    senderAccountId: string,
     bearerToken?: string,
   ): Promise<SendPaymentResponse> {
-    return this.decoratedClient.send(
+    return this.decoratedClient.sendPayment(
       amount,
-      paymentPointer,
-      sender,
+      destinationPaymentPointer,
+      senderAccountId,
       bearerToken,
     )
   }

--- a/test/default-ilp-client-test.ts
+++ b/test/default-ilp-client-test.ts
@@ -49,7 +49,7 @@ describe('Default ILP Client', function(): void {
     const client = fakeSuceedingNetworkClient()
 
     // WHEN the balance for an account is requested
-    const amount = await client.send(100, '$money/baz', 'test.foo.bar')
+    const amount = await client.sendPayment(100, '$money/baz', 'test.foo.bar')
 
     // THEN the balance is returned
     assert.equal(Number(amount.getAmountDelivered()), 50)
@@ -60,7 +60,7 @@ describe('Default ILP Client', function(): void {
     const client = fakeErroringNetworkClient()
 
     // WHEN the balance for an account is requested
-    client.send(100, '$money/baz', 'test.foo.bar').catch((error) => {
+    client.sendPayment(100, '$money/baz', 'test.foo.bar').catch((error) => {
       // THEN an error is thrown
       assert.typeOf(error, 'Error')
       assert.equal(

--- a/test/ilp-integration-test.ts
+++ b/test/ilp-integration-test.ts
@@ -38,7 +38,7 @@ describe('ILP Integration Tests', function(): void {
     // AND an account on the connector with accountId = sdk_account2
 
     // WHEN a payment is sent from sdk_account1 to sdk_account2 for 10 units
-    const message = await ILPClientNode.send(
+    const message = await ILPClientNode.sendPayment(
       10,
       '$money.ilpv4.dev/sdk_account2',
       'sdk_account1',


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->
Asana task: https://app.asana.com/0/1143722888069470/1165556580466057

Changed `IlpClient.send` to `IlpClient.sendPayment` and changed parameter names to better match with other version of the SDK.

### Context of Change

Currently, the public `IlpClient` API is slightly different in parameter name and order across Xpring4j, Xpring-JS, and XpringKit.  After this PR is merged, the other two SDKs should expose the same API for `sendPayment`.  This will make the ILP SDK more consistent across languages and provide a clearer API for users.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before / After
Before, the `send` API had the following signature:
```javascript
public async send(
    amount: BigInteger | number | string,
    paymentPointer: string,
    sender: string,
    bearerToken?: string,
  ): Promise<SendPaymentResponse>
```

After:
```javascript
public async sendPayment(
    amount: BigInteger | number | string,
    destinationPaymentPointer: string,
    senderAccountId: string,
    bearerToken?: string,
  ): Promise<SendPaymentResponse>
```
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Because this change is just an API change and not a functional change, the existing test suite covers ILP functionality.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks

- Align XpringKit to this signature. XpringKit will have vanity parameter names, but the actual parameter names will be the same as this.
- Update Xpring-SDK-Demo for javascript