### PR TITLE
Fix Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build/**/*"
   ],
   "scripts": {
-    "build": "npm run clean && ./scripts/regenerate_protos.sh && ./scripts/regenerate_pay_id_api.sh && npm run lint && tsc -d && copyfiles -u 3 './src/XRP/Generated/**/*' ./build/XRP/Generated && copyfiles -u 3 './src/ILP/Generated/**/*' ./build/ILP/Generated && copyfiles -u 3 './src/PayID/Generated/**/*' ./build/PayID/Generated",
+    "build": "npm run clean && ./scripts/regenerate_protos.sh && ./scripts/regenerate_pay_id_api.sh && npm run lint && tsc -d --allowJs false && copyfiles -u 3 './src/XRP/Generated/**/*' ./build/XRP/Generated && copyfiles -u 3 './src/ILP/Generated/**/*' ./build/ILP/Generated && copyfiles -u 3 './src/PayID/Generated/**/*' ./build/PayID/Generated",
     "clean": "rm -rf ./src/XRP/Generated ./src/ILP/Generated ./dist ./build ./src/PayID/Generated",
     "pretest": "npm run clean && ./scripts/regenerate_protos.sh && ./scripts/regenerate_pay_id_api.sh && npm run lint && tsc --noEmit",
     "lint": "eslint . --ext .ts --fix",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build/**/*"
   ],
   "scripts": {
-    "build": "npm run clean && ./scripts/regenerate_protos.sh && ./scripts/regenerate_pay_id_api.sh && npm run lint && tsc -d && copyfiles -u 3 './src/XRP/Generated/**/*' ./build/XRP/Generated && copyfiles -u 3 './src/ILP/Generated/**/*' ./build/ILP/Generated",
+    "build": "npm run clean && ./scripts/regenerate_protos.sh && ./scripts/regenerate_pay_id_api.sh && npm run lint && tsc -d && copyfiles -u 3 './src/XRP/Generated/**/*' ./build/XRP/Generated && copyfiles -u 3 './src/ILP/Generated/**/*' ./build/ILP/Generated && copyfiles -u 3 './src/PayID/Generated/**/*' ./build/PayID/Generated",
     "clean": "rm -rf ./src/XRP/Generated ./src/ILP/Generated ./dist ./build ./src/PayID/Generated",
     "pretest": "npm run clean && ./scripts/regenerate_protos.sh && ./scripts/regenerate_pay_id_api.sh && npm run lint && tsc --noEmit",
     "lint": "eslint . --ext .ts --fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,14 @@
     "moduleResolution": "node",
 
     // Advanced Options
-    "allowJs": true,
+    "allowJs": false,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true
   },
   "include": [
     "src/**/*"
+  ],
+  "exclude": [
+    "src/PayID/Generated/*"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "moduleResolution": "node",
 
     // Advanced Options
-    "allowJs": false,
+    "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,8 +29,5 @@
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    "src/PayID/Generated/*"
   ]
 }


### PR DESCRIPTION
## High Level Overview of Change

Swagger generates JS files with incorrect annotations and `tsc` compiles them. This fails builds upstream. 

### Context of Change

Swagger's JS is a bit rough around the edges and it causes typescript declaration file generation to output faulty files. 

Dodge this problem by not generating .d.ts files for .js files. 

### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

npm package actually works. 

## Test Plan

I pulled down the wallet on branch [ac/utility-refactor](https://github.com/xpring-eng/xpring-wallet-system/pull/619) and ran:
```shell
$ cd system
$ npm i 
$ tsc -d
```

I observed a typescript error. 

Then I ran `npm link` to link this build in instead and ran `tsc -d` again. No errors!
