### PR TITLE
Fix `undefined` in messages 

### DIFF
--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -80,7 +80,7 @@ export default class PayIDClient implements PayIDClientInterface {
                 const message = `Could not resolve ${payID} on network ${this.network}`
                 reject(new PayIDError(PayIDErrorType.MappingNotFound, message))
               } else {
-                const message = `${error.status}: ${error.response.text}`
+                const message = `${error.status}: ${error.response?.text}`
                 reject(
                   new PayIDError(PayIDErrorType.UnexpectedResponse, message),
                 )
@@ -158,7 +158,7 @@ export default class PayIDClient implements PayIDClientInterface {
           (error, data, _response) => {
             // TODO(keefertaylor): Provide more granular error handling.
             if (error) {
-              const message = `${error.status}: ${error.response.text}`
+              const message = `${error.status}: ${error.response?.text}`
               reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
               // TODO(keefertaylor): make sure the header matches the request.
             } else if (data) {
@@ -268,7 +268,7 @@ export default class PayIDClient implements PayIDClientInterface {
           (error, data, _response) => {
             // TODO(keefertaylor): Provide more granular error handling.
             if (error) {
-              const message = `${error.status}: ${error.response.text}`
+              const message = `${error.status}: ${error.response?.text}`
               reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
             } else if (data) {
               resolve(data)


### PR DESCRIPTION
## High Level Overview of Change

Fix error when `response` is undefined.


### Context of Change

Need optional chaining otherwise we sometimes will try to read an undefined object. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Library is useable

## Test Plan

CI