### PR TITLE
Bind PayID to a network

### DIFF
--- a/src/Common/xrpl-network.ts
+++ b/src/Common/xrpl-network.ts
@@ -1,0 +1,10 @@
+/**
+ * Possible networks to resolve
+ */
+enum XRPLNetwork {
+  Dev = 'devnet',
+  Test = 'testnet',
+  Main = 'mainnet',
+}
+
+export default XRPLNetwork

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -3,15 +3,7 @@ import Mapping from './generated/model/Mapping'
 import ApiClient from './generated/ApiClient'
 import PayIDError, { PayIDErrorType } from './pay-id-error'
 import PayIDClientInterface from './pay-id-client-interface'
-
-/**
- * Possible networks to resolve
- */
-export enum XRPLNetwork {
-  Dev = 'devnet',
-  Test = 'testnet',
-  Main = 'mainnet',
-}
+import XRPLNetwork from '../Common/xrpl-network'
 
 /**
  * A client for PayID.

--- a/test/PayID/pay-id-client-test.ts
+++ b/test/PayID/pay-id-client-test.ts
@@ -1,8 +1,9 @@
 import { assert } from 'chai'
 import nock from 'nock'
 import { PayIDUtils } from 'xpring-common-js'
-import PayIDClient, { XRPLNetwork } from '../../src/PayID/pay-id-client'
+import PayIDClient from '../../src/PayID/pay-id-client'
 import PayIDError, { PayIDErrorType } from '../../src/PayID/pay-id-error'
+import XRPLNetwork from '../../src/Common/xrpl-network'
 
 describe('Pay ID Client', function(): void {
   afterEach(function() {

--- a/test/PayID/pay-id-client-test.ts
+++ b/test/PayID/pay-id-client-test.ts
@@ -14,7 +14,7 @@ describe('Pay ID Client', function(): void {
   it('xrpAddressForPayID - invalid Pay ID', function(done): void {
     // GIVEN a PayIDClient and an invalid PayID.
     const invalidPayID = 'xpring.money/georgewashington' // Does not start with '$'
-    const payIDClient = new PayIDClient()
+    const payIDClient = new PayIDClient(XRPLNetwork.Test)
 
     // WHEN an XRPAddress is requested for an invalid pay ID THEN an invalid payment pointer error is thrown.
     payIDClient.xrpAddressForPayID(invalidPayID).catch((error) => {
@@ -29,7 +29,7 @@ describe('Pay ID Client', function(): void {
   it('xrpAddressForPayID - successful response - match found', async function() {
     // GIVEN a PayID client, valid PayID and mocked networking to return a match for the PayID.
     const payID = '$xpring.money/georgewashington'
-    const payIDClient = new PayIDClient()
+    const payIDClient = new PayIDClient(XRPLNetwork.Test)
 
     const paymentPointer = PayIDUtils.parsePaymentPointer(payID)
     if (!paymentPointer) {
@@ -54,7 +54,7 @@ describe('Pay ID Client', function(): void {
   it('xrpAddressForPayID - successful response - match not found', function(done) {
     // GIVEN a PayID client, valid PayID and mocked networking to return a 404 for the payID.
     const payID = '$xpring.money/georgewashington'
-    const payIDClient = new PayIDClient()
+    const payIDClient = new PayIDClient(XRPLNetwork.Test)
     const network = XRPLNetwork.Test
 
     const paymentPointer = PayIDUtils.parsePaymentPointer(payID)
@@ -68,7 +68,7 @@ describe('Pay ID Client', function(): void {
       .reply(404, {})
 
     // WHEN an XRPAddress is requested.
-    payIDClient.xrpAddressForPayID(payID, network).catch((error) => {
+    payIDClient.xrpAddressForPayID(payID).catch((error) => {
       // THEN an unexpected response is thrown with the details of the error.
       assert.equal(
         (error as PayIDError).errorType,
@@ -86,7 +86,7 @@ describe('Pay ID Client', function(): void {
   it('xrpAddressForPayID - unknown mime type', function(done) {
     // GIVEN a PayIDClient and with mocked networking to return a server error.
     const payID = '$xpring.money/georgewashington'
-    const payIDClient = new PayIDClient()
+    const payIDClient = new PayIDClient(XRPLNetwork.Test)
 
     const serverErrorCode = 415
     const serverError = {
@@ -117,7 +117,7 @@ describe('Pay ID Client', function(): void {
   it('xrpAddressForPayID - failed request', function(done) {
     // GIVEN a PayIDClient and with mocked networking to return a server error.
     const payID = '$xpring.money/georgewashington'
-    const payIDClient = new PayIDClient()
+    const payIDClient = new PayIDClient(XRPLNetwork.Test)
 
     const serverErrorCode = 503
     const serverError = {
@@ -148,7 +148,7 @@ describe('Pay ID Client', function(): void {
   it('xrpAddressForPayID - successful response - unexpected response format', function(done) {
     // GIVEN a PayID client, valid PayID and mocked networking to return a match for the PayID.
     const payID = '$xpring.money/georgewashington'
-    const payIDClient = new PayIDClient()
+    const payIDClient = new PayIDClient(XRPLNetwork.Test)
 
     const paymentPointer = PayIDUtils.parsePaymentPointer(payID)
     if (!paymentPointer) {

--- a/test/PayID/pay-id-integration-test.ts
+++ b/test/PayID/pay-id-integration-test.ts
@@ -6,23 +6,18 @@ import XRPLNetwork from '../../src/Common/xrpl-network'
 // A timeout for these tests.
 const timeoutMs = 60 * 1000 // 1 minute
 
-// A PayIDClient under test.
-const payIDClient = new PayIDClient()
-
 describe('PayID Integration Tests', function(): void {
   it('Resolve PayID to XRP - known PayID - mainnet', async function(): Promise<
     void
   > {
     this.timeout(timeoutMs)
 
-    // GIVEN a Pay ID that will resolve.
+    // GIVEN a Pay ID that will resolve on Mainnet.
+    const payIDClient = new PayIDClient(XRPLNetwork.Main)
     const payID = '$dev.payid.xpring.money/hbergren'
 
-    // WHEN it is resolved to an XRP address on mainnet
-    const xrpAddress = await payIDClient.xrpAddressForPayID(
-      payID,
-      XRPLNetwork.Main,
-    )
+    // WHEN it is resolved to an XRP address
+    const xrpAddress = await payIDClient.xrpAddressForPayID(payID)
 
     // THEN the address is the expected value.
     assert.equal(xrpAddress, 'X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn')
@@ -33,7 +28,8 @@ describe('PayID Integration Tests', function(): void {
   > {
     this.timeout(timeoutMs)
 
-    // GIVEN a Pay ID that will resolve.
+    // GIVEN a Pay ID that will resolve on Testnet.
+    const payIDClient = new PayIDClient(XRPLNetwork.Test)
     const payID = '$dev.payid.xpring.money/hbergren'
 
     // WHEN it is resolved to an XRP address on testnet
@@ -46,12 +42,13 @@ describe('PayID Integration Tests', function(): void {
   it('Resolve PayID to XRP - unknown PayID - devnet', function(done) {
     this.timeout(timeoutMs)
 
-    // GIVEN a Pay ID that will resolve.
+    // GIVEN a Pay ID that will not resolve on Devnet.
     const payID = '$dev.payid.xpring.money/hbergren'
     const network = XRPLNetwork.Dev
+    const payIDClient = new PayIDClient(network)
 
     // WHEN it is resolved to an unmapped value.
-    payIDClient.xrpAddressForPayID(payID, network).catch((error) => {
+    payIDClient.xrpAddressForPayID(payID).catch((error) => {
       // THEN an unexpected response is thrown with the details of the error.
       assert.equal(
         (error as PayIDError).errorType,

--- a/test/PayID/pay-id-integration-test.ts
+++ b/test/PayID/pay-id-integration-test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai'
 import PayIDError, { PayIDErrorType } from '../../src/PayID/pay-id-error'
-import PayIDClient, { XRPLNetwork } from '../../src/PayID/pay-id-client'
+import PayIDClient from '../../src/PayID/pay-id-client'
+import XRPLNetwork from '../../src/Common/xrpl-network'
 
 // A timeout for these tests.
 const timeoutMs = 60 * 1000 // 1 minute


### PR DESCRIPTION
## High Level Overview of Change

Bind a client to a network, rather than allowing changing of networks via method calls. 

### Context of Change

`XRPClient` is bound to a network because it connects to 1 node and there's only ever one network at that node.

`XpringClient` will be initialized with a network so it's bound to a network as well.

`PayIDClient` should be network bound per client to keep this mental model going. I also can't think of a good use case where you're going to be changing networks all the time, and if it's really needed you can just create two `PayIDClient`s.

### Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Breaking change - but no one uses this yet. 

## Test Plan

CI

## Future Tasks
- Explicitly bind XRPClient to a network. 