### PR TITLE
Fix URL escaping on well known path. 

### DIFF
--- a/pay-id-api-spec/pay-id.v1.yml
+++ b/pay-id-api-spec/pay-id.v1.yml
@@ -2,6 +2,7 @@ info:
   title: PayID
   version: '0.0.1'
 paths:
+  # TODO(keefertaylor): Consider if we should just encode {path} into the base URL.
   '/{path}':
     parameters:
       - schema:
@@ -33,13 +34,7 @@ paths:
           description: Internal error
       operationId: resolvePayID
       description: Resolve a pay id
-  '/{path}/invoice':
-    parameters:
-      - schema:
-          type: string
-        name: path
-        in: path
-        required: true
+  '/invoice':
     get:
       summary: get-invoice
       tags: []
@@ -104,13 +99,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SignatureWrapper_Invoice'
       operationId: post-path-invoice
-  '/{path}/receipt':
-    parameters:
-      - schema:
-          type: string
-        name: path
-        in: path
-        required: true
+  '/receipt':
     post:
       summary: ''
       operationId: post-path-receipt

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -63,7 +63,7 @@ export default class PayIDClient implements PayIDClientInterface {
 
       try {
         client.callApi(
-          '/{path}',
+          payIDComponents.path,
           'GET',
           pathParams,
           queryParams,
@@ -116,9 +116,6 @@ export default class PayIDClient implements PayIDClientInterface {
       throw PayIDError.invalidPaymentPointer
     }
 
-    // Swagger generates the '/' in the URL by default and the payment pointer's 'path' is prefixed by a '/'. Strip off the leading '/'.
-    const path = paymentPointer.path.substring(1)
-
     const client = new ApiClient()
     client.basePath = `https://${paymentPointer.host}`
 
@@ -131,7 +128,7 @@ export default class PayIDClient implements PayIDClientInterface {
       // TODO(keefertaylor): Dedupe this with the above information.
       const postBody = null
       const pathParams = {
-        path,
+        path: paymentPointer.path,
       }
       const queryParams = {
         nonce,
@@ -144,7 +141,7 @@ export default class PayIDClient implements PayIDClientInterface {
 
       try {
         client.callApi(
-          '/{path}/invoice',
+          `${paymentPointer.path}/invoice`,
           'GET',
           pathParams,
           queryParams,
@@ -252,18 +249,14 @@ export default class PayIDClient implements PayIDClientInterface {
       throw PayIDError.invalidPaymentPointer
     }
 
-    // Swagger generates the '/' in the URL by default and the payment pointer's 'path' is prefixed by a '/'. Strip off the leading '/'.
-    const path = paymentPointer.path.substring(1)
-
     const client = new ApiClient()
-    client.basePath = `https://${paymentPointer.host}`
+    client.basePath = `https://${paymentPointer.host}${paymentPointer.path}`
 
     const apiInstance = new DefaultApi(client)
 
     return new Promise((resolve, reject) => {
       try {
         apiInstance.postPathInvoice(
-          path,
           { body: signatureWrapper },
           (error, data, _response) => {
             // TODO(keefertaylor): Provide more granular error handling.
@@ -309,7 +302,7 @@ export default class PayIDClient implements PayIDClientInterface {
     }
 
     const client = new ApiClient()
-    client.basePath = `https://${payIDComponents.host}`
+    client.basePath = `https://${payIDComponents.host}${payIDComponents.path}`
 
     const apiInstance = new DefaultApi(client)
     const opts = {
@@ -318,19 +311,15 @@ export default class PayIDClient implements PayIDClientInterface {
 
     return new Promise((resolve, reject) => {
       try {
-        apiInstance.postPathReceipt(
-          payIDComponents.path,
-          opts,
-          (error, _data, _response) => {
-            // TODO(keefertaylor): Provide more specific error handling here.
-            if (error) {
-              const message = `${error.status}: ${error.response?.text}`
-              reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
-            } else {
-              resolve()
-            }
-          },
-        )
+        apiInstance.postPathReceipt(opts, (error, _data, _response) => {
+          // TODO(keefertaylor): Provide more specific error handling here.
+          if (error) {
+            const message = `${error.status}: ${error.response?.text}`
+            reject(new PayIDError(PayIDErrorType.UnexpectedResponse, message))
+          } else {
+            resolve()
+          }
+        })
       } catch (exception) {
         // Something really wrong happened, we don't have enough information to tell. This could be a transient network error, the payment pointer doesn't exist, or any other number of errors.
         reject(new PayIDError(PayIDErrorType.Unknown, exception.message))
@@ -346,13 +335,9 @@ export default class PayIDClient implements PayIDClientInterface {
     if (!paymentPointer) {
       throw PayIDError.invalidPaymentPointer
     }
-
-    // Swagger generates the '/' in the URL by default and the payment pointer's 'path' is prefixed by a '/'. Strip off the leading '/'.
-    const path = paymentPointer.path.substring(1)
-
     return {
       host: paymentPointer.host,
-      path,
+      path: paymentPointer.path,
     }
   }
 }

--- a/test/PayID/pay-id-integration-test.ts
+++ b/test/PayID/pay-id-integration-test.ts
@@ -15,13 +15,13 @@ describe('PayID Integration Tests', function(): void {
 
     // GIVEN a Pay ID that will resolve on Mainnet.
     const payIDClient = new PayIDClient(XRPLNetwork.Main)
-    const payID = '$dev.payid.xpring.money/hbergren'
+    const payID = '$pay.michael.zochow.ski'
 
     // WHEN it is resolved to an XRP address
     const xrpAddress = await payIDClient.xrpAddressForPayID(payID)
 
     // THEN the address is the expected value.
-    assert.equal(xrpAddress, 'X7zmKiqEhMznSXgj9cirEnD5sWo3iZSbeFRexSFN1xZ8Ktn')
+    assert.equal(xrpAddress, 'X7zmKiqEhMznSXgj9cirEnD5sWo3iZSHqcZEd67ddMfJG9Y')
   })
 
   it('Resolve PayID to XRP - known PayID - testnet', async function(): Promise<


### PR DESCRIPTION
## High Level Overview of Change

If you feed `path` as a parameter to Swagger it tries to escape things in the path. That means that for the well known value, we hit: `<host>/.wellknown%2fpay` instead of `.wellknown/pay`.

### Context of Change

This is a quick and dirty fix for a late breaking bug. I will fix this forward soon.  

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Can hit well known PayIDs.

## Test Plan

CI