### PR TITLE
Fix missing interface conformance

### DIFF
--- a/src/PayID/xrp-pay-id-client.ts
+++ b/src/PayID/xrp-pay-id-client.ts
@@ -2,11 +2,13 @@ import { Utils } from 'xpring-common-js'
 import PayIDClient from './pay-id-client'
 import XRPLNetwork from '../Common/xrpl-network'
 import PayIDError, { PayIDErrorType } from './pay-id-error'
+import XRPPayIDClientInterface from './xrp-pay-id-client-interface'
 
 /**
  * Provides functionality for XRP in the PayID protocol.
  */
-export default class XRPPayIDClient extends PayIDClient {
+export default class XRPPayIDClient extends PayIDClient
+  implements XRPPayIDClientInterface {
   /**
    * @param xrplNetwork The XRP Ledger network that this client attaches to.
    */


### PR DESCRIPTION
## High Level Overview of Change

`XRPPayIDClient` should conform to `XRPPayIDClientInterface`. 

### Context of Change

I'm actually not positive how this compiles as we use `XRPPayIDClient` as a parameter of type `XRPPayIDClientInterface` pretty liberally throughout our codebase. 

My guess is [TypeScripts typing rules](https://www.typescriptlang.org/docs/handbook/type-compatibility.html#introduction) let us get away with this since the class / interface are the same shape, but maybe one of our local typescript gurus can weigh in. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

n/a

## Test Plan

CI
