### PR TITLE
[WIP] (4/n) Convert IssuedCurrency protocol buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1085,6 +1085,11 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
       "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
     },
+    "bigint-typescript-definitions": {
+      "version": "5.5.3-0",
+      "resolved": "https://registry.npmjs.org/bigint-typescript-definitions/-/bigint-typescript-definitions-5.5.3-0.tgz",
+      "integrity": "sha1-MACJQJrsBjQBxMf16EBiNYAIxw0="
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "big-integer": "^1.6.48",
+    "bigint-typescript-definitions": "^5.5.3-0",
     "grpc": "^1.24.2",
     "grpc-web": "1.0.7",
     "xhr2": "0.2.0",

--- a/src/xrp-issued-currency.ts
+++ b/src/xrp-issued-currency.ts
@@ -1,0 +1,29 @@
+// import bigInt from 'big-integer'
+import bigInt from 'bigint-typescript-definitions'
+import XRPCurrency from './xrp-currency'
+import { IssuedCurrencyAmount } from './generated/web/org/xrpl/rpc/v1/amount_pb'
+
+/*
+ * An issued currency on the XRP Ledger
+ * - SeeAlso: https://xrpl.org/basic-data-types.html#specifying-currency-amounts
+ */
+export default class XRPIssuedCurrency {
+  public currency: XRPCurrency | undefined
+
+  public value: BigInteger | undefined
+
+  public issuer: string | undefined
+
+  public constructor(issuedCurrency: IssuedCurrencyAmount) {
+    const value = bigInt(issuedCurrency.getValue())
+    if (!value) {
+      return
+    }
+    this.value = value
+    const currency = issuedCurrency.getCurrency()
+    if (currency) {
+      this.currency = new XRPCurrency(currency)
+    }
+    this.issuer = issuedCurrency.getIssuer()?.getAddress()
+  }
+}

--- a/src/xrp-issued-currency.ts
+++ b/src/xrp-issued-currency.ts
@@ -1,5 +1,5 @@
-// import bigInt from 'big-integer'
-import bigInt from 'bigint-typescript-definitions'
+import bigInt from 'big-integer'
+// import bigInt from 'bigint-typescript-definitions'
 import XRPCurrency from './xrp-currency'
 import { IssuedCurrencyAmount } from './generated/web/org/xrpl/rpc/v1/amount_pb'
 

--- a/src/xrp-issued-currency.ts
+++ b/src/xrp-issued-currency.ts
@@ -16,10 +16,11 @@ export default class XRPIssuedCurrency {
 
   public constructor(issuedCurrency: IssuedCurrencyAmount) {
     const value = bigInt(issuedCurrency.getValue())
-    if (!value) {
+    if (value && typeof value === 'string') {
+      this.value = value
+    } else {
       return
     }
-    this.value = value
     const currency = issuedCurrency.getCurrency()
     if (currency) {
       this.currency = new XRPCurrency(currency)

--- a/test/protocol-buffer-conversion-test.ts
+++ b/test/protocol-buffer-conversion-test.ts
@@ -131,7 +131,7 @@ describe('Protocol Buffer Conversion', function(): void {
     const issuedCurrency = new XRPIssuedCurrency(issuedCurrencyProto)
 
     // THEN the issued currency converted as expected.
-    assert.equal(
+    assert.deepEqual(
       issuedCurrency?.currency,
       new XRPCurrency(issuedCurrencyProto.getCurrency()),
     )


### PR DESCRIPTION
## High Level Overview of Change
Provide a native swift wrapper for the [IssuedCurrencyAmount protocol buffer](https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/amount.proto#L28).

Analogue in Swift: https://github.com/xpring-eng/XpringKit/pull/129
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
We want to provide an API which returns transaction history. This API shouldn't return raw protocol buffers as they have some slightly complex abstractions and because that means we're tying a network layer to a public API.

This is the start of building up several types to ultimately serve all transaction types.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->
- [x] New feature (non-breaking change which adds functionality)

## Before / After
No change.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
New CI introduced for unit tests.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
