### PR TITLE
Updates in response to breaking PayID changes - Public API

### DIFF
--- a/pay-id-api-spec/pay-id.v1.yml
+++ b/pay-id-api-spec/pay-id.v1.yml
@@ -147,7 +147,7 @@ components:
       properties:
         paymentNetwork:
           type: string
-        environment?:
+        environment:
           type: string
         addressDetailsType:
           type: string
@@ -162,7 +162,9 @@ components:
       type: object
       properties:
         addresses:
-          type: Address[]
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
         proofOfControlSignature:
           type: string
         payId:

--- a/pay-id-api-spec/pay-id.v1.yml
+++ b/pay-id-api-spec/pay-id.v1.yml
@@ -141,21 +141,36 @@ components:
           type: string
       required:
         - address
-    PaymentInformation:
-      title: PaymentInformation
+    Address:
+      title: Address
       type: object
       properties:
+        paymentNetwork:
+          type: string
+        environment?:
+          type: string
         addressDetailsType:
           type: string
         addressDetails:
           $ref: '#/components/schemas/CryptoAddressDetails'
-        proof_of_control_signature:
-          type: string
-        paymentPointer:
-          type: string
       required:
+        - paymentNetwork
         - addressDetailsType
         - addressDetails
+    PaymentInformation:
+      title: PaymentInformation
+      type: object
+      properties:
+        addresses:
+          type: Address[]
+        proofOfControlSignature:
+          type: string
+        payId:
+          type: string
+        memo:
+          type: string
+      required:
+        - addresses
     Invoice:
       title: Invoice
       type: object

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -89,8 +89,8 @@ export default class PayIDClient {
         throw new PayIDError(PayIDErrorType.UnexpectedResponse, message)
       }
       // TODO(keefertaylor): make sure the header matches the request.
-    } else if (data?.addressDetails) {
-      return data.addressDetails
+    } else if (data?.addresses) {
+      return data.addresses[0].addressDetails
     } else {
       throw new PayIDError(PayIDErrorType.UnexpectedResponse)
     }

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -90,6 +90,7 @@ export default class PayIDClient {
       }
       // TODO(keefertaylor): make sure the header matches the request.
     } else if (data?.addresses) {
+      // TODO(amiecorso): what if addresses is empty or contains more than one CryptoAddressDetails?
       return data.addresses[0].addressDetails
     } else {
       throw new PayIDError(PayIDErrorType.UnexpectedResponse)

--- a/test/PayID/pay-id-client-test.ts
+++ b/test/PayID/pay-id-client-test.ts
@@ -58,10 +58,14 @@ describe('Pay ID Client', function (): void {
     nock('https://xpring.money')
       .get('/georgewashington')
       .reply(200, {
-        addressDetailsType: 'CryptoAddressDetails',
-        addressDetails: {
-          address: 'X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4',
-        },
+        addresses: [
+          {
+            addressDetailsType: 'CryptoAddressDetails',
+            addressDetails: {
+              address: 'X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4',
+            },
+          },
+        ],
       })
 
     // WHEN an XRP address is requested.

--- a/test/PayID/xrp-pay-id-client-test.ts
+++ b/test/PayID/xrp-pay-id-client-test.ts
@@ -24,10 +24,14 @@ describe('XRP Pay ID Client', function (): void {
     nock('https://xpring.money')
       .get('/georgewashington')
       .reply(200, {
-        addressDetailsType: 'CryptoAddressDetails',
-        addressDetails: {
-          address: xAddress,
-        },
+        addresses: [
+          {
+            addressDetailsType: 'CryptoAddressDetails',
+            addressDetails: {
+              address: xAddress,
+            },
+          },
+        ],
       })
 
     // WHEN an XRP address is requested.
@@ -52,10 +56,14 @@ describe('XRP Pay ID Client', function (): void {
     nock('https://xpring.money')
       .get('/georgewashington')
       .reply(200, {
-        addressDetailsType: 'CryptoAddressDetails',
-        addressDetails: {
-          address: classicAddress,
-        },
+        addresses: [
+          {
+            addressDetailsType: 'CryptoAddressDetails',
+            addressDetails: {
+              address: classicAddress,
+            },
+          },
+        ],
       })
 
     // WHEN an XRP address is requested.
@@ -81,11 +89,15 @@ describe('XRP Pay ID Client', function (): void {
     nock('https://xpring.money')
       .get('/georgewashington')
       .reply(200, {
-        addressDetailsType: 'CryptoAddressDetails',
-        addressDetails: {
-          address: classicAddress,
-          tag,
-        },
+        addresses: [
+          {
+            addressDetailsType: 'CryptoAddressDetails',
+            addressDetails: {
+              address: classicAddress,
+              tag,
+            },
+          },
+        ],
       })
 
     // WHEN an XRP address is requested.


### PR DESCRIPTION
## High Level Overview of Change
This PR updates the SDK to handle breaking changes made to PayID.  Specifically, the `PaymentInformation` type was changed to return addresses in the form of an array of `Address` (new type) objects. 

Note: I think Codecov is failing because there are so many changes to the .yml?  I think this is ok?

@keefertaylor check out my TODO in `PayIDClient`.

---------------------------------------------------------------
New object structure in payid:

<img width="605" alt="Screen Shot 2020-05-21 at 6 42 45 PM" src="https://user-images.githubusercontent.com/24928141/82622532-efdd2700-9b92-11ea-9dbe-a81eef7aed36.png">


<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
`PayIDClient` unit and integration tests pass again.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Update other SDKs
