### PR TITLE
(2/2) Check networks in components of XpringClient

### DIFF
--- a/src/PayID/pay-id-client-interface.ts
+++ b/src/PayID/pay-id-client-interface.ts
@@ -1,7 +1,14 @@
+import XRPLNetwork from '../Common/xrpl-network'
+
 /**
  * An interface for a PayID client.
  */
 export default interface PayIDClient {
+  /**
+   * @param network The network that addresses will be resolved on.
+   */
+  network: XRPLNetwork
+
   /**
    * Retrieve the XRP Address associated with a PayID.
    *

--- a/src/XRP/xrp-client-interface.ts
+++ b/src/XRP/xrp-client-interface.ts
@@ -1,11 +1,15 @@
 import { Wallet } from 'xpring-common-js'
 import { BigInteger } from 'big-integer'
 import TransactionStatus from './transaction-status'
+import XRPLNetwork from '../Common/xrpl-network'
 
 /**
  * An interface describing XRPClient.
  */
 export default interface XRPClientInterface {
+  /** The XRPL Network of the node that this client is communicating with. */
+  network: XRPLNetwork
+
   /**
    * Retrieve the balance for the given address.
    *

--- a/src/Xpring/xpring-client.ts
+++ b/src/Xpring/xpring-client.ts
@@ -2,6 +2,7 @@ import { Wallet } from 'xpring-common-js'
 import { BigInteger } from 'big-integer'
 import PayIDClientInterface from '../PayID/pay-id-client-interface'
 import XRPClientInterface from '../XRP/xrp-client-interface'
+import XpringError from './xpring-error'
 
 /**
  * Composes interactions of Xpring services.
@@ -12,11 +13,19 @@ export default class XpringClient {
    *
    * @param payIDClient A Pay ID Client used to interact with the Pay ID protocol.
    * @param xrpClient An XRP Client used to interact with the XRP Ledger protocol.
+   * @throws A XpringError if the networks of the inputs do not match.
    */
   constructor(
     private readonly payIDClient: PayIDClientInterface,
     private readonly xrpClient: XRPClientInterface,
-  ) {}
+  ) {
+    // Verify that networks match.
+    const payIDNetwork = payIDClient.network
+    const xrpNetwork = xrpClient.network
+    if (payIDNetwork !== xrpNetwork) {
+      throw XpringError.mismatchedNetworks
+    }
+  }
 
   /**
    * Send the given amount of XRP from the source wallet to the destination Pay ID.

--- a/src/Xpring/xpring-error.ts
+++ b/src/Xpring/xpring-error.ts
@@ -9,8 +9,11 @@ export enum XpringErrorType {
  * Represents errors thrown by PayID components of the Xpring SDK.
  */
 export default class XpringError extends Error {
-  /**
-   * Default errors.
+  /** 
+   * Input entities given to a Xpring component were attached to different networks. 
+   *
+   * For instance, this error may be thrown if a XpringClient was constructed with 
+   * a PayIDClient attached to Testnet and a XRPClient attached to Mainnet.
    */
   public static mismatchedNetworks = new XpringError(
     XpringErrorType.MismatchedNetworks,

--- a/src/Xpring/xpring-error.ts
+++ b/src/Xpring/xpring-error.ts
@@ -1,0 +1,30 @@
+/**
+ * Types of errors that originate from Xpring.
+ */
+export enum XpringErrorType {
+  MismatchedNetworks,
+}
+
+/**
+ * Represents errors thrown by PayID components of the Xpring SDK.
+ */
+export default class XpringError extends Error {
+  /**
+   * Default errors.
+   */
+  public static mismatchedNetworks = new XpringError(
+    XpringErrorType.MismatchedNetworks,
+    'Components are not connecting to the same network.',
+  )
+
+  /**
+   * @param errorType The type of error.
+   * @param message The error message.
+   */
+  public constructor(
+    public readonly errorType: XpringErrorType,
+    message: string | undefined = undefined,
+  ) {
+    super(message)
+  }
+}

--- a/src/Xpring/xpring-error.ts
+++ b/src/Xpring/xpring-error.ts
@@ -13,7 +13,7 @@ export default class XpringError extends Error {
    * Input entities given to a Xpring component were attached to different networks. 
    *
    * For instance, this error may be thrown if a XpringClient was constructed with 
-   * a PayIDClient attached to Testnet and a XRPClient attached to Mainnet.
+   * a PayIDClient attached to Testnet and an XRPClient attached to Mainnet.
    */
   public static mismatchedNetworks = new XpringError(
     XpringErrorType.MismatchedNetworks,

--- a/src/Xpring/xpring-error.ts
+++ b/src/Xpring/xpring-error.ts
@@ -6,7 +6,7 @@ export enum XpringErrorType {
 }
 
 /**
- * Represents errors thrown by PayID components of the Xpring SDK.
+ * Represents errors thrown by Xpring components of the Xpring SDK.
  */
 export default class XpringError extends Error {
   /** 

--- a/test/PayID/fakes/fake-pay-id-client.ts
+++ b/test/PayID/fakes/fake-pay-id-client.ts
@@ -1,5 +1,6 @@
 import PayIDClientInterface from '../../../src/PayID/pay-id-client-interface'
 import Result from '../../Common/Helpers/result'
+import { XRPLNetwork } from '../../../src'
 
 /**
  * A fake Pay ID Client which can return faked values.
@@ -8,7 +9,10 @@ export default class FakePayIDClient implements PayIDClientInterface {
   /**
    * @param xrpAddressResult The object that will be returned or thrown from a call to `xrpAddressForPayID`.
    */
-  constructor(private readonly xrpAddressResult: Result<string>) {}
+  constructor(
+    private readonly xrpAddressResult: Result<string>,
+    public readonly network: XRPLNetwork = XRPLNetwork.Test,
+  ) {}
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async xrpAddressForPayID(_payID: string): Promise<string> {

--- a/test/XRP/fakes/fake-xrp-client.ts
+++ b/test/XRP/fakes/fake-xrp-client.ts
@@ -1,7 +1,7 @@
 import { BigInteger } from 'big-integer'
 import { XRPClientDecorator } from '../../../src/XRP/xrp-client-decorator'
 import TransactionStatus from '../../../src/XRP/transaction-status'
-import { Wallet } from '../../../src/index'
+import { Wallet, XRPLNetwork } from '../../../src/index'
 import RawTransactionStatus from '../../../src/XRP/raw-transaction-status'
 import XRPTransaction from '../../../src/XRP/model/xrp-transaction'
 import Result from '../../Common/Helpers/result'
@@ -15,6 +15,7 @@ class FakeXRPClient implements XRPClientDecorator {
     public getRawTransactionStatusValue: Result<RawTransactionStatus>,
     public accountExistsValue: Result<boolean>,
     public paymentHistoryValue: Result<Array<XRPTransaction>>,
+    public readonly network: XRPLNetwork = XRPLNetwork.Test,
   ) {}
 
   async getBalance(_address: string): Promise<BigInteger> {

--- a/test/Xpring/xpring-client-test.ts
+++ b/test/Xpring/xpring-client-test.ts
@@ -155,7 +155,7 @@ describe('Xpring Client', function(): void {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const xpringClient = new XpringClient(payIDClient, xrpClient)
       assert.fail(
-        `Should not have been able to construct a but instead created: ${xpringClient}`,
+        `Should not have been able to construct an instance of XpringClient but instead created: ${xpringClient}`,
       )
     } catch (error) {
       assert.deepEqual(error, XpringError.mismatchedNetworks)


### PR DESCRIPTION
## High Level Overview of Change

Throw an error if XpringClient is initialized with objects that are bound to different networks.

### Context of Change

`XpringClient` composes functionality across components. It would not make sense to have components be operating on different networks as they try to interoperate. Provide a sanity check at construction time for this case.

Note that while the `network` property exists in `PayIDClient` and `XRPClient` they are not exposed in the interface and need to be created on `FakePayIDClient` and `FakeXRPClient`.

Introduce a `XpringError` to handle these cases. Throw a XpringError if this precondition is not met.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Safer code, fewer sharp edges.

## Test Plan

Additional unit test introduced to prove correctness.
