### PR TITLE
Send Accept Header when POSTing Invoice

### DIFF
--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -78,7 +78,7 @@ export default class PayIDClient {
 
     const { error, data } = await PayIDClient.callSwaggerRPC<
       PaymentInformation
-    >(basePath, path, HTTPMethod.Get, null, accepts, PaymentInformation)
+    >(basePath, path, HTTPMethod.Get, undefined, accepts, PaymentInformation)
 
     if (error) {
       if (error.status === 404) {
@@ -115,7 +115,14 @@ export default class PayIDClient {
 
     const { error, data } = await PayIDClient.callSwaggerRPC<
       SignatureWrapperInvoice
-    >(basePath, path, HTTPMethod.Get, null, accepts, SignatureWrapperInvoice)
+    >(
+      basePath,
+      path,
+      HTTPMethod.Get,
+      undefined,
+      accepts,
+      SignatureWrapperInvoice,
+    )
 
     // TODO(keefertaylor): Provide more granular error handling.
     if (error) {
@@ -297,7 +304,7 @@ export default class PayIDClient {
    * @param path The path for the request. This value is taken as is, clients of this method are responsible for escaping
    *             or other transformations.
    * @param method The HTTP method to use for the request.
-   * @param postBody A body to post.
+   * @param postBody An optional body to POST.
    * @param accepts An array of acceptable Content-Type headers, ordered in preference from most to least desirable.
    * @param returnType The type of the returned object.
    */
@@ -305,7 +312,7 @@ export default class PayIDClient {
     basePath: string,
     path: string,
     httpMethod: HTTPMethod,
-    postBody: object,
+    postBody: object | undefined,
     accepts: Array<string>,
     // The next line is T.type.
     // TODO(keefertaylor): Figure out a way to express this in typescript.

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -18,6 +18,14 @@ interface PayIDComponents {
   path: string
 }
 
+/**
+ * HTTP methods used on requests.
+ */
+enum HTTPMethod {
+  Get = 'GET',
+  Post = 'POST',
+}
+
 // TODO(keefertaylor): Do not use any. Either generate .d.ts files by using a typescript code generator or manually create interfaces.
 /** The result of a call to a Swagger RPC which fetched a response of type T. */
 interface SwaggerCallResult<T> {
@@ -70,7 +78,7 @@ export default class PayIDClient {
 
     const { error, data } = await PayIDClient.callSwaggerRPC<
       PaymentInformation
-    >(basePath, path, accepts, PaymentInformation)
+    >(basePath, path, HTTPMethod.Get, null, accepts, PaymentInformation)
 
     if (error) {
       if (error.status === 404) {
@@ -107,7 +115,7 @@ export default class PayIDClient {
 
     const { error, data } = await PayIDClient.callSwaggerRPC<
       SignatureWrapperInvoice
-    >(basePath, path, accepts, SignatureWrapperInvoice)
+    >(basePath, path, HTTPMethod.Get, null, accepts, SignatureWrapperInvoice)
 
     // TODO(keefertaylor): Provide more granular error handling.
     if (error) {
@@ -194,28 +202,22 @@ export default class PayIDClient {
     )
 
     const payIDComponents = PayIDClient.parsePayID(payID)
+    const basePath = `https://${payIDComponents.host}`
+    const path = `${payIDComponents.path}/invoice?nonce=${nonce}`
 
-    const client = new ApiClient()
-    client.basePath = `https://${payIDComponents.host}${payIDComponents.path}`
+    // Accept only the given network in response.
+    const accepts = [`application/${this.network}+json`]
 
-    const apiInstance = new DefaultApi(client)
-
-    const { error, data } = await new Promise<
-      SwaggerCallResult<SignatureWrapperInvoice>
-    >((resolve, _reject) => {
-      apiInstance.postPathInvoice(
-        nonce,
-        { body: signatureWrapper },
-        (swaggerError, swaggerData, response) => {
-          // Transform results of the callback to a wrapper object.
-          resolve({
-            error: swaggerError,
-            data: swaggerData,
-            response,
-          })
-        },
-      )
-    })
+    const { error, data } = await PayIDClient.callSwaggerRPC<
+      SignatureWrapperInvoice
+    >(
+      basePath,
+      path,
+      HTTPMethod.Post,
+      signatureWrapper,
+      accepts,
+      SignatureWrapperInvoice,
+    )
 
     // TODO(keefertaylor): Provide more granular error handling.
     if (error) {
@@ -294,12 +296,16 @@ export default class PayIDClient {
    * @param basePath The base URL for the RPC.
    * @param path The path for the request. This value is taken as is, clients of this method are responsible for escaping
    *             or other transformations.
+   * @param method The HTTP method to use for the request.
+   * @param postBody A body to post.
    * @param accepts An array of acceptable Content-Type headers, ordered in preference from most to least desirable.
    * @param returnType The type of the returned object.
    */
   private static async callSwaggerRPC<T>(
     basePath: string,
     path: string,
+    httpMethod: HTTPMethod,
+    postBody: object,
     accepts: Array<string>,
     // The next line is T.type.
     // TODO(keefertaylor): Figure out a way to express this in typescript.
@@ -315,8 +321,6 @@ export default class PayIDClient {
       //
       // NOTE: At some point additional fields may need to be generalized (ex. httpMethod). These fields
       // are hidden for convenience and configurability and may be exposed when needed.
-      const postBody = null
-      const httpMethod = 'GET'
       const queryParams = {}
       const headerParams = {}
       const formParams = {}


### PR DESCRIPTION
## High Level Overview of Change

Send an `Accept: <content-type>` header along with an invoice POST request. 

### Context of Change

This is a small change to the protocol as defined by the whitepaper. The PayID backend supports this, so integration tests validate that this change WAI. 

Swagger (the tool we use to generate the network) doesn't support custom headers, so we refactor some of the internal methods to deal with this new logic. Refactors allow a configurable request type (GET vs POST) and a body param. 

This is a non-breaking change.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Before: Integration tests fail at head because the PayID backend deployed this change. 
After: Xpring-JS is compliant with the PayID protocol and integration tests pass. 

## Test Plan

CI
