### PR TITLE
Removes LedgerSpecifier from GetAccountTransactionHistoryRequest

### DIFF
--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -316,10 +316,6 @@ class DefaultXRPClient implements XRPClientDecorator {
     const request = this.networkClient.GetAccountTransactionHistoryRequest()
     request.setAccount(account)
 
-    const ledger = new LedgerSpecifier()
-    ledger.setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED)
-    request.setLedgerSpecifier(ledger)
-
     const transactionHistory = await this.networkClient.getTransactionHistory(
       request,
     )


### PR DESCRIPTION
## High Level Overview of Change
A `GetAccountTransactionHistory` gRPC request only returns validated transaction data by default.  Adding a `LedgerSpecifer` to the request is likely to result in incomplete data, so this PR removes the `LedgerSpecifer` from `GetAccountTransactionHistoryRequest`.

For more details on when to use `LedgerSpecifier`s see the notes in these PRs:
- https://github.com/xpring-eng/xpring4j/pull/218
- https://github.com/xpring-eng/XpringKit/pull/204

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
Before: Transaction history likely to be incomplete unless transactions were *just* submitted.
After: transaction history should be correct.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI / integration tests pass
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
