### PR TITLE
Add configuration for Patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,11 @@
 coverage:
   status:
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        base: auto 
+        if_ci_failed: error
     project:
       default:
         target: 80%


### PR DESCRIPTION
## High Level Overview of Change

The `project` tag applies the setting to a project, while the `patch` tag is needed to run on the PR's coverage. 

### Context of Change

Now that we have a base code coverage submitted, I am experimenting and ensuring it works. Not providing a patch configuration was one place I messed up. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Configuration runs on patch. 

## Test Plan

CI
<!--
## Future Tasks
For future tasks related to PR.
-->
