### PR TITLE
Add tests for error cases in PayID

### DIFF
--- a/test/PayID/pay-id-client-test.ts
+++ b/test/PayID/pay-id-client-test.ts
@@ -72,16 +72,20 @@ describe('Pay ID Client', function(): void {
     assert.isUndefined(xrpAddress)
   })
 
-  it('xrpAddressForPayID - failed request', function(done) {
+  it('xrpAddressForPayID - unknown mime type', function(done) {
     // GIVEN a PayIDClient and with mocked networking to return a server error.
     const payID = '$xpring.money/georgewashington'
     const payIDClient = new PayIDClient()
 
-    const serverErrorCode = 500
-    const serverErrorMessage = 'internal error'
+    const serverErrorCode = 415
+    const serverError = {
+      statusCode: serverErrorCode,
+      error: 'Unsupported Media Type',
+      message: 'Unknown MIME type requested.',
+    }
     nock('https://xpring.money')
       .get('/georgewashington')
-      .reply(serverErrorCode, serverErrorMessage)
+      .reply(serverErrorCode, serverError)
 
     // WHEN an XRPAddress is requested for a Pay ID.
     payIDClient.xrpAddressForPayID(payID).catch((error) => {
@@ -93,7 +97,38 @@ describe('Pay ID Client', function(): void {
 
       const { message } = error
       assert.include(message, `${serverErrorCode}`)
-      assert.include(message, serverErrorMessage)
+      assert.include(message, serverError.message)
+
+      done()
+    })
+  })
+
+  it('xrpAddressForPayID - failed request', function(done) {
+    // GIVEN a PayIDClient and with mocked networking to return a server error.
+    const payID = '$xpring.money/georgewashington'
+    const payIDClient = new PayIDClient()
+
+    const serverErrorCode = 503
+    const serverError = {
+      statusCode: serverErrorCode,
+      error: 'Internal error',
+      message: 'Something went wrong and it is not your fault',
+    }
+    nock('https://xpring.money')
+      .get('/georgewashington')
+      .reply(serverErrorCode, serverError)
+
+    // WHEN an XRPAddress is requested for a Pay ID.
+    payIDClient.xrpAddressForPayID(payID).catch((error) => {
+      // THEN an unexpected response is thrown with the details of the error.
+      assert.equal(
+        (error as PayIDError).errorType,
+        PayIDErrorType.UnexpectedResponse,
+      )
+
+      const { message } = error
+      assert.include(message, `${serverErrorCode}`)
+      assert.include(message, serverError.message)
 
       done()
     })


### PR DESCRIPTION
## High Level Overview of Change

The PayID spec describes a PayID server as returning a 503 for internal errors and a 415 if the server doesn't understand a mime type.

### Context of Change

Adding tests to check all error conditions explicitly provided by the protocol. 

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

More tests

## Test Plan

CI
