### PR TITLE
Enforce Ledger Specifiers as to not use Open Ledgers

### DIFF
--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -29,6 +29,7 @@ import GRPCNetworkClientWeb from './grpc-xrp-network-client.web'
 import { XRPNetworkClient } from './xrp-network-client'
 import isNode from '../Common/utils'
 import XRPError from './xrp-error'
+import { LedgerSpecifier } from './Generated/web/org/xrpl/rpc/v1/ledger_pb'
 
 /** A margin to pad the current ledger sequence with when submitting transactions. */
 const maxLedgerVersionOffset = 10
@@ -80,6 +81,10 @@ class DefaultXRPClient implements XRPClientDecorator {
 
     const request = this.networkClient.GetAccountInfoRequest()
     request.setAccount(account)
+
+    const ledger = new LedgerSpecifier()
+    ledger.setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED)
+    request.setLedger(ledger)
 
     const accountInfo = await this.networkClient.getAccountInfo(request)
     const accountData = accountInfo.getAccountData()
@@ -250,6 +255,10 @@ class DefaultXRPClient implements XRPClientDecorator {
     const request = this.networkClient.GetAccountInfoRequest()
     request.setAccount(account)
 
+    const ledger = new LedgerSpecifier()
+    ledger.setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED)
+    request.setLedger(ledger)
+
     const accountInfo = await this.networkClient.getAccountInfo(request)
     if (!accountInfo) {
       throw XRPError.malformedResponse
@@ -306,6 +315,10 @@ class DefaultXRPClient implements XRPClientDecorator {
 
     const request = this.networkClient.GetAccountTransactionHistoryRequest()
     request.setAccount(account)
+
+    const ledger = new LedgerSpecifier()
+    ledger.setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED)
+    request.setLedgerSpecifier(ledger)
 
     const transactionHistory = await this.networkClient.getTransactionHistory(
       request,


### PR DESCRIPTION
## High Level Overview of Change
Currently when requesting account information and transaction history we are not setting the ledger specifier to validated ledgers only. This means all the balances we return and potentially the transaction histories can include unconfirmed values. This could lead to issues where a user thinks they have received a payment when in reality that payment could be fraudulent.

I noticed this in the XpringWallet as the balance was consistently updating in under 500ms after being funded from the faucet, this should of course take 4s on average.

### Context of Change
Add ledger specifier to the default xrp client.

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Before / After
No more unconfirmed transactions impacting the user's balance.

## Test Plan
CI Passes

<!--
## Future Tasks
For future tasks related to PR.
-->
