### PR TITLE
Enable cookie forwarding in ILP client

### DIFF
--- a/src/ILP/grpc-ilp-network-client.web.ts
+++ b/src/ILP/grpc-ilp-network-client.web.ts
@@ -25,8 +25,12 @@ class GrpcIlpNetworkClientWeb implements IlpNetworkClient {
       }
     }
     // FIXME wrong credentials
-    this.balanceClient = new BalanceServiceClient(grpcURL, null, null)
-    this.paymentClient = new IlpOverHttpServiceClient(grpcURL, null, null)
+    this.balanceClient = new BalanceServiceClient(grpcURL, null, {
+      withCredentials: 'true',
+    })
+    this.paymentClient = new IlpOverHttpServiceClient(grpcURL, null, {
+      withCredentials: 'true',
+    })
   }
 
   getBalance(
@@ -34,7 +38,9 @@ class GrpcIlpNetworkClientWeb implements IlpNetworkClient {
     bearerToken?: string,
   ): Promise<GetBalanceResponse> {
     return new Promise((resolve, reject): void => {
-      const metaData: Metadata = { Authorization: bearerToken || '' }
+      const metaData: Metadata | undefined = bearerToken
+        ? { Authorization: bearerToken }
+        : undefined
 
       this.balanceClient.getBalance(request, metaData, (error, response) => {
         if (error != null || response === null) {
@@ -51,7 +57,9 @@ class GrpcIlpNetworkClientWeb implements IlpNetworkClient {
     bearerToken?: string,
   ): Promise<SendPaymentResponse> {
     return new Promise((resolve, reject): void => {
-      const metaData: Metadata = { Authorization: bearerToken || '' }
+      const metaData: Metadata | undefined = bearerToken
+        ? { Authorization: bearerToken }
+        : undefined
 
       this.paymentClient.sendMoney(request, metaData, (error, response) => {
         if (error != null || response === null) {

--- a/src/ILP/grpc-ilp-network-client.web.ts
+++ b/src/ILP/grpc-ilp-network-client.web.ts
@@ -24,7 +24,6 @@ class GrpcIlpNetworkClientWeb implements IlpNetworkClient {
         // Swallow the error here for browsers
       }
     }
-    // FIXME wrong credentials
     this.balanceClient = new BalanceServiceClient(grpcURL, null, {
       withCredentials: 'true',
     })


### PR DESCRIPTION
## High Level Overview of Change
- Fix bug in `DefaultIlpClient` which would cause a request with no `Authorization` header to return a 403, even if an auth cookie was forwarded
- Enable cookie forwarding in ILP network clients
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
There was a bug in `DefaultIlpClient` with the way we were setting the `Authorization` header/metadata in gRPC web calls. If `IlpClient.getBalance` or `IlpClient.sendPayment` were called with no bearer token, an `Authorization` header would still be set, but its value would be empty.  This would cause Hermes to assume the client wanted to authenticate via a header and disregard any cookie auth.

Speaking of cookie auth, cookies were not being propagated automatically from browser to Hermes, because the gRPC network clients were not configured to allow that. This is something we clearly need to enable auth in the xpring wallet.

This PR fixes both of these bugs.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
Auth Header Bug:
Before: `Authorization` header/metadata was set regardless of the presence of a bearer token in the SDK request. If there was no bearer token, the header would be set as `Authorization: ''`
After: `Authorization` header/metadata only set if `bearerToken` is non-null

Cookie forwarding:
Before: `BalanceServiceClient` and `IlpOverHttpServiceClient` were not configured to forward cookies
After: `BalanceServiceClient` and `IlpOverHttpServiceClient` are configured to forward cookies
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
@theotherian has tested this change in xpring.io staging
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

## Future Tasks
New release
