### PR TITLE
Properly namespace `XRPUtils` for export/import hygiene

### DIFF
--- a/src/XRP/index.ts
+++ b/src/XRP/index.ts
@@ -1,6 +1,7 @@
 export { default as RippledFlags } from './rippled-flags'
 export { default as TransactionStatus } from './transaction-status'
 export { default as XRPClient } from './xrp-client'
+export { default as XRPUtils } from './xrp-utils'
 export {
   XRPCurrencyAmount,
   XRPCurrency,

--- a/src/XRP/index.ts
+++ b/src/XRP/index.ts
@@ -2,15 +2,3 @@ export { default as RippledFlags } from './rippled-flags'
 export { default as TransactionStatus } from './transaction-status'
 export { default as XRPClient } from './xrp-client'
 export { default as XRPUtils } from './xrp-utils'
-export {
-  XRPCurrencyAmount,
-  XRPCurrency,
-  XRPIssuedCurrency,
-  XRPMemo,
-  XRPPathElement,
-  XRPPath,
-  XRPPayment,
-  XRPSigner,
-  XRPTransactionType,
-  XRPTransaction,
-} from './model'

--- a/src/XRP/xrp-utils.ts
+++ b/src/XRP/xrp-utils.ts
@@ -1,117 +1,113 @@
-/* eslint-disable no-inner-declarations */
-/* eslint-disable @typescript-eslint/no-namespace */
 import BigNumber from 'bignumber.js'
 import { XRPErrorType, XRPError } from '..'
 
-namespace XRPUtils {
-  export function dropsToXrp(drops: BigNumber.Value): string {
-    const dropsRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
+function dropsToXrp(drops: BigNumber.Value): string {
+  const dropsRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
 
-    if (typeof drops === 'string') {
-      if (!dropsRegEx.exec(drops)) {
-        throw new XRPError(
-          XRPErrorType.InvalidInput,
-          `dropsToXrp: invalid value '${drops}',` +
-            ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
-        )
-      } else if (drops === '.') {
-        throw new XRPError(
-          XRPErrorType.InvalidInput,
-          `dropsToXrp: invalid value '${drops}',` +
-            ` should be a BigNumber or string-encoded number.`,
-        )
-      }
-    }
-
-    // Converting to BigNumber and then back to string should remove any
-    // decimal point followed by zeros, e.g. '1.00'.
-    // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
-    // eslint-disable-next-line no-param-reassign
-    drops = new BigNumber(drops).toString(10)
-
-    // drops are only whole units
-    if (drops.includes('.')) {
-      throw new XRPError(
-        XRPErrorType.InvalidInput,
-        `dropsToXrp: value '${drops}' has too many decimal places.`,
-      )
-    }
-
-    // This should never happen; the value has already been
-    // validated above. This just ensures BigNumber did not do
-    // something unexpected.
-
+  if (typeof drops === 'string') {
     if (!dropsRegEx.exec(drops)) {
       throw new XRPError(
         XRPErrorType.InvalidInput,
-        `dropsToXrp: failed sanity check -` +
-          ` value '${drops}',` +
-          ` does not match (^-?[0-9]+$).`,
+        `dropsToXrp: invalid value '${drops}',` +
+          ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
+      )
+    } else if (drops === '.') {
+      throw new XRPError(
+        XRPErrorType.InvalidInput,
+        `dropsToXrp: invalid value '${drops}',` +
+          ` should be a BigNumber or string-encoded number.`,
       )
     }
-
-    return new BigNumber(drops).dividedBy(1000000.0).toString(10)
   }
 
-  export function xrpToDrops(xrp: BigNumber.Value): string {
-    const xrpRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
+  // Converting to BigNumber and then back to string should remove any
+  // decimal point followed by zeros, e.g. '1.00'.
+  // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
+  // eslint-disable-next-line no-param-reassign
+  drops = new BigNumber(drops).toString(10)
 
-    if (typeof xrp === 'string') {
-      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-      if (!xrpRegEx.exec(xrp)) {
-        throw new XRPError(
-          XRPErrorType.InvalidInput,
-          `xrpToDrops: invalid value '${xrp}',` +
-            ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
-        )
-      } else if (xrp === '.') {
-        throw new XRPError(
-          XRPErrorType.InvalidInput,
-          `xrpToDrops: invalid value '${xrp}',` +
-            ` should be a BigNumber or string-encoded number.`,
-        )
-      }
-    }
+  // drops are only whole units
+  if (drops.includes('.')) {
+    throw new XRPError(
+      XRPErrorType.InvalidInput,
+      `dropsToXrp: value '${drops}' has too many decimal places.`,
+    )
+  }
 
-    // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
-    // eslint-disable-next-line no-param-reassign
-    xrp = new BigNumber(xrp).toString(10)
+  // This should never happen; the value has already been
+  // validated above. This just ensures BigNumber did not do
+  // something unexpected.
 
-    // This should never happen; the value has already been
-    // validated above. This just ensures BigNumber did not do
-    // something unexpected.
+  if (!dropsRegEx.exec(drops)) {
+    throw new XRPError(
+      XRPErrorType.InvalidInput,
+      `dropsToXrp: failed sanity check -` +
+        ` value '${drops}',` +
+        ` does not match (^-?[0-9]+$).`,
+    )
+  }
+
+  return new BigNumber(drops).dividedBy(1000000.0).toString(10)
+}
+
+function xrpToDrops(xrp: BigNumber.Value): string {
+  const xrpRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
+
+  if (typeof xrp === 'string') {
+    // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
     if (!xrpRegEx.exec(xrp)) {
       throw new XRPError(
         XRPErrorType.InvalidInput,
-        `xrpToDrops: failed sanity check -` +
-          ` value '${xrp}',` +
-          ` does not match (^-?[0-9.]+$).`,
+        `xrpToDrops: invalid value '${xrp}',` +
+          ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
       )
-    }
-
-    const components = xrp.split('.')
-    if (components.length > 2) {
+    } else if (xrp === '.') {
       throw new XRPError(
         XRPErrorType.InvalidInput,
-        `xrpToDrops: failed sanity check -` +
-          ` value '${xrp}' has` +
-          ` too many decimal points.`,
+        `xrpToDrops: invalid value '${xrp}',` +
+          ` should be a BigNumber or string-encoded number.`,
       )
     }
-
-    const fraction = components[1] || '0'
-    if (fraction.length > 6) {
-      throw new XRPError(
-        XRPErrorType.InvalidInput,
-        `xrpToDrops: value '${xrp}' has too many decimal places.`,
-      )
-    }
-
-    return new BigNumber(xrp)
-      .times(1000000.0)
-      .integerValue(BigNumber.ROUND_FLOOR)
-      .toString(10)
   }
+
+  // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
+  // eslint-disable-next-line no-param-reassign
+  xrp = new BigNumber(xrp).toString(10)
+
+  // This should never happen; the value has already been
+  // validated above. This just ensures BigNumber did not do
+  // something unexpected.
+  if (!xrpRegEx.exec(xrp)) {
+    throw new XRPError(
+      XRPErrorType.InvalidInput,
+      `xrpToDrops: failed sanity check -` +
+        ` value '${xrp}',` +
+        ` does not match (^-?[0-9.]+$).`,
+    )
+  }
+
+  const components = xrp.split('.')
+  if (components.length > 2) {
+    throw new XRPError(
+      XRPErrorType.InvalidInput,
+      `xrpToDrops: failed sanity check -` +
+        ` value '${xrp}' has` +
+        ` too many decimal points.`,
+    )
+  }
+
+  const fraction = components[1] || '0'
+  if (fraction.length > 6) {
+    throw new XRPError(
+      XRPErrorType.InvalidInput,
+      `xrpToDrops: value '${xrp}' has too many decimal places.`,
+    )
+  }
+
+  return new BigNumber(xrp)
+    .times(1000000.0)
+    .integerValue(BigNumber.ROUND_FLOOR)
+    .toString(10)
 }
 
-export default XRPUtils
+export default { xrpToDrops, dropsToXrp }

--- a/src/XRP/xrp-utils.ts
+++ b/src/XRP/xrp-utils.ts
@@ -110,4 +110,5 @@ function xrpToDrops(xrp: BigNumber.Value): string {
     .toString(10)
 }
 
-export default { xrpToDrops, dropsToXrp }
+const XRPUtils = { dropsToXrp, xrpToDrops }
+export default XRPUtils

--- a/src/XRP/xrp-utils.ts
+++ b/src/XRP/xrp-utils.ts
@@ -1,113 +1,117 @@
+/* eslint-disable no-inner-declarations */
+/* eslint-disable @typescript-eslint/no-namespace */
 import BigNumber from 'bignumber.js'
 import { XRPErrorType, XRPError } from '..'
 
-function dropsToXrp(drops: BigNumber.Value): string {
-  const dropsRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
+namespace XRPUtils {
+  export function dropsToXrp(drops: BigNumber.Value): string {
+    const dropsRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
 
-  if (typeof drops === 'string') {
+    if (typeof drops === 'string') {
+      if (!dropsRegEx.exec(drops)) {
+        throw new XRPError(
+          XRPErrorType.InvalidInput,
+          `dropsToXrp: invalid value '${drops}',` +
+            ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
+        )
+      } else if (drops === '.') {
+        throw new XRPError(
+          XRPErrorType.InvalidInput,
+          `dropsToXrp: invalid value '${drops}',` +
+            ` should be a BigNumber or string-encoded number.`,
+        )
+      }
+    }
+
+    // Converting to BigNumber and then back to string should remove any
+    // decimal point followed by zeros, e.g. '1.00'.
+    // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
+    // eslint-disable-next-line no-param-reassign
+    drops = new BigNumber(drops).toString(10)
+
+    // drops are only whole units
+    if (drops.includes('.')) {
+      throw new XRPError(
+        XRPErrorType.InvalidInput,
+        `dropsToXrp: value '${drops}' has too many decimal places.`,
+      )
+    }
+
+    // This should never happen; the value has already been
+    // validated above. This just ensures BigNumber did not do
+    // something unexpected.
+
     if (!dropsRegEx.exec(drops)) {
       throw new XRPError(
         XRPErrorType.InvalidInput,
-        `dropsToXrp: invalid value '${drops}',` +
-          ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
-      )
-    } else if (drops === '.') {
-      throw new XRPError(
-        XRPErrorType.InvalidInput,
-        `dropsToXrp: invalid value '${drops}',` +
-          ` should be a BigNumber or string-encoded number.`,
+        `dropsToXrp: failed sanity check -` +
+          ` value '${drops}',` +
+          ` does not match (^-?[0-9]+$).`,
       )
     }
+
+    return new BigNumber(drops).dividedBy(1000000.0).toString(10)
   }
 
-  // Converting to BigNumber and then back to string should remove any
-  // decimal point followed by zeros, e.g. '1.00'.
-  // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
-  // eslint-disable-next-line no-param-reassign
-  drops = new BigNumber(drops).toString(10)
+  export function xrpToDrops(xrp: BigNumber.Value): string {
+    const xrpRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
 
-  // drops are only whole units
-  if (drops.includes('.')) {
-    throw new XRPError(
-      XRPErrorType.InvalidInput,
-      `dropsToXrp: value '${drops}' has too many decimal places.`,
-    )
-  }
+    if (typeof xrp === 'string') {
+      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+      if (!xrpRegEx.exec(xrp)) {
+        throw new XRPError(
+          XRPErrorType.InvalidInput,
+          `xrpToDrops: invalid value '${xrp}',` +
+            ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
+        )
+      } else if (xrp === '.') {
+        throw new XRPError(
+          XRPErrorType.InvalidInput,
+          `xrpToDrops: invalid value '${xrp}',` +
+            ` should be a BigNumber or string-encoded number.`,
+        )
+      }
+    }
 
-  // This should never happen; the value has already been
-  // validated above. This just ensures BigNumber did not do
-  // something unexpected.
+    // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
+    // eslint-disable-next-line no-param-reassign
+    xrp = new BigNumber(xrp).toString(10)
 
-  if (!dropsRegEx.exec(drops)) {
-    throw new XRPError(
-      XRPErrorType.InvalidInput,
-      `dropsToXrp: failed sanity check -` +
-        ` value '${drops}',` +
-        ` does not match (^-?[0-9]+$).`,
-    )
-  }
-
-  return new BigNumber(drops).dividedBy(1000000.0).toString(10)
-}
-
-function xrpToDrops(xrp: BigNumber.Value): string {
-  const xrpRegEx = RegExp(/^-?[0-9]*\.?[0-9]*$/)
-
-  if (typeof xrp === 'string') {
-    // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+    // This should never happen; the value has already been
+    // validated above. This just ensures BigNumber did not do
+    // something unexpected.
     if (!xrpRegEx.exec(xrp)) {
       throw new XRPError(
         XRPErrorType.InvalidInput,
-        `xrpToDrops: invalid value '${xrp}',` +
-          ` should be a number matching (^-?[0-9]*\\.?[0-9]*$).`,
-      )
-    } else if (xrp === '.') {
-      throw new XRPError(
-        XRPErrorType.InvalidInput,
-        `xrpToDrops: invalid value '${xrp}',` +
-          ` should be a BigNumber or string-encoded number.`,
+        `xrpToDrops: failed sanity check -` +
+          ` value '${xrp}',` +
+          ` does not match (^-?[0-9.]+$).`,
       )
     }
+
+    const components = xrp.split('.')
+    if (components.length > 2) {
+      throw new XRPError(
+        XRPErrorType.InvalidInput,
+        `xrpToDrops: failed sanity check -` +
+          ` value '${xrp}' has` +
+          ` too many decimal points.`,
+      )
+    }
+
+    const fraction = components[1] || '0'
+    if (fraction.length > 6) {
+      throw new XRPError(
+        XRPErrorType.InvalidInput,
+        `xrpToDrops: value '${xrp}' has too many decimal places.`,
+      )
+    }
+
+    return new BigNumber(xrp)
+      .times(1000000.0)
+      .integerValue(BigNumber.ROUND_FLOOR)
+      .toString(10)
   }
-
-  // Important: specify base 10 to avoid exponential notation, e.g. '1e-7'.
-  // eslint-disable-next-line no-param-reassign
-  xrp = new BigNumber(xrp).toString(10)
-
-  // This should never happen; the value has already been
-  // validated above. This just ensures BigNumber did not do
-  // something unexpected.
-  if (!xrpRegEx.exec(xrp)) {
-    throw new XRPError(
-      XRPErrorType.InvalidInput,
-      `xrpToDrops: failed sanity check -` +
-        ` value '${xrp}',` +
-        ` does not match (^-?[0-9.]+$).`,
-    )
-  }
-
-  const components = xrp.split('.')
-  if (components.length > 2) {
-    throw new XRPError(
-      XRPErrorType.InvalidInput,
-      `xrpToDrops: failed sanity check -` +
-        ` value '${xrp}' has` +
-        ` too many decimal points.`,
-    )
-  }
-
-  const fraction = components[1] || '0'
-  if (fraction.length > 6) {
-    throw new XRPError(
-      XRPErrorType.InvalidInput,
-      `xrpToDrops: value '${xrp}' has too many decimal places.`,
-    )
-  }
-
-  return new BigNumber(xrp)
-    .times(1000000.0)
-    .integerValue(BigNumber.ROUND_FLOOR)
-    .toString(10)
 }
 
-export { xrpToDrops, dropsToXrp }
+export default XRPUtils

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export { default as XpringClient } from './Xpring/xpring-client'
 export { default as XRPError, XRPErrorType } from './XRP/xrp-error'
 export { default as IlpError, IlpErrorType } from './ILP/ilp-error'
 export { default as XRPPayIDClient } from './PayID/xrp-pay-id-client'
-
+export { XRPUtils } from './XRP'
 export { RippledFlags, TransactionStatus, XRPClient } from './XRP'
 export {
   XRPCurrencyAmount,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,4 +27,4 @@ export {
   XRPSigner,
   XRPTransactionType,
   XRPTransaction,
-} from './XRP'
+} from './XRP/model'

--- a/test/XRP/xrp-utils-test.ts
+++ b/test/XRP/xrp-utils-test.ts
@@ -1,13 +1,13 @@
 import { assert } from 'chai'
 import BigNumber from 'bignumber.js'
-import { dropsToXrp, xrpToDrops } from '../../src/XRP/xrp-utils'
+import { XRPUtils } from '../../src'
 import 'mocha'
 
 describe('xrp-drops-conversion', function (): void {
   // xrpToDrops and dropsToXrp tests
   it('dropsToXrp() - works with a typical amount', function (): void {
     // GIVEN a typical, valid drops value, WHEN converted to xrp
-    const xrp = dropsToXrp('2000000')
+    const xrp = XRPUtils.dropsToXrp('2000000')
 
     // THEN the conversion is as expected
     assert.strictEqual(xrp, '2', '2 million drops equals 2 XRP')
@@ -16,43 +16,43 @@ describe('xrp-drops-conversion', function (): void {
   it('dropsToXrp() - works with fractions', function (): void {
     // GIVEN drops amounts that convert to fractional xrp amounts
     // WHEN converted to xrp THEN the conversion is as expected
-    let xrp = dropsToXrp('3456789')
+    let xrp = XRPUtils.dropsToXrp('3456789')
     assert.strictEqual(xrp, '3.456789', '3,456,789 drops equals 3.456789 XRP')
 
-    xrp = dropsToXrp('3400000')
+    xrp = XRPUtils.dropsToXrp('3400000')
     assert.strictEqual(xrp, '3.4', '3,400,000 drops equals 3.4 XRP')
 
-    xrp = dropsToXrp('1')
+    xrp = XRPUtils.dropsToXrp('1')
     assert.strictEqual(xrp, '0.000001', '1 drop equals 0.000001 XRP')
 
-    xrp = dropsToXrp('1.0')
+    xrp = XRPUtils.dropsToXrp('1.0')
     assert.strictEqual(xrp, '0.000001', '1.0 drops equals 0.000001 XRP')
 
-    xrp = dropsToXrp('1.00')
+    xrp = XRPUtils.dropsToXrp('1.00')
     assert.strictEqual(xrp, '0.000001', '1.00 drops equals 0.000001 XRP')
   })
 
   it('dropsToXrp() - works with zero', function (): void {
     // GIVEN several equivalent representations of zero
     // WHEN converted to xrp, THEN the result is zero
-    let xrp = dropsToXrp('0')
+    let xrp = XRPUtils.dropsToXrp('0')
     assert.strictEqual(xrp, '0', '0 drops equals 0 XRP')
 
     // negative zero is equivalent to zero
-    xrp = dropsToXrp('-0')
+    xrp = XRPUtils.dropsToXrp('-0')
     assert.strictEqual(xrp, '0', '-0 drops equals 0 XRP')
 
-    xrp = dropsToXrp('0.00')
+    xrp = XRPUtils.dropsToXrp('0.00')
     assert.strictEqual(xrp, '0', '0.00 drops equals 0 XRP')
 
-    xrp = dropsToXrp('000000000')
+    xrp = XRPUtils.dropsToXrp('000000000')
     assert.strictEqual(xrp, '0', '000000000 drops equals 0 XRP')
   })
 
   it('dropsToXrp() - works with a negative value', function (): void {
     // GIVEN a negative drops amount
     // WHEN converted to xrp
-    const xrp = dropsToXrp('-2000000')
+    const xrp = XRPUtils.dropsToXrp('-2000000')
 
     // THEN the conversion is also negative
     assert.strictEqual(xrp, '-2', '-2 million drops equals -2 XRP')
@@ -61,30 +61,30 @@ describe('xrp-drops-conversion', function (): void {
   it('dropsToXrp() - works with a value ending with a decimal point', function (): void {
     // GIVEN a positive or negative drops amount that ends with a decimal point
     // WHEN converted to xrp THEN the conversion is successful and correct
-    let xrp = dropsToXrp('2000000.')
+    let xrp = XRPUtils.dropsToXrp('2000000.')
     assert.strictEqual(xrp, '2', '2000000. drops equals 2 XRP')
 
-    xrp = dropsToXrp('-2000000.')
+    xrp = XRPUtils.dropsToXrp('-2000000.')
     assert.strictEqual(xrp, '-2', '-2000000. drops equals -2 XRP')
   })
 
   it('dropsToXrp() - works with BigNumber objects', function (): void {
     // GIVEN drops amounts represented as BigNumber objects
     // WHEN converted to xrp THEN the conversions are correct and successful
-    let xrp = dropsToXrp(new BigNumber(2000000))
+    let xrp = XRPUtils.dropsToXrp(new BigNumber(2000000))
     assert.strictEqual(xrp, '2', '(BigNumber) 2 million drops equals 2 XRP')
 
-    xrp = dropsToXrp(new BigNumber(-2000000))
+    xrp = XRPUtils.dropsToXrp(new BigNumber(-2000000))
     assert.strictEqual(xrp, '-2', '(BigNumber) -2 million drops equals -2 XRP')
 
-    xrp = dropsToXrp(new BigNumber(2345678))
+    xrp = XRPUtils.dropsToXrp(new BigNumber(2345678))
     assert.strictEqual(
       xrp,
       '2.345678',
       '(BigNumber) 2,345,678 drops equals 2.345678 XRP',
     )
 
-    xrp = dropsToXrp(new BigNumber(-2345678))
+    xrp = XRPUtils.dropsToXrp(new BigNumber(-2345678))
     assert.strictEqual(
       xrp,
       '-2.345678',
@@ -97,39 +97,39 @@ describe('xrp-drops-conversion', function (): void {
 
     // GIVEN a drops amount represented as a positive or negative number
     // WHEN converted to xrp THEN the conversion is correct and successful
-    let xrp = dropsToXrp(2000000)
+    let xrp = XRPUtils.dropsToXrp(2000000)
     assert.strictEqual(xrp, '2', '(number) 2 million drops equals 2 XRP')
 
-    xrp = dropsToXrp(-2000000)
+    xrp = XRPUtils.dropsToXrp(-2000000)
     assert.strictEqual(xrp, '-2', '(number) -2 million drops equals -2 XRP')
   })
 
   it('dropsToXrp() - throws with an amount with too many decimal places', function (): void {
     assert.throws(() => {
-      dropsToXrp('1.2')
+      XRPUtils.dropsToXrp('1.2')
     }, /has too many decimal places/)
 
     assert.throws(() => {
-      dropsToXrp('0.10')
+      XRPUtils.dropsToXrp('0.10')
     }, /has too many decimal places/)
   })
 
   it('dropsToXrp() - throws with an invalid value', function (): void {
     // GIVEN invalid drops values, WHEN converted to xrp, THEN an error is thrown
     assert.throws(() => {
-      dropsToXrp('FOO')
+      XRPUtils.dropsToXrp('FOO')
     }, /invalid value/)
 
     assert.throws(() => {
-      dropsToXrp('1e-7')
+      XRPUtils.dropsToXrp('1e-7')
     }, /invalid value/)
 
     assert.throws(() => {
-      dropsToXrp('2,0')
+      XRPUtils.dropsToXrp('2,0')
     }, /invalid value/)
 
     assert.throws(() => {
-      dropsToXrp('.')
+      XRPUtils.dropsToXrp('.')
     }, /dropsToXrp: invalid value '\.', should be a BigNumber or string-encoded number\./)
   })
 
@@ -137,18 +137,18 @@ describe('xrp-drops-conversion', function (): void {
     // GIVEN invalid drops values that contain more than one decimal point
     // WHEN converted to xrp THEN an error is thrown
     assert.throws(() => {
-      dropsToXrp('1.0.0')
+      XRPUtils.dropsToXrp('1.0.0')
     }, /dropsToXrp: invalid value '1\.0\.0'/)
 
     assert.throws(() => {
-      dropsToXrp('...')
+      XRPUtils.dropsToXrp('...')
     }, /dropsToXrp: invalid value '\.\.\.'/)
   })
 
   it('xrpToDrops() - works with a typical amount', function (): void {
     // GIVEN an xrp amoun that is typical and valid
     // WHEN converted to drops
-    const drops = xrpToDrops('2')
+    const drops = XRPUtils.xrpToDrops('2')
 
     // THEN the conversion is successful and correct
     assert.strictEqual(drops, '2000000', '2 XRP equals 2 million drops')
@@ -157,55 +157,55 @@ describe('xrp-drops-conversion', function (): void {
   it('xrpToDrops() - works with fractions', function (): void {
     // GIVEN xrp amounts that are fractional
     // WHEN converted to drops THEN the conversions are successful and correct
-    let drops = xrpToDrops('3.456789')
+    let drops = XRPUtils.xrpToDrops('3.456789')
     assert.strictEqual(drops, '3456789', '3.456789 XRP equals 3,456,789 drops')
-    drops = xrpToDrops('3.400000')
+    drops = XRPUtils.xrpToDrops('3.400000')
     assert.strictEqual(drops, '3400000', '3.400000 XRP equals 3,400,000 drops')
-    drops = xrpToDrops('0.000001')
+    drops = XRPUtils.xrpToDrops('0.000001')
     assert.strictEqual(drops, '1', '0.000001 XRP equals 1 drop')
-    drops = xrpToDrops('0.0000010')
+    drops = XRPUtils.xrpToDrops('0.0000010')
     assert.strictEqual(drops, '1', '0.0000010 XRP equals 1 drop')
   })
 
   it('xrpToDrops() - works with zero', function (): void {
     // GIVEN xrp amounts that are various equivalent representations of zero
     // WHEN converted to drops THEN the conversions are equal to zero
-    let drops = xrpToDrops('0')
+    let drops = XRPUtils.xrpToDrops('0')
     assert.strictEqual(drops, '0', '0 XRP equals 0 drops')
-    drops = xrpToDrops('-0') // negative zero is equivalent to zero
+    drops = XRPUtils.xrpToDrops('-0') // negative zero is equivalent to zero
     assert.strictEqual(drops, '0', '-0 XRP equals 0 drops')
-    drops = xrpToDrops('0.000000')
+    drops = XRPUtils.xrpToDrops('0.000000')
     assert.strictEqual(drops, '0', '0.000000 XRP equals 0 drops')
-    drops = xrpToDrops('0.0000000')
+    drops = XRPUtils.xrpToDrops('0.0000000')
     assert.strictEqual(drops, '0', '0.0000000 XRP equals 0 drops')
   })
 
   it('xrpToDrops() - works with a negative value', function (): void {
     // GIVEN a negative xrp amount
     // WHEN converted to drops THEN the conversion is also negative
-    const drops = xrpToDrops('-2')
+    const drops = XRPUtils.xrpToDrops('-2')
     assert.strictEqual(drops, '-2000000', '-2 XRP equals -2 million drops')
   })
 
   it('xrpToDrops() - works with a value ending with a decimal point', function (): void {
     // GIVEN an xrp amount that ends with a decimal point
     // WHEN converted to drops THEN the conversion is correct and successful
-    let drops = xrpToDrops('2.')
+    let drops = XRPUtils.xrpToDrops('2.')
     assert.strictEqual(drops, '2000000', '2. XRP equals 2000000 drops')
-    drops = xrpToDrops('-2.')
+    drops = XRPUtils.xrpToDrops('-2.')
     assert.strictEqual(drops, '-2000000', '-2. XRP equals -2000000 drops')
   })
 
   it('xrpToDrops() - works with BigNumber objects', function (): void {
     // GIVEN an xrp amount represented as a BigNumber object
     // WHEN converted to drops THEN the conversion is correct and successful
-    let drops = xrpToDrops(new BigNumber(2))
+    let drops = XRPUtils.xrpToDrops(new BigNumber(2))
     assert.strictEqual(
       drops,
       '2000000',
       '(BigNumber) 2 XRP equals 2 million drops',
     )
-    drops = xrpToDrops(new BigNumber(-2))
+    drops = XRPUtils.xrpToDrops(new BigNumber(-2))
     assert.strictEqual(
       drops,
       '-2000000',
@@ -218,13 +218,13 @@ describe('xrp-drops-conversion', function (): void {
 
     // GIVEN an xrp amounts represented as a number (positive and negative)
     // WHEN converted to drops THEN the conversions are successful and correct
-    let drops = xrpToDrops(2)
+    let drops = XRPUtils.xrpToDrops(2)
     assert.strictEqual(
       drops,
       '2000000',
       '(number) 2 XRP equals 2 million drops',
     )
-    drops = xrpToDrops(-2)
+    drops = XRPUtils.xrpToDrops(-2)
     assert.strictEqual(
       drops,
       '-2000000',
@@ -236,10 +236,10 @@ describe('xrp-drops-conversion', function (): void {
     // GIVEN an xrp amount with too many decimal places
     // WHEN converted to a drops amount THEN an error is thrown
     assert.throws(() => {
-      xrpToDrops('1.1234567')
+      XRPUtils.xrpToDrops('1.1234567')
     }, /has too many decimal places/)
     assert.throws(() => {
-      xrpToDrops('0.0000001')
+      XRPUtils.xrpToDrops('0.0000001')
     }, /has too many decimal places/)
   })
 
@@ -247,16 +247,16 @@ describe('xrp-drops-conversion', function (): void {
     // GIVEN xrp amounts represented as various invalid values
     // WHEN converted to drops THEN an error is thrown
     assert.throws(() => {
-      xrpToDrops('FOO')
+      XRPUtils.xrpToDrops('FOO')
     }, /invalid value/)
     assert.throws(() => {
-      xrpToDrops('1e-7')
+      XRPUtils.xrpToDrops('1e-7')
     }, /invalid value/)
     assert.throws(() => {
-      xrpToDrops('2,0')
+      XRPUtils.xrpToDrops('2,0')
     }, /invalid value/)
     assert.throws(() => {
-      xrpToDrops('.')
+      XRPUtils.xrpToDrops('.')
     }, /xrpToDrops: invalid value '\.', should be a BigNumber or string-encoded number\./)
   })
 
@@ -264,10 +264,10 @@ describe('xrp-drops-conversion', function (): void {
     // GIVEN an xrp amount with more than one decimal point, or all decimal points
     // WHEN converted to drops THEN an error is thrown
     assert.throws(() => {
-      xrpToDrops('1.0.0')
+      XRPUtils.xrpToDrops('1.0.0')
     }, /xrpToDrops: invalid value '1\.0\.0'/)
     assert.throws(() => {
-      xrpToDrops('...')
+      XRPUtils.xrpToDrops('...')
     }, /xrpToDrops: invalid value '\.\.\.'/)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change
This PR fixes the namespacing problems WRT `xrpToDrops` and `dropsToXrp` utility functions.  Initially, I had these exported naked at the top level of `xpring-js`.  In an effort to keep things organized, these should be namespaced as `XRPUtils`.  However, I did that wrong by removing the top-level exports and believing I could import based on the directory structure in a similar way to other languages' package style (Java Python etc.), but that doesn't work and led to an import statement all the way from `node_modules` in the wallet.   This PR should achieve the goal.

This will be a breaking change for the Wallet, which should change its import to:
`import {...., XRPUtils} from 'xpring-js'`
And should then resolve scope with:
`  ... XRPUtils.xrpToDrops(...) .. ` etc. 

@keefertaylor : There are utilities in `xpring-common-js` that are currently being exported as `Utils` from `xpring-js`.  Maybe we should audit this situation and decide of any of those should be considered `XRPUtils`, and the rest we could consider exporting as `XpringUtils` or something... just because `Utils` is such a pollutant.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Keep the SDKs organized.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)


## Before / After
`xrpToDrops` and `dropsToXrp` available in `XRPUtils`
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI
Also tested wallet imports via `npm link`
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
