### PR TITLE
Adds X-Addresses to `XRPTransaction` and `XRPPayment` model objects

### DIFF
--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -375,7 +375,7 @@ class DefaultXRPClient implements XRPClientDecorator {
         case Transaction.TransactionDataCase.PAYMENT: {
           const xrpTransaction = XRPTransaction.from(
             getTransactionResponse,
-            this.isTest(),
+            this.network,
           )
           if (!xrpTransaction) {
             throw XRPError.paymentConversionFailure
@@ -410,14 +410,7 @@ class DefaultXRPClient implements XRPClientDecorator {
     const getTransactionResponse = await this.networkClient.getTransaction(
       getTransactionRequest,
     )
-    return XRPTransaction.from(getTransactionResponse, this.isTest())
-  }
-
-  /**
-   * Return a boolean indicating whether this client is connected to the XRPL Testnet or not.
-   */
-  private isTest(): boolean {
-    return this.network === XRPLNetwork.Test
+    return XRPTransaction.from(getTransactionResponse, this.network)
   }
 }
 

--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -373,7 +373,10 @@ class DefaultXRPClient implements XRPClientDecorator {
       const transaction = getTransactionResponse.getTransaction()
       switch (transaction?.getTransactionDataCase()) {
         case Transaction.TransactionDataCase.PAYMENT: {
-          const xrpTransaction = XRPTransaction.from(getTransactionResponse)
+          const xrpTransaction = XRPTransaction.from(
+            getTransactionResponse,
+            this.isTest(),
+          )
           if (!xrpTransaction) {
             throw XRPError.paymentConversionFailure
           } else {
@@ -407,7 +410,14 @@ class DefaultXRPClient implements XRPClientDecorator {
     const getTransactionResponse = await this.networkClient.getTransaction(
       getTransactionRequest,
     )
-    return XRPTransaction.from(getTransactionResponse)
+    return XRPTransaction.from(getTransactionResponse, this.isTest())
+  }
+
+  /**
+   * Return a boolean indicating whether this client is connected to the XRPL Testnet or not.
+   */
+  private isTest(): boolean {
+    return this.network === XRPLNetwork.Test
   }
 }
 

--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -30,6 +30,7 @@ import { XRPNetworkClient } from './xrp-network-client'
 import isNode from '../Common/utils'
 import XRPError from './xrp-error'
 import { LedgerSpecifier } from './Generated/web/org/xrpl/rpc/v1/ledger_pb'
+import XRPLNetwork from '../Common/xrpl-network'
 
 /** A margin to pad the current ledger sequence with when submitting transactions. */
 const maxLedgerVersionOffset = 10
@@ -44,15 +45,17 @@ class DefaultXRPClient implements XRPClientDecorator {
    * The DefaultXRPClient will use gRPC to communicate with the given endpoint.
    *
    * @param grpcURL The URL of the gRPC instance to connect to.
+   * @param network The network this XRPClient is connecting to.
    * @param forceWeb If `true`, then we will use the gRPC-Web client even when on Node. Defaults to false. This is mainly for testing and in the future will be removed when we have browser testing.
    */
   public static defaultXRPClientWithEndpoint(
     grpcURL: string,
+    network: XRPLNetwork,
     forceWeb = false,
   ): DefaultXRPClient {
     return isNode() && !forceWeb
-      ? new DefaultXRPClient(new GRPCNetworkClient(grpcURL))
-      : new DefaultXRPClient(new GRPCNetworkClientWeb(grpcURL))
+      ? new DefaultXRPClient(new GRPCNetworkClient(grpcURL), network)
+      : new DefaultXRPClient(new GRPCNetworkClientWeb(grpcURL), network)
   }
 
   /**
@@ -61,8 +64,12 @@ class DefaultXRPClient implements XRPClientDecorator {
    * In general, clients should prefer to call `xrpClientWithEndpoint`. This constructor is provided to improve testability of this class.
    *
    * @param networkClient A network client which will manage remote RPCs to Rippled.
+   * @param network The network this XRPClient is connecting to.
    */
-  public constructor(private readonly networkClient: XRPNetworkClient) {}
+  public constructor(
+    private readonly networkClient: XRPNetworkClient,
+    readonly network: XRPLNetwork,
+  ) {}
 
   /**
    * Retrieve the balance for the given address.

--- a/src/XRP/model/xrp-payment.ts
+++ b/src/XRP/model/xrp-payment.ts
@@ -2,6 +2,7 @@ import { Utils } from 'xpring-common-js'
 import { Payment } from '../Generated/web/org/xrpl/rpc/v1/transaction_pb'
 import XRPCurrencyAmount from './xrp-currency-amount'
 import XRPPath from './xrp-path'
+import XRPLNetwork from '../../Common/xrpl-network'
 
 /*
  * Represents a payment on the XRP Ledger.
@@ -14,11 +15,14 @@ export default class XRPPayment {
    *
    * @param payment a Payment (protobuf object) whose field values will be used
    *                to construct an XRPPayment
-   * @param isTest Whether this Payment object came from the XRPL Testnet, defaults to `false`.
+   * @param xrplNetwork The XRPL network from which this object was retrieved, defaults to XRPLNetwork.Main (Mainnet).
    * @return an XRPPayment with its fields set via the analogous protobuf fields.
    * @see https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L224
    */
-  public static from(payment: Payment, isTest = false): XRPPayment | undefined {
+  public static from(
+    payment: Payment,
+    xrplNetwork = XRPLNetwork.Main,
+  ): XRPPayment | undefined {
     const paymentAmountValue = payment.getAmount()?.getValue()
     const amount =
       paymentAmountValue && XRPCurrencyAmount.from(paymentAmountValue)
@@ -36,7 +40,7 @@ export default class XRPPayment {
     const destinationXAddress = Utils.encodeXAddress(
       destination,
       destinationTag,
-      isTest,
+      xrplNetwork === XRPLNetwork.Test,
     )
 
     // If the deliverMin field is set, it must be able to be transformed into a XRPCurrencyAmount.

--- a/src/XRP/model/xrp-transaction.ts
+++ b/src/XRP/model/xrp-transaction.ts
@@ -6,6 +6,7 @@ import XRPTransactionType from './xrp-transaction-type'
 import XRPPayment from './xrp-payment'
 import XRPMemo from './xrp-memo'
 import { GetTransactionResponse } from '../Generated/web/org/xrpl/rpc/v1/get_transaction_pb'
+import XRPLNetwork from '../../Common/xrpl-network'
 
 /*
  * A transaction on the XRP Ledger.
@@ -19,13 +20,13 @@ export default class XRPTransaction {
    *
    * @param transaction a Transaction (protobuf object) whose field values will be used
    *                    to construct an XRPTransaction
-   * @param isTest Whether this Transaction object came from the XRPL Testnet, defaults to `false`.
+   * @param xrplNetwork The XRPL network from which this object was retrieved, defaults to XRPLNetwork.Main (Mainnet).
    * @returns an XRPTransaction with its fields set via the analogous protobuf fields.
    * @see https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L13
    */
   public static from(
     getTransactionResponse: GetTransactionResponse,
-    isTest = false,
+    xrplNetwork = XRPLNetwork.Main,
   ): XRPTransaction | undefined {
     const transaction = getTransactionResponse.getTransaction()
     if (!transaction) {
@@ -35,7 +36,11 @@ export default class XRPTransaction {
     const account = transaction.getAccount()?.getValue()?.getAddress()
 
     const accountXAddress = account
-      ? Utils.encodeXAddress(account, undefined, isTest)
+      ? Utils.encodeXAddress(
+          account,
+          undefined,
+          xrplNetwork === XRPLNetwork.Test,
+        )
       : undefined
 
     const fee = transaction.getFee()?.getDrops()
@@ -78,7 +83,7 @@ export default class XRPTransaction {
         if (!payment) {
           return undefined
         }
-        paymentFields = payment && XRPPayment.from(payment, isTest)
+        paymentFields = payment && XRPPayment.from(payment, xrplNetwork)
         if (!paymentFields) {
           return undefined
         }

--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -4,7 +4,7 @@ import { XRPClientDecorator } from './xrp-client-decorator'
 import RawTransactionStatus from './raw-transaction-status'
 import TransactionStatus from './transaction-status'
 import XRPTransaction from './model/xrp-transaction'
-import { XRPError } from '..'
+import { XRPError, XRPLNetwork } from '..'
 import { XRPErrorType } from './xrp-error'
 
 async function sleep(milliseconds: number): Promise<void> {
@@ -15,7 +15,10 @@ async function sleep(milliseconds: number): Promise<void> {
  * An XRPClient which blocks on `send` calls until the transaction has reached a deterministic state.
  */
 class ReliableSubmissionXRPClient implements XRPClientDecorator {
-  public constructor(private readonly decoratedClient: XRPClientDecorator) {}
+  public constructor(
+    private readonly decoratedClient: XRPClientDecorator,
+    readonly network: XRPLNetwork,
+  ) {}
 
   public async getBalance(address: string): Promise<BigInteger> {
     return this.decoratedClient.getBalance(address)

--- a/src/XRP/xrp-client-decorator.ts
+++ b/src/XRP/xrp-client-decorator.ts
@@ -3,9 +3,15 @@ import { BigInteger } from 'big-integer'
 import TransactionStatus from './transaction-status'
 import RawTransactionStatus from './raw-transaction-status'
 import XRPTransaction from './model/xrp-transaction'
+import XRPLNetwork from '../Common/xrpl-network'
 
 /** A decorator interface for XRPClients. */
 export interface XRPClientDecorator {
+  /**
+   * The network this XRPClient is connecting to.
+   */
+  network: XRPLNetwork
+
   /**
    * Retrieve the balance for the given address.
    *

--- a/src/XRP/xrp-client.ts
+++ b/src/XRP/xrp-client.ts
@@ -31,9 +31,13 @@ class XRPClient implements XRPClientInterface {
 
     const defaultXRPClient = DefaultXRPClient.defaultXRPClientWithEndpoint(
       grpcURL,
+      network,
       forceWeb,
     )
-    this.decoratedClient = new ReliableSubmissionXRPClient(defaultXRPClient)
+    this.decoratedClient = new ReliableSubmissionXRPClient(
+      defaultXRPClient,
+      network,
+    )
   }
 
   /**

--- a/test/XRP/default-xrp-client-test.ts
+++ b/test/XRP/default-xrp-client-test.ts
@@ -29,6 +29,7 @@ import {
 } from './fakes/fake-xrp-protobufs'
 import XRPTransaction from '../../src/XRP/model/xrp-transaction'
 import XRPError, { XRPErrorType } from '../../src/XRP/xrp-error'
+import XRPLNetwork from '../../src/Common/xrpl-network'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -79,7 +80,10 @@ describe('Default XRP Client', function (): void {
     void
   > {
     // GIVEN a DefaultXRPClient.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN the balance for an account is requested.
     const balance = await xrpClient.getBalance(testAddress)
@@ -90,7 +94,10 @@ describe('Default XRP Client', function (): void {
 
   it('Get Account Balance - classic address', function (done): void {
     // GIVEN an XRPClient and a classic address
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const classicAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
 
     // WHEN the balance for an account is requested THEN an error to use X-Addresses is thrown.
@@ -102,7 +109,10 @@ describe('Default XRP Client', function (): void {
 
   it('Get Account Balance - error', function (done): void {
     // GIVEN an XRPClient which wraps an erroring network client.
-    const xrpClient = new DefaultXRPClient(fakeErroringNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeErroringNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN a balance is requested THEN an error is propagated.
     xrpClient.getBalance(testAddress).catch((error) => {
@@ -122,7 +132,7 @@ describe('Default XRP Client', function (): void {
     const fakeNetworkClient = new FakeXRPNetworkClient(
       fakeNetworkClientResponses,
     )
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN a balance is requested THEN an error is propagated.
     xrpClient.getBalance(testAddress).catch((error) => {
@@ -155,7 +165,10 @@ describe('Default XRP Client', function (): void {
       const fakeNetworkClient = new FakeXRPNetworkClient(
         transactionStatusResponses,
       )
-      const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+      const xrpClient = new DefaultXRPClient(
+        fakeNetworkClient,
+        XRPLNetwork.Test,
+      )
 
       // WHEN the transaction status is retrieved.
       const transactionStatus = await xrpClient.getPaymentStatus(
@@ -185,7 +198,7 @@ describe('Default XRP Client', function (): void {
     const fakeNetworkClient = new FakeXRPNetworkClient(
       transactionStatusResponses,
     )
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN the transaction status is retrieved.
     const transactionStatus = await xrpClient.getPaymentStatus(transactionHash)
@@ -215,7 +228,10 @@ describe('Default XRP Client', function (): void {
       const fakeNetworkClient = new FakeXRPNetworkClient(
         transactionStatusResponses,
       )
-      const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+      const xrpClient = new DefaultXRPClient(
+        fakeNetworkClient,
+        XRPLNetwork.Test,
+      )
 
       // WHEN the transaction status is retrieved.
       const transactionStatus = await xrpClient.getPaymentStatus(
@@ -245,7 +261,7 @@ describe('Default XRP Client', function (): void {
     const fakeNetworkClient = new FakeXRPNetworkClient(
       transactionStatusResponses,
     )
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN the transaction status is retrieved.
     const transactionStatus = await xrpClient.getPaymentStatus(transactionHash)
@@ -265,7 +281,7 @@ describe('Default XRP Client', function (): void {
     const fakeNetworkClient = new FakeXRPNetworkClient(
       transactionStatusResponses,
     )
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN the transaction status is retrieved THEN an error is thrown.
     xrpClient.getPaymentStatus(transactionHash).catch((error) => {
@@ -276,7 +292,10 @@ describe('Default XRP Client', function (): void {
 
   it('Send XRP Transaction - success with BigInteger', async function () {
     // GIVEN an XRPClient, a wallet, and a BigInteger denomonated amount.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
@@ -299,7 +318,10 @@ describe('Default XRP Client', function (): void {
 
   it('Send XRP Transaction - success with number', async function () {
     // GIVEN an XRPClient, a wallet, and a number denominated amount.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 10
@@ -322,7 +344,10 @@ describe('Default XRP Client', function (): void {
 
   it('Send XRP Transaction - success with string', async function () {
     // GIVEN an XRPClient, a wallet, and a numeric string denominated amount.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = '10'
@@ -345,7 +370,10 @@ describe('Default XRP Client', function (): void {
 
   it('Send XRP Transaction - failure with invalid string', function (done) {
     // GIVEN an XRPClient, a wallet and an amount that is invalid.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 'not_a_number'
@@ -367,7 +395,10 @@ describe('Default XRP Client', function (): void {
     const feeFailingNetworkClient = new FakeXRPNetworkClient(
       feeFailureResponses,
     )
-    const xrpClient = new DefaultXRPClient(feeFailingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      feeFailingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
@@ -385,7 +416,10 @@ describe('Default XRP Client', function (): void {
 
   it('Send XRP Transaction - failure with classic address', function (done) {
     // GIVEN an XRPClient, a wallet, and a classic address as the destination.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
     const amount = bigInt('10')
@@ -407,7 +441,10 @@ describe('Default XRP Client', function (): void {
     const feeFailingNetworkClient = new FakeXRPNetworkClient(
       feeFailureResponses,
     )
-    const xrpClient = new DefaultXRPClient(feeFailingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      feeFailingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
@@ -429,7 +466,10 @@ describe('Default XRP Client', function (): void {
     const feeFailingNetworkClient = new FakeXRPNetworkClient(
       feeFailureResponses,
     )
-    const xrpClient = new DefaultXRPClient(feeFailingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      feeFailingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const { wallet } = Wallet.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
@@ -443,7 +483,10 @@ describe('Default XRP Client', function (): void {
 
   it('Check if account exists - successful network request', async function () {
     // GIVEN a DefaultXRPClient.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN the account does exist
     const exists = await xrpClient.accountExists(testAddress)
@@ -464,7 +507,10 @@ describe('Default XRP Client', function (): void {
     const fakeErroringNetworkClient = new FakeXRPNetworkClient(
       fakeNetworkClientResponses,
     )
-    const xrpClient = new DefaultXRPClient(fakeErroringNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeErroringNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN Account existence is checked
     const exists = await xrpClient.accountExists(testAddress)
@@ -485,7 +531,10 @@ describe('Default XRP Client', function (): void {
     const fakeErroringNetworkClient = new FakeXRPNetworkClient(
       fakeNetworkClientResponses,
     )
-    const xrpClient = new DefaultXRPClient(fakeErroringNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeErroringNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN Account existence is checked
     // THEN an error is re-thrown (cannot conclude account doesn't exist)
@@ -498,7 +547,10 @@ describe('Default XRP Client', function (): void {
 
   it('Check if account exists - error with classic address', function (done) {
     // GIVEN a DefaultXRPClient and a classic address
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const classicAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
 
     // WHEN accountExists is called using a classic address THEN an error to use X-Addresses is thrown.
@@ -510,7 +562,10 @@ describe('Default XRP Client', function (): void {
 
   it('Payment History - successful response', async function (): Promise<void> {
     // GIVEN a DefaultXRPClient.
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN the payment history for an address is requested.
     const paymentHistory = await xrpClient.paymentHistory(testAddress)
@@ -524,7 +579,10 @@ describe('Default XRP Client', function (): void {
 
   it('Payment History - classic address', function (done): void {
     // GIVEN an XRPClient and a classic address
-    const xrpClient = new DefaultXRPClient(fakeSucceedingNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeSucceedingNetworkClient,
+      XRPLNetwork.Test,
+    )
     const classicAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
 
     // WHEN the payment history for an account is requested THEN an error to use X-Addresses is thrown.
@@ -536,7 +594,10 @@ describe('Default XRP Client', function (): void {
 
   it('Payment History - network failure', function (done): void {
     // GIVEN an XRPClient which wraps an erroring network client.
-    const xrpClient = new DefaultXRPClient(fakeErroringNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      fakeErroringNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN the payment history is requested THEN an error is propagated.
     xrpClient.paymentHistory(testAddress).catch((error) => {
@@ -571,7 +632,10 @@ describe('Default XRP Client', function (): void {
       heteroHistoryNetworkResponses,
     )
 
-    const xrpClient = new DefaultXRPClient(heteroHistoryNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      heteroHistoryNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN the transactionHistory is requested.
     const transactionHistory = await xrpClient.paymentHistory(testAddress)
@@ -596,7 +660,10 @@ describe('Default XRP Client', function (): void {
     const invalidHistoryNetworkClient = new FakeXRPNetworkClient(
       invalidHistoryNetworkResponses,
     )
-    const xrpClient = new DefaultXRPClient(invalidHistoryNetworkClient)
+    const xrpClient = new DefaultXRPClient(
+      invalidHistoryNetworkClient,
+      XRPLNetwork.Test,
+    )
 
     // WHEN the transactionHistory is requested THEN a conversion error is thrown.
     xrpClient.paymentHistory(testAddress).catch((error) => {
@@ -617,7 +684,7 @@ describe('Default XRP Client', function (): void {
       testGetTransactionResponseProto,
     )
     const fakeNetworkClient = new FakeXRPNetworkClient(fakeNetworkResponses)
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN a transaction is requested.
     const transaction = await xrpClient.getPayment(transactionHash)
@@ -642,7 +709,7 @@ describe('Default XRP Client', function (): void {
       notFoundError,
     )
     const fakeNetworkClient = new FakeXRPNetworkClient(fakeNetworkResponses)
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN a transaction is requested, THEN the error is re-thrown.
     xrpClient.getPayment(transactionHash).catch((error) => {
@@ -663,7 +730,7 @@ describe('Default XRP Client', function (): void {
       testInvalidGetTransactionResponseProto,
     )
     const fakeNetworkClient = new FakeXRPNetworkClient(fakeNetworkResponses)
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN a transaction is requested.
     const transaction = await xrpClient.getPayment(transactionHash)
@@ -683,7 +750,7 @@ describe('Default XRP Client', function (): void {
       testInvalidGetTransactionResponseProtoUnsupportedType,
     )
     const fakeNetworkClient = new FakeXRPNetworkClient(fakeNetworkResponses)
-    const xrpClient = new DefaultXRPClient(fakeNetworkClient)
+    const xrpClient = new DefaultXRPClient(fakeNetworkClient, XRPLNetwork.Test)
 
     // WHEN a transaction is requested.
     const transaction = await xrpClient.getPayment(transactionHash)

--- a/test/XRP/default-xrp-client-test.ts
+++ b/test/XRP/default-xrp-client-test.ts
@@ -692,7 +692,7 @@ describe('Default XRP Client', function (): void {
     // THEN the returned transaction is as expected.
     assert.deepEqual(
       transaction,
-      XRPTransaction.from(testGetTransactionResponseProto),
+      XRPTransaction.from(testGetTransactionResponseProto, true),
     )
   })
 

--- a/test/XRP/default-xrp-client-test.ts
+++ b/test/XRP/default-xrp-client-test.ts
@@ -692,7 +692,7 @@ describe('Default XRP Client', function (): void {
     // THEN the returned transaction is as expected.
     assert.deepEqual(
       transaction,
-      XRPTransaction.from(testGetTransactionResponseProto, true),
+      XRPTransaction.from(testGetTransactionResponseProto, xrpClient.network),
     )
   })
 

--- a/test/XRP/reliable-submission-xrp-client-test.ts
+++ b/test/XRP/reliable-submission-xrp-client-test.ts
@@ -6,6 +6,7 @@ import ReliableSubmissionXRPClient from '../../src/XRP/reliable-submission-xrp-c
 import RawTransactionStatus from '../../src/XRP/raw-transaction-status'
 import TransactionStatus from '../../src/XRP/transaction-status'
 import { testXRPTransaction } from './fakes/fake-xrp-protobufs'
+import { XRPLNetwork } from '../../src'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -46,6 +47,7 @@ describe('Reliable Submission XRP Client', function (): void {
     )
     this.reliableSubmissionClient = new ReliableSubmissionXRPClient(
       this.fakeXRPClient,
+      XRPLNetwork.Test,
     )
   })
 

--- a/test/XRP/xrp-protocol-buffer-conversion-test.ts
+++ b/test/XRP/xrp-protocol-buffer-conversion-test.ts
@@ -224,6 +224,62 @@ describe('Protocol Buffer Conversion', function (): void {
       payment?.destinationTag,
       testPaymentProtoAllFieldsSet.getDestinationTag()?.getValue(),
     )
+    assert.equal(
+      payment?.destinationXAddress,
+      Utils.encodeXAddress(payment?.destination!, payment?.destinationTag),
+    )
+    assert.deepEqual(
+      payment?.deliverMin,
+      XRPCurrencyAmount.from(
+        testPaymentProtoAllFieldsSet.getDeliverMin()?.getValue()!,
+      ),
+    )
+    assert.deepEqual(
+      payment?.invoiceID,
+      testPaymentProtoAllFieldsSet.getInvoiceId()?.getValue(),
+    )
+    assert.deepEqual(
+      payment?.paths,
+      testPaymentProtoAllFieldsSet
+        .getPathsList()
+        .map((path) => XRPPath.from(path)),
+    )
+    assert.deepEqual(
+      payment?.sendMax,
+      XRPCurrencyAmount.from(
+        testPaymentProtoAllFieldsSet.getSendMax()?.getValue()!,
+      ),
+    )
+  })
+
+  it('Convert Payment with all fields set - Testnet', function (): void {
+    // GIVEN a payment protocol buffer with all fields set.
+    // WHEN the protocol buffer is converted to a native TypeScript type with isTest flag set to true.
+    const payment = XRPPayment.from(testPaymentProtoAllFieldsSet, true)
+
+    // THEN the result is as expected.
+    assert.deepEqual(
+      payment?.amount,
+      XRPCurrencyAmount.from(
+        testPaymentProtoAllFieldsSet.getAmount()?.getValue()!,
+      ),
+    )
+    assert.equal(
+      payment?.destination,
+      testPaymentProtoAllFieldsSet.getDestination()?.getValue()?.getAddress(),
+    )
+    assert.equal(
+      payment?.destinationTag,
+      testPaymentProtoAllFieldsSet.getDestinationTag()?.getValue(),
+    )
+    assert.equal(
+      payment?.destinationXAddress,
+      Utils.encodeXAddress(
+        payment?.destination!,
+        payment?.destinationTag,
+        true,
+      ),
+    )
     assert.deepEqual(
       payment?.deliverMin,
       XRPCurrencyAmount.from(
@@ -266,6 +322,10 @@ describe('Protocol Buffer Conversion', function (): void {
         .getDestination()
         ?.getValue()
         ?.getAddress(),
+    )
+    assert.equal(
+      payment?.destinationXAddress,
+      Utils.encodeXAddress(payment?.destination!, payment?.destinationTag),
     )
     assert.isUndefined(payment?.destinationTag)
     assert.isUndefined(payment?.deliverMin)

--- a/test/XRP/xrp-protocol-buffer-conversion-test.ts
+++ b/test/XRP/xrp-protocol-buffer-conversion-test.ts
@@ -409,6 +409,10 @@ describe('Protocol Buffer Conversion', function (): void {
 
     // THEN all fields are present and converted correctly.
     assert.equal(transaction?.account, testAddress)
+    assert.equal(
+      transaction?.accountXAddress,
+      Utils.encodeXAddress(transaction?.account!, undefined),
+    )
     assert.equal(transaction?.fee, testFee)
     assert.equal(transaction?.sequence, testSequence)
     assert.equal(transaction?.signingPublicKey, testPublicKey)
@@ -445,6 +449,10 @@ describe('Protocol Buffer Conversion', function (): void {
 
     // THEN all fields are present and converted correctly.
     assert.equal(transaction?.account, testAddress)
+    assert.equal(
+      transaction?.accountXAddress,
+      Utils.encodeXAddress(transaction?.account!, undefined),
+    )
     assert.equal(transaction?.fee, testFee)
     assert.equal(transaction?.sequence, testSequence)
     assert.deepEqual(transaction?.signingPublicKey, testPublicKey)

--- a/test/XRP/xrp-protocol-buffer-conversion-test.ts
+++ b/test/XRP/xrp-protocol-buffer-conversion-test.ts
@@ -9,7 +9,7 @@ import XRPPayment from '../../src/XRP/model/xrp-payment'
 import XRPMemo from '../../src/XRP/model/xrp-memo'
 import XRPSigner from '../../src/XRP/model/xrp-signer'
 import XRPTransaction from '../../src/XRP/model/xrp-transaction'
-import { Utils } from '../../src'
+import { Utils, XRPLNetwork } from '../../src'
 import {
   testAddress,
   testPublicKey,
@@ -255,7 +255,10 @@ describe('Protocol Buffer Conversion', function (): void {
   it('Convert Payment with all fields set - Testnet', function (): void {
     // GIVEN a payment protocol buffer with all fields set.
     // WHEN the protocol buffer is converted to a native TypeScript type with isTest flag set to true.
-    const payment = XRPPayment.from(testPaymentProtoAllFieldsSet, true)
+    const payment = XRPPayment.from(
+      testPaymentProtoAllFieldsSet,
+      XRPLNetwork.Test,
+    )
 
     // THEN the result is as expected.
     assert.deepEqual(


### PR DESCRIPTION
## High Level Overview of Change
This PR adds X-address to the `XRPPayment` and `XRPTransaction` model objects.  `XRPPayment` contains a `destination` and a `destinationTag` property, and now also contains a `destinationXAddress` property that is the X-address encoded version of this information. `XRPTransaction` contains an `account` property, and now also contains an `accountXAddress` property, which is the X-address encoded version of the originating account with no destination tag.

In order to create the correct X-address encoding, we need to know whether we're on Testnet or Mainnet.  Therefore the `.from` constructors for `XRPPayment` and `XRPTransaction` now have an additional `XRPLNetwork` parameter.  Tests and client code have been updated accordingly. 
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
`XRPTransaction` and `XRPPayment` now contain X-address versions of address and tag properties. 
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Unit tests for protocol buffer conversion into these objects have been updated to verify the X-address properties.
CI stil passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Questions for @keefertaylor 
- do we need to deprecate the classic address/tag fields, or just leave everything side-by-side?
- should a note about this go in the CHANGELOG?  Technically the `XRPTransaction` and `XRPPayment` objects experience a breaking change because their constructors changed.
- should other classes that contain XRP addresses (such as `XRPPathElement` or `XRPIssuedCurrency`) also contain X-address versions of these?