### PR TITLE
Adds error condition and unit test for multiple returned addresses for PayID

### DIFF
--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -90,8 +90,8 @@ export default class PayIDClient {
       }
       // TODO(keefertaylor): make sure the header matches the request.
     } else if (data?.addresses) {
+      // With a specific network, exactly one address should be returned by a PayId lookup.
       if (data.addresses.length === 1) {
-        // With a specific network, exactly one address should be returned by a PayId lookup.
         return data.addresses[0].addressDetails
       }
       throw new PayIDError(PayIDErrorType.UnexpectedResponse)

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -89,7 +89,7 @@ export default class PayIDClient {
         throw new PayIDError(PayIDErrorType.UnexpectedResponse, message)
       }
       // TODO(keefertaylor): make sure the header matches the request.
-    } else if (data?.addresses) {
+    } else if (data?.addresses?.length === 1) {
       // With a specific network, exactly one address should be returned by a PayID lookup.
       if (data.addresses.length === 1) {
         return data.addresses[0].addressDetails

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -90,8 +90,11 @@ export default class PayIDClient {
       }
       // TODO(keefertaylor): make sure the header matches the request.
     } else if (data?.addresses) {
-      // TODO(amiecorso): what if addresses is empty or contains more than one CryptoAddressDetails?
-      return data.addresses[0].addressDetails
+      if (data.addresses.length === 1) {
+        // With a specific network, exactly one address should be returned by a PayId lookup.
+        return data.addresses[0].addressDetails
+      }
+      throw new PayIDError(PayIDErrorType.UnexpectedResponse)
     } else {
       throw new PayIDError(PayIDErrorType.UnexpectedResponse)
     }

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -90,7 +90,7 @@ export default class PayIDClient {
       }
       // TODO(keefertaylor): make sure the header matches the request.
     } else if (data?.addresses) {
-      // With a specific network, exactly one address should be returned by a PayId lookup.
+      // With a specific network, exactly one address should be returned by a PayID lookup.
       if (data.addresses.length === 1) {
         return data.addresses[0].addressDetails
       }


### PR DESCRIPTION
## High Level Overview of Change
This PR follows up a [TODO here](https://github.com/xpring-eng/Xpring-JS/pull/474), throwing an error if a PayID lookup returns a number of addresses other than 1, and introducing a unit test to check this behavior.
This functionality is already implemented in the other two SDKs as part of the original response to the breaking PublicAPI changes.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
The SDKs will likely support multiple address lookup and content negotiation in the future.  However, the current implementation of a `PayIDClient` or `XRPPayIDClient` is tied to a specific network, and therefore should only ever be retrieving a single address for a PayID.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
Error now thrown if the number of addresses returned by a PayID lookup is different from 1.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
New unit test introduced. CI passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
