### PR TITLE
Refactor `XRPLNetwork` to `Common`

### DIFF
--- a/src/Common/xrpl-network.ts
+++ b/src/Common/xrpl-network.ts
@@ -1,0 +1,10 @@
+/**
+ * Possible networks to resolve
+ */
+enum XRPLNetwork {
+  Dev = 'devnet',
+  Test = 'testnet',
+  Main = 'mainnet',
+}
+
+export default XRPLNetwork

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -3,15 +3,7 @@ import Mapping from './generated/model/Mapping'
 import ApiClient from './generated/ApiClient'
 import PayIDError, { PayIDErrorType } from './pay-id-error'
 import PayIDClientInterface from './pay-id-client-interface'
-
-/**
- * Possible networks to resolve
- */
-export enum XRPLNetwork {
-  Dev = 'devnet',
-  Test = 'testnet',
-  Main = 'mainnet',
-}
+import XRPLNetwork from '../Common/xrpl-network'
 
 /**
  * A client for PayID.

--- a/test/PayID/pay-id-client-test.ts
+++ b/test/PayID/pay-id-client-test.ts
@@ -1,8 +1,9 @@
 import { assert } from 'chai'
 import nock from 'nock'
 import { PayIDUtils } from 'xpring-common-js'
-import PayIDClient, { XRPLNetwork } from '../../src/PayID/pay-id-client'
+import PayIDClient from '../../src/PayID/pay-id-client'
 import PayIDError, { PayIDErrorType } from '../../src/PayID/pay-id-error'
+import XRPLNetwork from '../../src/Common/xrpl-network'
 
 describe('Pay ID Client', function(): void {
   afterEach(function() {

--- a/test/PayID/pay-id-integration-test.ts
+++ b/test/PayID/pay-id-integration-test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai'
 import PayIDError, { PayIDErrorType } from '../../src/PayID/pay-id-error'
-import PayIDClient, { XRPLNetwork } from '../../src/PayID/pay-id-client'
+import PayIDClient from '../../src/PayID/pay-id-client'
+import XRPLNetwork from '../../src/Common/xrpl-network'
 
 // A timeout for these tests.
 const timeoutMs = 60 * 1000 // 1 minute


### PR DESCRIPTION
## High Level Overview of Change

Refactor this enum to a separate file and make it common. 

### Context of Change

I need to consume this enum in `pay-id-client-interface` and it's exported from `pay-id-client`. `pay-id-client` imports `pay-id-client-interface`. This causes a circular dependency which means I have to move this to its own file. 

`XpringClient` is also going to consume this object, so I'm moving it to `Common/` now so that we don't need to move it again later. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

No change

## Test Plan

CI
