### PR TITLE
Update Node Addresses to new Xpring nodes

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -134,7 +134,7 @@ wallet.verify(message, signature); // true
 ```javascript
 const { XRPClient } = require("xpring-js");
 
-const remoteURL = test.xrp.xpring.io:50051; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
+const remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xpringClient = new XpringClient(remoteURL, true)
 ```
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -32,16 +32,16 @@ $ npm i xpring-js
 開発者がすぐに開発を開始できるように, Xpringは現在、サーバー側コンポーネントをホスト型サービスとして提供し、クライアント側ライブラリからのリクエストをXRPノードにプロキシします。開発者は次のエンドポイントに到達できます:
 
 ```
-# TestNet
+# TestNet - Node Environment
 test.xrp.xpring.io:50051
 
-# MainNet
+# MainNet - Node Environment
 main.xrp.xpring.io:50051
 
-#TestNet
+#TestNet - Browser Environment
 https://envoy.test.xrp.xpring.io
 
-#MainNet
+#MainNet - Browser Environment
 https://envoy.main.xrp.xpring.io
 ```
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -145,7 +145,7 @@ const xpringClient = new XpringClient(remoteURL, true)
 ```javascript
 const { XRPClient } = require("xpring-js");
 
-const remoteURL = test.xrp.xpring.io:50051; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
+const remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xpringClient = new XpringClient(remoteURL, true);
 
 const address = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
@@ -161,7 +161,7 @@ console.log(balance); // Logs a balance in drops of XRP
 ```javascript
 const { Wallet, XRPAmount, XRPClient } = require("xpring-js");
 
-const remoteURL = test.xrp.xpring.io:50051; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
+const remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xpringClient = new XpringClient(remoteURL, true)
 
 // Amount of XRP to send

--- a/README-ja.md
+++ b/README-ja.md
@@ -30,18 +30,19 @@ $ npm i xpring-js
 サーバー側コンポーネントは、クライアント側のリクエストをXRPノードに送信します。
 
 開発者がすぐに開発を開始できるように, Xpringは現在、サーバー側コンポーネントをホスト型サービスとして提供し、クライアント側ライブラリからのリクエストをXRPノードにプロキシします。開発者は次のエンドポイントに到達できます:
+
 ```
-# TestNet - Node
-alpha.test.xrp.xpring.io:50051
+# TestNet
+test.xrp.xpring.io:50051
 
-# MainNet - Node
-alpha.xrp.xpring.io:50051
+# MainNet
+main.xrp.xpring.io:50051
 
-#TestNet - Browser
+#TestNet
 https://envoy.test.xrp.xpring.io
 
-#MainNet - Browser
-https://envoy.xrp.xpring.io
+#MainNet
+https://envoy.main.xrp.xpring.io
 ```
 
 Xpringは、XRPノードユーザーが[rippled](https://github.com/ripple/rippled)のオープンソースコンポーネントとしてアダプターを展開および使用するためのゼロコンフィグの方法の構築に取り組んでいます。乞うご期待！
@@ -133,7 +134,7 @@ wallet.verify(message, signature); // true
 ```javascript
 const { XRPClient } = require("xpring-js");
 
-const remoteURL = alpha.test.xrp.xpring.io:50051; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+const remoteURL = test.xrp.xpring.io:50051; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xpringClient = new XpringClient(remoteURL, true)
 ```
 
@@ -144,7 +145,7 @@ const xpringClient = new XpringClient(remoteURL, true)
 ```javascript
 const { XRPClient } = require("xpring-js");
 
-const remoteURL = alpha.test.xrp.xpring.io:50051; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+const remoteURL = test.xrp.xpring.io:50051; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xpringClient = new XpringClient(remoteURL, true);
 
 const address = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
@@ -160,7 +161,7 @@ console.log(balance); // Logs a balance in drops of XRP
 ```javascript
 const { Wallet, XRPAmount, XRPClient } = require("xpring-js");
 
-const remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+const remoteURL = test.xrp.xpring.io:50051; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xpringClient = new XpringClient(remoteURL, true)
 
 // Amount of XRP to send

--- a/README.md
+++ b/README.md
@@ -28,16 +28,15 @@ $ npm i xpring-js
 
 Xpring SDK needs to communicate with a rippled node which has gRPC enabled. Consult the [rippled documentation](https://github.com/ripple/rippled#build-from-source) for details on how to build your own node.
 
-To get developers started right away, Xpring currently hosts nodes. These nodes are provided on a best effort basis, and may be subject to downtime.
+To get developers started right away, Xpring currently provides nodes.
 
-if you are using Xpring-JS in a node environment, use the following addresses to boostrap your application:
-
+If you are using Xpring-JS in a node environment, use the following addresses to boostrap your application:
 ```
 # TestNet
-alpha.test.xrp.xpring.io:50051
+test.xrp.xpring.io:50051
 
 # MainNet
-alpha.xrp.xpring.io:50051
+main.xrp.xpring.io:50051
 ```
 
 If you are using Xpring-JS from within a browser, use the following addresses to boostrap your application:
@@ -46,7 +45,7 @@ If you are using Xpring-JS from within a browser, use the following addresses to
 https://envoy.test.xrp.xpring.io
 
 #MainNet
-https://envoy.xrp.xpring.io
+https://envoy.main.xrp.xpring.io
 ```
 
 ## Usage
@@ -137,7 +136,7 @@ wallet.verify(message, signature); // true
 ```javascript
 const { XRPClient } = require("xpring-js");
 
-const remoteURL = alpha.test.xrp.xpring.io:50051; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+const remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xrpClient = new XRPClient(remoteURL, true);
 ```
 
@@ -148,7 +147,7 @@ A `XRPClient` can check the balance of an account on the XRP Ledger.
 ```javascript
 const { XRPClient } = require("xpring-js");
 
-const remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+const remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xrpClient = new XRPClient(remoteURL, true);
 
 const address = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
@@ -176,7 +175,7 @@ These states are determined by the `TransactionStatus` enum.
 ```javascript
 const { XRPClient } = require("xpring-js");
 
-const remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+const remoteURL = "test.xrp.xpring.io:50051"; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xrpClient = new XRPClient(remoteURL, true);
 
 const transactionHash = "9FC7D277C1C8ED9CE133CC17AEA9978E71FC644CE6F5F0C8E26F1C635D97AF4A";
@@ -194,7 +193,7 @@ A `XRPClient` can send XRP to other accounts on the XRP Ledger.
 ```javascript
 const { Wallet, XRPAmount, XRPClient } = require("xpring-js");
 
-const remoteURL = "alpha.test.xrp.xpring.io:50051"; // TestNet URL, use alpha.xrp.xpring.io:50051 for MainNet
+const remoteURL = test.xrp.xpring.io:50051; // TestNet URL, use main.xrp.xpring.io:50051 for MainNet
 const xrpClient = new XRPClient(remoteURL, true);
 
 // Amount of XRP to send

--- a/test/xpring-client-integration-test.ts
+++ b/test/xpring-client-integration-test.ts
@@ -15,18 +15,18 @@ const wallet = Wallet.generateWalletFromSeed('snYP7oArxKepd3GPDcrjMsJYiJeJB')!
 
 // A hash of a successfully validated transaction.
 const transactionHash =
-  '24E31668208A3165E6C702CDA66425808EAD670EABCBFA6C4403FFA93500D486'
+  '6D9B6CDA7F6752548800C4FC14A037B8DAC2EF47E61028793768766EAB7FC81B'
 
 // A XpringClient that makes requests. Uses the legacy protocol buffer implementation.
 const legacyGRPCURLNode = 'grpc.xpring.tech:80'
 const legacyXpringClientNode = new XpringClient(legacyGRPCURLNode)
 
 // A XpringClient that makes requests. Uses the legacy protocol buffer implementation and sends the requests to an HTTP envoy emulating how the browser would behave
-const legacyGRPCURLWeb = 'https://grpchttp.xpring.io'
-const legacyXpringClientWeb = new XpringClient(legacyGRPCURLWeb, false, true)
+const grpcWebURL = 'https://envoy.test.xrp.xpring.io'
+const xpringWebClient = new XpringClient(grpcWebURL, false, true)
 
 // A XpringClient that makes requests. Uses rippled's gRPC implementation.
-const rippledURL = '3.14.64.116:50051'
+const rippledURL = 'test.xrp.xpring.io:50051'
 const xpringClient = new XpringClient(rippledURL, true)
 
 // Some amount of XRP to send.
@@ -40,10 +40,10 @@ describe('Xpring JS XpringClient Integration Tests', function(): void {
     assert.exists(balance)
   })
 
-  it('Get Account Balance - Legacy Web Shim', async function(): Promise<void> {
+  it('Get Account Balance - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const balance = await legacyXpringClientWeb.getBalance(recipientAddress)
+    const balance = await xpringWebClient.getBalance(recipientAddress)
     assert.exists(balance)
   })
 
@@ -65,12 +65,10 @@ describe('Xpring JS XpringClient Integration Tests', function(): void {
     assert.deepEqual(transactionStatus, TransactionStatus.Succeeded)
   })
 
-  it('Get Transaction Status - Legacy Web Shim', async function(): Promise<
-    void
-  > {
+  it('Get Transaction Status - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const transactionStatus = await legacyXpringClientWeb.getPaymentStatus(
+    const transactionStatus = await xpringWebClient.getPaymentStatus(
       transactionHash,
     )
     assert.deepEqual(transactionStatus, TransactionStatus.Succeeded)
@@ -96,14 +94,10 @@ describe('Xpring JS XpringClient Integration Tests', function(): void {
     assert.exists(result)
   })
 
-  it('Send XRP - Legacy Web Shim', async function(): Promise<void> {
+  it('Send XRP - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const result = await legacyXpringClientWeb.send(
-      amount,
-      recipientAddress,
-      wallet,
-    )
+    const result = await xpringWebClient.send(amount, recipientAddress, wallet)
     assert.exists(result)
   })
 
@@ -125,14 +119,10 @@ describe('Xpring JS XpringClient Integration Tests', function(): void {
     assert.equal(doesExist, true)
   })
 
-  it('Check if Account Exists - Legacy Web Shim', async function(): Promise<
-    void
-  > {
+  it('Check if Account Exists - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const doesExist = await legacyXpringClientWeb.accountExists(
-      recipientAddress,
-    )
+    const doesExist = await xpringWebClient.accountExists(recipientAddress)
     assert.equal(doesExist, true)
   })
 

--- a/test/xpring-client-integration-test.ts
+++ b/test/xpring-client-integration-test.ts
@@ -23,7 +23,7 @@ const legacyXpringClientNode = new XpringClient(legacyGRPCURLNode)
 
 // A XpringClient that makes requests. Uses the legacy protocol buffer implementation and sends the requests to an HTTP envoy emulating how the browser would behave
 const grpcWebURL = 'https://envoy.test.xrp.xpring.io'
-const xpringWebClient = new XpringClient(grpcWebURL, false, true)
+const xpringWebClient = new XpringClient(grpcWebURL, true, true)
 
 // A XpringClient that makes requests. Uses rippled's gRPC implementation.
 const rippledURL = 'test.xrp.xpring.io:50051'

--- a/test/xrp-client-integration-test.ts
+++ b/test/xrp-client-integration-test.ts
@@ -13,20 +13,20 @@ const recipientAddress = 'X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4'
 // A wallet with some balance on TestNet.
 const wallet = Wallet.generateWalletFromSeed('snYP7oArxKepd3GPDcrjMsJYiJeJB')!
 
-// A hash of a successfully validated transaction.
+// A hash of a successfully validated payment transaction.
 const transactionHash =
-  '24E31668208A3165E6C702CDA66425808EAD670EABCBFA6C4403FFA93500D486'
+  '6D9B6CDA7F6752548800C4FC14A037B8DAC2EF47E61028793768766EAB7FC81B'
 
 // An XRPClient that makes requests. Uses the legacy protocol buffer implementation.
 const legacyGRPCURLNode = 'grpc.xpring.tech:80'
 const legacyXRPClientNode = new XRPClient(legacyGRPCURLNode)
 
 // An XRPClient that makes requests. Uses the legacy protocol buffer implementation and sends the requests to an HTTP envoy emulating how the browser would behave
-const legacyGRPCURLWeb = 'https://grpchttp.xpring.io'
-const legacyXRPClientWeb = new XRPClient(legacyGRPCURLWeb, false, true)
+const grpcWebURL = 'https://envoy.test.xrp.xpring.io'
+const xpringWebClient = new XRPClient(grpcWebURL, false, true)
 
 // An XRPClient that makes requests. Uses rippled's gRPC implementation.
-const rippledURL = '3.14.64.116:50051'
+const rippledURL = 'test.xrp.xpring.io:50051'
 const xrpClient = new XRPClient(rippledURL, true)
 
 // Some amount of XRP to send.
@@ -40,10 +40,10 @@ describe('Xpring JS XRPClient Integration Tests', function(): void {
     assert.exists(balance)
   })
 
-  it('Get Account Balance - Legacy Web Shim', async function(): Promise<void> {
+  it('Get Account Balance - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const balance = await legacyXRPClientWeb.getBalance(recipientAddress)
+    const balance = await xpringWebClient.getBalance(recipientAddress)
     assert.exists(balance)
   })
 
@@ -65,12 +65,10 @@ describe('Xpring JS XRPClient Integration Tests', function(): void {
     assert.deepEqual(transactionStatus, TransactionStatus.Succeeded)
   })
 
-  it('Get Transaction Status - Legacy Web Shim', async function(): Promise<
-    void
-  > {
+  it('Get Transaction Status - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const transactionStatus = await legacyXRPClientWeb.getTransactionStatus(
+    const transactionStatus = await xpringWebClient.getTransactionStatus(
       transactionHash,
     )
     assert.deepEqual(transactionStatus, TransactionStatus.Succeeded)
@@ -96,14 +94,10 @@ describe('Xpring JS XRPClient Integration Tests', function(): void {
     assert.exists(result)
   })
 
-  it('Send XRP - Legacy Web Shim', async function(): Promise<void> {
+  it('Send XRP - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const result = await legacyXRPClientWeb.send(
-      amount,
-      recipientAddress,
-      wallet,
-    )
+    const result = await xpringWebClient.send(amount, recipientAddress, wallet)
     assert.exists(result)
   })
 
@@ -123,12 +117,10 @@ describe('Xpring JS XRPClient Integration Tests', function(): void {
     assert.equal(doesExist, true)
   })
 
-  it('Check if Account Exists - Legacy Web Shim', async function(): Promise<
-    void
-  > {
+  it('Check if Account Exists - Web Shim', async function(): Promise<void> {
     this.timeout(timeoutMs)
 
-    const doesExist = await legacyXRPClientWeb.accountExists(recipientAddress)
+    const doesExist = await xpringWebClient.accountExists(recipientAddress)
     assert.equal(doesExist, true)
   })
 

--- a/test/xrp-client-integration-test.ts
+++ b/test/xrp-client-integration-test.ts
@@ -23,7 +23,7 @@ const legacyXRPClientNode = new XRPClient(legacyGRPCURLNode)
 
 // An XRPClient that makes requests. Uses the legacy protocol buffer implementation and sends the requests to an HTTP envoy emulating how the browser would behave
 const grpcWebURL = 'https://envoy.test.xrp.xpring.io'
-const xpringWebClient = new XRPClient(grpcWebURL, false, true)
+const xpringWebClient = new XRPClient(grpcWebURL, true, true)
 
 // An XRPClient that makes requests. Uses rippled's gRPC implementation.
 const rippledURL = 'test.xrp.xpring.io:50051'


### PR DESCRIPTION
## High Level Overview of Change

Xpring is hosting production grade nodes on xpring.io. Point documentation / integration tests at these nodes. 

Analogs:
Swift: https://github.com/xpring-eng/XpringKit/pull/155
Java:https://github.com/xpring-eng/xpring4j/pull/132
JavaScript: https://github.com/xpring-eng/Xpring-JS/pull/247

### Context of Change

Note Xpring's nodes have limited history so they don't have the old transaction hash. I grabbed a new one from Testnet.xrpl.org. 

### Type of Change

- [x] Documentation Updates

## Before / After

Better nodes, stable documentation, stable integration tests.

## Test Plan

CI