### PR TITLE
Catch errors when calling with Swagger

### DIFF
--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -141,31 +141,37 @@ export default class PayIDClient implements PayIDClientInterface {
       const authNames = []
       const contentTypes = []
       const returnType = SignatureWrapperInvoice
-      client.callApi(
-        '/{path}/invoice',
-        'GET',
-        pathParams,
-        queryParams,
-        headerParams,
-        formParams,
-        postBody,
-        authNames,
-        contentTypes,
-        accepts,
-        returnType,
-        (error, data, _response) => {
-          // TODO(keefertaylor): Provide more granular error handling.
-          if (error) {
-            const message = `${error.status}: ${error.response.text}`
-            reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
-            // TODO(keefertaylor): make sure the header matches the request.
-          } else if (data) {
-            resolve(data)
-          } else {
-            reject(new PayIDError(PayIDErrorType.UnexpectedResponse))
-          }
-        },
-      )
+
+      try {
+        client.callApi(
+          '/{path}/invoice',
+          'GET',
+          pathParams,
+          queryParams,
+          headerParams,
+          formParams,
+          postBody,
+          authNames,
+          contentTypes,
+          accepts,
+          returnType,
+          (error, data, _response) => {
+            // TODO(keefertaylor): Provide more granular error handling.
+            if (error) {
+              const message = `${error.status}: ${error.response.text}`
+              reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
+              // TODO(keefertaylor): make sure the header matches the request.
+            } else if (data) {
+              resolve(data)
+            } else {
+              reject(new PayIDError(PayIDErrorType.UnexpectedResponse))
+            }
+          },
+        )
+      } catch (exception) {
+        // Something really wrong happened, we don't have enough information to tell. This could be a transient network error, the payment pointer doesn't exist, or any other number of errors.
+        reject(new PayIDError(PayIDErrorType.Unknown, exception.message))
+      }
     })
   }
 
@@ -255,21 +261,26 @@ export default class PayIDClient implements PayIDClientInterface {
     const apiInstance = new DefaultApi(client)
 
     return new Promise((resolve, reject) => {
-      apiInstance.postPathInvoice(
-        path,
-        { body: signatureWrapper },
-        (error, data, _response) => {
-          // TODO(keefertaylor): Provide more granular error handling.
-          if (error) {
-            const message = `${error.status}: ${error.response.text}`
-            reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
-          } else if (data) {
-            resolve(data)
-          } else {
-            reject(new PayIDError(PayIDErrorType.UnexpectedResponse))
-          }
-        },
-      )
+      try {
+        apiInstance.postPathInvoice(
+          path,
+          { body: signatureWrapper },
+          (error, data, _response) => {
+            // TODO(keefertaylor): Provide more granular error handling.
+            if (error) {
+              const message = `${error.status}: ${error.response.text}`
+              reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
+            } else if (data) {
+              resolve(data)
+            } else {
+              reject(new PayIDError(PayIDErrorType.UnexpectedResponse))
+            }
+          },
+        )
+      } catch (exception) {
+        // Something really wrong happened, we don't have enough information to tell. This could be a transient network error, the payment pointer doesn't exist, or any other number of errors.
+        reject(new PayIDError(PayIDErrorType.Unknown, exception.message))
+      }
     })
   }
 
@@ -306,19 +317,24 @@ export default class PayIDClient implements PayIDClientInterface {
     }
 
     return new Promise((resolve, reject) => {
-      apiInstance.postPathReceipt(
-        payIDComponents.path,
-        opts,
-        (error, _data, _response) => {
-          // TODO(keefertaylor): Provide more specific error handling here.
-          if (error) {
-            const message = `${error.status}: ${error.response.text}`
-            reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
-          } else {
-            resolve()
-          }
-        },
-      )
+      try {
+        apiInstance.postPathReceipt(
+          payIDComponents.path,
+          opts,
+          (error, _data, _response) => {
+            // TODO(keefertaylor): Provide more specific error handling here.
+            if (error) {
+              const message = `${error.status}: ${error.response.text}`
+              reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
+            } else {
+              resolve()
+            }
+          },
+        )
+      } catch (exception) {
+        // Something really wrong happened, we don't have enough information to tell. This could be a transient network error, the payment pointer doesn't exist, or any other number of errors.
+        reject(new PayIDError(PayIDErrorType.Unknown, exception.message))
+      }
     })
   }
 


### PR DESCRIPTION
## High Level Overview of Change

If Swagger gets back a response code other than the one it is expecting, it throws some random exceptions. We should catch these and convert them to PayID Errors. 

### Context of Change

We really can't type this better than `unknown`. Xpring SDK cannot handle all cases in "any input can give you any output". We can't distinguish this as "mapping doesn't exist" because the mapping may exist and be in a new protocol version (hence I can't parse the response) or I may have any other number of transient errors. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Exceptions are caught.

## Test Plan

CI continues to pass. 

I can't find a great way to test this logic. All other paths through the method are tested. 