### PR TITLE
Revert "(1/n) Rename function to indicate it does not return the latest validated ledger"

### DIFF
--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -156,7 +156,7 @@ class DefaultXRPClient implements XRPClientDecorator {
 
     const fee = await this.getMinimumFee()
     const accountData = await this.getAccountData(classicAddress.address)
-    const currentOpenLedgerSequence = await this.getCurrentOpenLedgerSequence()
+    const lastValidatedLedgerSequence = await this.getLastValidatedLedgerSequence()
 
     const xrpDropsAmount = new XRPDropsAmount()
     xrpDropsAmount.setDrops(normalizedDrops)
@@ -185,7 +185,7 @@ class DefaultXRPClient implements XRPClientDecorator {
 
     const lastLedgerSequence = new LastLedgerSequence()
     lastLedgerSequence.setValue(
-      currentOpenLedgerSequence + maxLedgerVersionOffset,
+      lastValidatedLedgerSequence + maxLedgerVersionOffset,
     )
 
     const signingPublicKeyBytes = Utils.toBytes(sender.getPublicKey())
@@ -216,7 +216,7 @@ class DefaultXRPClient implements XRPClientDecorator {
     return Utils.toHex(response.getHash_asU8())
   }
 
-  public async getCurrentOpenLedgerSequence(): Promise<number> {
+  public async getLastValidatedLedgerSequence(): Promise<number> {
     const getFeeResponse = await this.getFee()
     return getFeeResponse.getLedgerCurrentIndex()
   }

--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -54,7 +54,7 @@ class ReliableSubmissionXRPClient implements XRPClientDecorator {
     }
 
     // Retrieve the latest ledger index.
-    let currentOpenLedgerSequence = await this.getCurrentOpenLedgerSequence()
+    let latestLedgerSequence = await this.getLastValidatedLedgerSequence()
 
     // Poll until the transaction is validated, or until the lastLedgerSequence has been passed.
     /*
@@ -65,13 +65,13 @@ class ReliableSubmissionXRPClient implements XRPClientDecorator {
      */
     /* eslint-disable no-await-in-loop */
     while (
-      currentOpenLedgerSequence <= lastLedgerSequence &&
+      latestLedgerSequence <= lastLedgerSequence &&
       !rawTransactionStatus.isValidated
     ) {
       await sleep(ledgerCloseTimeMs)
 
       // Update latestLedgerSequence and rawTransactionStatus
-      currentOpenLedgerSequence = await this.getCurrentOpenLedgerSequence()
+      latestLedgerSequence = await this.getLastValidatedLedgerSequence()
       rawTransactionStatus = await this.getRawTransactionStatus(transactionHash)
     }
     /* eslint-enable no-await-in-loop */
@@ -79,8 +79,8 @@ class ReliableSubmissionXRPClient implements XRPClientDecorator {
     return transactionHash
   }
 
-  public async getCurrentOpenLedgerSequence(): Promise<number> {
-    return this.decoratedClient.getCurrentOpenLedgerSequence()
+  public async getLastValidatedLedgerSequence(): Promise<number> {
+    return this.decoratedClient.getLastValidatedLedgerSequence()
   }
 
   public async getRawTransactionStatus(

--- a/src/XRP/xrp-client-decorator.ts
+++ b/src/XRP/xrp-client-decorator.ts
@@ -41,11 +41,11 @@ export interface XRPClientDecorator {
   ): Promise<string>
 
   /**
-   * Retrieve the currently open ledger's sequence number.
+   * Retrieve the latest validated ledger sequence on the XRP Ledger.
    *
-   * @returns The index of the currently open ledger.
+   * @returns The index of the latest validated ledger.
    */
-  getCurrentOpenLedgerSequence(): Promise<number>
+  getLastValidatedLedgerSequence(): Promise<number>
 
   /**
    * Retrieve the raw transaction status for the given transaction hash.

--- a/test/XRP/fakes/fake-xrp-client.ts
+++ b/test/XRP/fakes/fake-xrp-client.ts
@@ -11,7 +11,7 @@ class FakeXRPClient implements XRPClientDecorator {
     public getBalanceValue: Result<BigInteger>,
     public getPaymentStatusValue: Result<TransactionStatus>,
     public sendValue: Result<string>,
-    public getCurrentOpenLedgerSequenceValue: Result<number>,
+    public getLastValidatedLedgerSequenceValue: Result<number>,
     public getRawTransactionStatusValue: Result<RawTransactionStatus>,
     public accountExistsValue: Result<boolean>,
     public paymentHistoryValue: Result<Array<XRPTransaction>>,
@@ -34,8 +34,8 @@ class FakeXRPClient implements XRPClientDecorator {
     return FakeXRPClient.returnOrThrow(this.sendValue)
   }
 
-  async getCurrentOpenLedgerSequence(): Promise<number> {
-    return FakeXRPClient.returnOrThrow(this.getCurrentOpenLedgerSequenceValue)
+  async getLastValidatedLedgerSequence(): Promise<number> {
+    return FakeXRPClient.returnOrThrow(this.getLastValidatedLedgerSequenceValue)
   }
 
   async getRawTransactionStatus(

--- a/test/XRP/reliable-submission-xrp-client-test.ts
+++ b/test/XRP/reliable-submission-xrp-client-test.ts
@@ -16,7 +16,7 @@ const transactionHash = 'DEADBEEF'
 const fakedGetBalanceValue = bigInt(10)
 const fakedTransactionStatusValue = TransactionStatus.Succeeded
 const fakedSendValue = transactionHash
-const fakeCurrentOpenLedgerSequenceValue = 10
+const fakedLastLedgerSequenceValue = 10
 
 const fakedRawTransactionStatusLastLedgerSequenceValue = 20
 const fakedRawTransactionStatusValidatedValue = true
@@ -31,26 +31,27 @@ const fakedRawTransactionStatusValue = new RawTransactionStatus(
 )
 const fakedTransactionHistoryValue = [testXRPTransaction]
 
-let fakeXRPClient: FakeXRPClient
-let reliableSubmissionClient: ReliableSubmissionXRPClient
-
 describe('Reliable Submission XRP Client', function (): void {
   beforeEach(function () {
-    fakeXRPClient = new FakeXRPClient(
+    this.fakeXRPClient = new FakeXRPClient(
       fakedGetBalanceValue,
       fakedTransactionStatusValue,
       fakedSendValue,
-      fakeCurrentOpenLedgerSequenceValue,
+      fakedLastLedgerSequenceValue,
       fakedRawTransactionStatusValue,
       fakedAccountExistsValue,
       fakedTransactionHistoryValue,
     )
-    reliableSubmissionClient = new ReliableSubmissionXRPClient(fakeXRPClient)
+    this.reliableSubmissionClient = new ReliableSubmissionXRPClient(
+      this.fakeXRPClient,
+    )
   })
 
   it('Get Account Balance - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` WHEN a balance is retrieved.
-    const returnedValue = await reliableSubmissionClient.getBalance(testAddress)
+    const returnedValue = await this.reliableSubmissionClient.getBalance(
+      testAddress,
+    )
 
     // THEN the result is returned unaltered.
     assert.deepEqual(returnedValue, fakedGetBalanceValue)
@@ -58,7 +59,7 @@ describe('Reliable Submission XRP Client', function (): void {
 
   it('Get Payment Status - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` WHEN a transaction status is retrieved.
-    const returnedValue = await reliableSubmissionClient.getPaymentStatus(
+    const returnedValue = await this.reliableSubmissionClient.getPaymentStatus(
       testAddress,
     )
 
@@ -68,15 +69,15 @@ describe('Reliable Submission XRP Client', function (): void {
 
   it('Get Latest Ledger Sequence - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` WHEN the latest ledger sequence is retrieved.
-    const returnedValue = await reliableSubmissionClient.getCurrentOpenLedgerSequence()
+    const returnedValue = await this.reliableSubmissionClient.getLastValidatedLedgerSequence()
 
     // THEN the result is returned unaltered.
-    assert.deepEqual(returnedValue, fakeCurrentOpenLedgerSequenceValue)
+    assert.deepEqual(returnedValue, fakedLastLedgerSequenceValue)
   })
 
   it('Get Raw Transaction Status - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` WHEN a raw transaction status is retrieved.
-    const returnedValue = await reliableSubmissionClient.getRawTransactionStatus(
+    const returnedValue = await this.reliableSubmissionClient.getRawTransactionStatus(
       testAddress,
     )
 
@@ -92,12 +93,12 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       const latestLedgerSequence =
         fakedRawTransactionStatusLastLedgerSequenceValue + 1
-      fakeXRPClient.getCurrentOpenLedgerSequenceValue = latestLedgerSequence
+      this.fakeXRPClient.latestLedgerSequence = latestLedgerSequence
     }, 200)
     const { wallet } = Wallet.generateRandomWallet()!
 
     // WHEN a reliable send is submitted
-    const transactionHash = await reliableSubmissionClient.send(
+    const transactionHash = await this.reliableSubmissionClient.send(
       '1',
       testAddress,
       wallet,
@@ -118,7 +119,7 @@ describe('Reliable Submission XRP Client', function (): void {
     const { wallet } = Wallet.generateRandomWallet()!
 
     // WHEN a reliable send is submitted
-    const transactionHash = await reliableSubmissionClient.send(
+    const transactionHash = await this.reliableSubmissionClient.send(
       '1',
       testAddress,
       wallet,
@@ -139,11 +140,11 @@ describe('Reliable Submission XRP Client', function (): void {
       0,
       fakedFullPaymentValue,
     )
-    fakeXRPClient.getRawTransactionStatusValue = malformedRawTransactionStatus
+    this.fakeXRPClient.getRawTransactionStatusValue = malformedRawTransactionStatus
     const { wallet } = Wallet.generateRandomWallet()!
 
     // WHEN `send` is called THEN the promise is rejected.
-    reliableSubmissionClient
+    this.reliableSubmissionClient
       .send('1', testAddress, wallet)
       .then(() => {})
       .catch(() => done())
@@ -151,7 +152,7 @@ describe('Reliable Submission XRP Client', function (): void {
 
   it('Payment History - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXRPClient` decorating a `FakeXRPClient` WHEN transaction history is retrieved.
-    const returnedValue = await reliableSubmissionClient.paymentHistory(
+    const returnedValue = await this.reliableSubmissionClient.paymentHistory(
       testAddress,
     )
 

--- a/test/Xpring/xpring-client-test.ts
+++ b/test/Xpring/xpring-client-test.ts
@@ -13,7 +13,7 @@ import XpringError from '../../src/Xpring/xpring-error'
 const fakeBalance = bigInt(10)
 const fakePaymentStatus = TransactionStatus.Succeeded
 const fakeTransactionHash = 'deadbeefdeadbeefdeadbeef'
-const fakeCurrentOpenLedgerSequenceValue = 10
+const fakeLastLedgerSequenceValue = 10
 const fakeAccountExistsResult = true
 const fakeRawTransactionStatus = new RawTransactionStatus(
   true,
@@ -44,7 +44,7 @@ describe('Xpring Client', function (): void {
       fakeBalance,
       fakePaymentStatus,
       expectedTransactionHash,
-      fakeCurrentOpenLedgerSequenceValue,
+      fakeLastLedgerSequenceValue,
       fakeRawTransactionStatus,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,
@@ -69,7 +69,7 @@ describe('Xpring Client', function (): void {
       fakeBalance,
       fakePaymentStatus,
       expectedTransactionHash,
-      fakeCurrentOpenLedgerSequenceValue,
+      fakeLastLedgerSequenceValue,
       fakeRawTransactionStatus,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,
@@ -93,7 +93,7 @@ describe('Xpring Client', function (): void {
       fakeBalance,
       fakePaymentStatus,
       xrpError,
-      fakeCurrentOpenLedgerSequenceValue,
+      fakeLastLedgerSequenceValue,
       fakeRawTransactionStatus,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,
@@ -118,7 +118,7 @@ describe('Xpring Client', function (): void {
       fakeBalance,
       fakePaymentStatus,
       xrpError,
-      fakeCurrentOpenLedgerSequenceValue,
+      fakeLastLedgerSequenceValue,
       fakeRawTransactionStatus,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,
@@ -142,7 +142,7 @@ describe('Xpring Client', function (): void {
       fakeBalance,
       fakePaymentStatus,
       fakeTransactionHash,
-      fakeCurrentOpenLedgerSequenceValue,
+      fakeLastLedgerSequenceValue,
       fakeRawTransactionStatus,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,


### PR DESCRIPTION
Reverts xpring-eng/Xpring-JS#455. 

I'm going to fix this in the same style as https://github.com/xpring-eng/XpringKit/pull/216.  It's easier to revert and do a clean PR than to try to build on top. 