### PR TITLE
Keeps xrpToDrops and dropsToXrp utilities in correct namespace

### DIFF
--- a/src/XRP/index.ts
+++ b/src/XRP/index.ts
@@ -13,4 +13,3 @@ export {
   XRPTransactionType,
   XRPTransaction,
 } from './model'
-export { xrpToDrops, dropsToXrp } from './xrp-utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,7 @@ export { default as XRPError, XRPErrorType } from './XRP/xrp-error'
 export { default as IlpError, IlpErrorType } from './ILP/ilp-error'
 export { default as XRPPayIDClient } from './PayID/xrp-pay-id-client'
 
-export {
-  RippledFlags,
-  TransactionStatus,
-  XRPClient,
-  xrpToDrops,
-  dropsToXrp,
-} from './XRP'
+export { RippledFlags, TransactionStatus, XRPClient } from './XRP'
 export {
   XRPCurrencyAmount,
   XRPCurrency,


### PR DESCRIPTION
## High Level Overview of Change
This PR removes some exports from `index.ts` files to maintain better namespacing as the SDK grows and diversifies.  Note that this a breaking change for imports from the SDK.   The Xpring Wallet will have to be updated when this change is released with the import statement:

```import { xrpToDrops, dropsToXrp } from 'xpring-js/src/XRP/xrp-utils'```

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Keep the SDKs organized as we go!
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before / After
Before: `xrpToDrops` and `dropsToXrp` in `xpring-js` namespace.
After:  `xrpToDrops` and `dropsToXrp` in 'xpring-js/src/XRP/xrp-utils'
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI passes
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Fix Wallet import when the new release of `xpring-js` is cut.  