### PR TITLE
(1/17) Creates `XRPAccountSet` Protobuf Wrapper Class

### DIFF
--- a/src/XRP/model/xrp-account-set.ts
+++ b/src/XRP/model/xrp-account-set.ts
@@ -2,6 +2,7 @@ import { AccountSet } from '../Generated/web/org/xrpl/rpc/v1/transaction_pb'
 
 /*
  * Represents an AccountSet transaction on the XRP Ledger.
+ * An AccountSet transaction modifies the properties of an account in the XRP Ledger.
  * @see: https://xrpl.org/accountset.html
  */
 export default class XRPAccountSet {

--- a/src/XRP/model/xrp-account-set.ts
+++ b/src/XRP/model/xrp-account-set.ts
@@ -3,6 +3,7 @@ import { AccountSet } from '../Generated/web/org/xrpl/rpc/v1/transaction_pb'
 /*
  * Represents an AccountSet transaction on the XRP Ledger.
  * An AccountSet transaction modifies the properties of an account in the XRP Ledger.
+ *
  * @see: https://xrpl.org/accountset.html
  */
 export default class XRPAccountSet {
@@ -35,7 +36,6 @@ export default class XRPAccountSet {
   }
 
   /**
-   *
    * @param clearFlag (Optional) Unique identifier of a flag to disable for this account.
    * @param domain (Optional) The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase.
    * @param emailHash (Optional) Hash of an email address to be used for generating an avatar image.

--- a/src/XRP/model/xrp-account-set.ts
+++ b/src/XRP/model/xrp-account-set.ts
@@ -1,0 +1,58 @@
+import { AccountSet } from '../Generated/web/org/xrpl/rpc/v1/transaction_pb'
+
+/*
+ * Represents an AccountSet transaction on the XRP Ledger.
+ * @see: https://xrpl.org/accountset.html
+ */
+export default class XRPAccountSet {
+  /**
+   * Constructs an XRPAccountSet from an AccountSet.
+   *
+   * @param accountSet an AccountSet (protobuf object) whose field values will be used
+   *                to construct an XRPAccountSet
+   * @return an XRPAccountSet with its fields set via the analogous protobuf fields.
+   * @see https://github.com/ripple/rippled/blob/3d86b49dae8173344b39deb75e53170a9b6c5284/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L100
+   */
+  public static from(accountSet: AccountSet): XRPAccountSet | undefined {
+    const clearFlag = accountSet.getClearFlag()?.getValue()
+    const domain = accountSet.getDomain()?.getValue()
+    const emailHash = accountSet.getEmailHash()?.getValue_asU8()
+    const messageKey = accountSet.getMessageKey()?.getValue_asU8()
+    const setFlag = accountSet.getSetFlag()?.getValue()
+    const transferRate = accountSet.getTransferRate()?.getValue()
+    const tickSize = accountSet.getTickSize()?.getValue()
+
+    return new XRPAccountSet(
+      clearFlag,
+      domain,
+      emailHash,
+      messageKey,
+      setFlag,
+      transferRate,
+      tickSize,
+    )
+  }
+
+  /**
+   *
+   * @param clearFlag (Optional) Unique identifier of a flag to disable for this account.
+   * @param domain (Optional) The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase.
+   * @param emailHash (Optional) Hash of an email address to be used for generating an avatar image.
+   * @param messageKey (Optional) Public key for sending encrypted messages to this account.
+   * @param setFlag (Optional) Integer flag to enable for this account.
+   * @param transferRate (Optional) The fee to charge when users transfer this account's issued currencies, represented as billionths of a unit.
+   *                     Cannot be more than 2000000000 or less than 1000000000, except for the special case 0 meaning no fee.
+   * @param tickSize (Optional) Tick size to use for offers involving a currency issued by this address.
+   *                  The exchange rates of those offers is rounded to this many significant digits.
+   *                  Valid values are 3 to 15 inclusive, or 0 to disable. (Requires the TickSize amendment.)
+   */
+  private constructor(
+    readonly clearFlag?: number, // uint32
+    readonly domain?: string, // string
+    readonly emailHash?: Uint8Array, // bytes
+    readonly messageKey?: Uint8Array, // bytes
+    readonly setFlag?: number, // uint32
+    readonly transferRate?: number, // uint32
+    readonly tickSize?: number, // uint32 (note says is actually uint8)
+  ) {}
+}

--- a/src/XRP/model/xrp-account-set.ts
+++ b/src/XRP/model/xrp-account-set.ts
@@ -47,12 +47,12 @@ export default class XRPAccountSet {
    *                  Valid values are 3 to 15 inclusive, or 0 to disable. (Requires the TickSize amendment.)
    */
   private constructor(
-    readonly clearFlag?: number, // uint32
-    readonly domain?: string, // string
-    readonly emailHash?: Uint8Array, // bytes
-    readonly messageKey?: Uint8Array, // bytes
-    readonly setFlag?: number, // uint32
-    readonly transferRate?: number, // uint32
-    readonly tickSize?: number, // uint32 (note says is actually uint8)
+    readonly clearFlag?: number,
+    readonly domain?: string,
+    readonly emailHash?: Uint8Array,
+    readonly messageKey?: Uint8Array,
+    readonly setFlag?: number,
+    readonly transferRate?: number,
+    readonly tickSize?: number,
   ) {}
 }

--- a/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
@@ -55,4 +55,5 @@ testAccountSetProtoAllFields.setSetFlag(testSetFlagProto)
 testAccountSetProtoAllFields.setTransferRate(testTransferRateProto)
 testAccountSetProtoAllFields.setTickSize(testTickSizeProto)
 
-export default { testAccountSetProtoAllFields }
+// eslint-disable-next-line import/prefer-default-export
+export { testAccountSetProtoAllFields }

--- a/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
@@ -24,7 +24,6 @@ const testTickSize = 7
 
 // AccountSet protos
 
-// Establish sub-protos
 const testClearFlagProto = new ClearFlag()
 testClearFlagProto.setValue(testClearFlag)
 

--- a/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
@@ -55,5 +55,7 @@ testAccountSetProtoAllFields.setSetFlag(testSetFlagProto)
 testAccountSetProtoAllFields.setTransferRate(testTransferRateProto)
 testAccountSetProtoAllFields.setTickSize(testTickSizeProto)
 
-// eslint-disable-next-line import/prefer-default-export
-export { testAccountSetProtoAllFields }
+const testAccountSetProtoOneFieldSet = new AccountSet()
+testAccountSetProtoOneFieldSet.setClearFlag(testClearFlagProto)
+
+export { testAccountSetProtoAllFields, testAccountSetProtoOneFieldSet }

--- a/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-transaction-type-protobufs.ts
@@ -1,0 +1,58 @@
+import { AccountSet } from '../../../src/XRP/Generated/web/org/xrpl/rpc/v1/transaction_pb'
+import {
+  ClearFlag,
+  Domain,
+  EmailHash,
+  MessageKey,
+  SetFlag,
+  TransferRate,
+  TickSize,
+} from '../../../src/XRP/Generated/web/org/xrpl/rpc/v1/common_pb'
+
+// Primitive test values ===============================================================
+
+// AccountSet
+const testClearFlag = 5
+const testDomain = 'testdomain'
+const testEmailHash = new Uint8Array([8, 9, 10])
+const testMessageKey = new Uint8Array([11, 12, 13])
+const testSetFlag = 4
+const testTransferRate = 1234567890
+const testTickSize = 7
+
+// Protobuf objects ======================================================================
+
+// AccountSet protos
+
+// Establish sub-protos
+const testClearFlagProto = new ClearFlag()
+testClearFlagProto.setValue(testClearFlag)
+
+const testDomainProto = new Domain()
+testDomainProto.setValue(testDomain)
+
+const testEmailHashProto = new EmailHash()
+testEmailHashProto.setValue(testEmailHash)
+
+const testMessageKeyProto = new MessageKey()
+testMessageKeyProto.setValue(testMessageKey)
+
+const testSetFlagProto = new SetFlag()
+testSetFlagProto.setValue(testSetFlag)
+
+const testTransferRateProto = new TransferRate()
+testTransferRateProto.setValue(testTransferRate)
+
+const testTickSizeProto = new TickSize()
+testTickSizeProto.setValue(testTickSize)
+
+const testAccountSetProtoAllFields = new AccountSet()
+testAccountSetProtoAllFields.setClearFlag(testClearFlagProto)
+testAccountSetProtoAllFields.setDomain(testDomainProto)
+testAccountSetProtoAllFields.setEmailHash(testEmailHashProto)
+testAccountSetProtoAllFields.setMessageKey(testMessageKeyProto)
+testAccountSetProtoAllFields.setSetFlag(testSetFlagProto)
+testAccountSetProtoAllFields.setTransferRate(testTransferRateProto)
+testAccountSetProtoAllFields.setTickSize(testTickSizeProto)
+
+export default { testAccountSetProtoAllFields }

--- a/test/XRP/xrp-transaction-type-proto-conversion-test.ts
+++ b/test/XRP/xrp-transaction-type-proto-conversion-test.ts
@@ -1,11 +1,14 @@
 import { assert } from 'chai'
 import XRPAccountSet from '../../src/XRP/model/xrp-account-set'
-import { testAccountSetProtoAllFields } from './fakes/fake-xrp-transaction-type-protobufs'
+import {
+  testAccountSetProtoAllFields,
+  testAccountSetProtoOneFieldSet,
+} from './fakes/fake-xrp-transaction-type-protobufs'
 
 describe('Protobuf Conversions - Transaction Types', function (): void {
   // AccountSet
 
-  it('Convert AccountSet protobuf to XRPAccountSet object', function (): void {
+  it('Convert AccountSet protobuf with all fields to XRPAccountSet object', function (): void {
     // GIVEN an AccountSet protocol buffer with all fields set.
     // WHEN the protocol buffer is converted to a native Typescript type.
     const accountSet = XRPAccountSet.from(testAccountSetProtoAllFields)
@@ -13,7 +16,49 @@ describe('Protobuf Conversions - Transaction Types', function (): void {
     // THEN the AccountSet converted as expected.
     assert.deepEqual(
       accountSet?.clearFlag,
-      testAccountSetProtoAllFields.getClearFlag().getValue(),
+      testAccountSetProtoAllFields.getClearFlag()?.getValue(),
     )
+    assert.deepEqual(
+      accountSet?.domain,
+      testAccountSetProtoAllFields.getDomain()?.getValue(),
+    )
+    assert.deepEqual(
+      accountSet?.emailHash,
+      testAccountSetProtoAllFields.getEmailHash()?.getValue(),
+    )
+    assert.deepEqual(
+      accountSet?.messageKey,
+      testAccountSetProtoAllFields.getMessageKey()?.getValue(),
+    )
+    assert.deepEqual(
+      accountSet?.setFlag,
+      testAccountSetProtoAllFields.getSetFlag()?.getValue(),
+    )
+    assert.deepEqual(
+      accountSet?.transferRate,
+      testAccountSetProtoAllFields.getTransferRate()?.getValue(),
+    )
+    assert.deepEqual(
+      accountSet?.tickSize,
+      testAccountSetProtoAllFields.getTickSize()?.getValue(),
+    )
+  })
+
+  it('Convert AccountSet protobuf with one field to XRPAccountSet object', function (): void {
+    // GIVEN an AccountSet protocol buffer with only one field set.
+    // WHEN the protocol buffer is converted to a native Typescript type.
+    const accountSet = XRPAccountSet.from(testAccountSetProtoOneFieldSet)
+
+    // THEN the AccountSet converted as expected.
+    assert.deepEqual(
+      accountSet?.clearFlag,
+      testAccountSetProtoAllFields.getClearFlag()?.getValue(),
+    )
+    assert.isUndefined(accountSet?.domain)
+    assert.isUndefined(accountSet?.emailHash)
+    assert.isUndefined(accountSet?.messageKey)
+    assert.isUndefined(accountSet?.setFlag)
+    assert.isUndefined(accountSet?.transferRate)
+    assert.isUndefined(accountSet?.tickSize)
   })
 })

--- a/test/XRP/xrp-transaction-type-proto-conversion-test.ts
+++ b/test/XRP/xrp-transaction-type-proto-conversion-test.ts
@@ -1,56 +1,6 @@
 import { assert } from 'chai'
-import bigInt from 'big-integer'
-import XRPCurrency from '../../src/XRP/model/xrp-currency'
-import XRPPathElement from '../../src/XRP/model/xrp-path-element'
-import XRPPath from '../../src/XRP/model/xrp-path'
-import XRPIssuedCurrency from '../../src/XRP/model/xrp-issued-currency'
-import XRPCurrencyAmount from '../../src/XRP/model/xrp-currency-amount'
-import XRPPayment from '../../src/XRP/model/xrp-payment'
-import XRPMemo from '../../src/XRP/model/xrp-memo'
-import XRPSigner from '../../src/XRP/model/xrp-signer'
-import XRPTransaction from '../../src/XRP/model/xrp-transaction'
-import { Utils } from '../../src'
-import {
-  testAddress,
-  testPublicKey,
-  testTransactionSignature,
-  testSequence,
-  testFee,
-  testMemoData,
-  testMemoFormat,
-  testMemoType,
-  testAccountTransactionID,
-  testFlags,
-  testSourceTag,
-  testLastLedgerSequence,
-  testTransactionHash,
-  expectedTimestamp,
-  testIsValidated,
-  testLedgerIndex,
-  testCurrencyProto,
-  testPathElementProto,
-  testEmptyPathElementProto,
-  testEmptyPathProto,
-  testPathProtoOneElement,
-  testPathProtoThreeElements,
-  testIssuedCurrencyProto,
-  testCurrencyAmountProtoDrops,
-  testCurrencyAmountProtoIssuedCurrency,
-  testPaymentProtoAllFieldsSet,
-  testPaymentProtoMandatoryFieldsOnly,
-  testMemoProtoAllFields,
-  testEmptyMemoProto,
-  testSignerProto,
-  testGetTransactionResponseProto,
-  testGetTransactionResponseProtoMandatoryOnly,
-  testInvalidIssuedCurrencyProto,
-  testInvalidCurrencyAmountProto,
-  testInvalidPaymentProtoBadAmount,
-  testInvalidPaymentProtoBadDeliverMin,
-  testInvalidPaymentProtoBadSendMax,
-  testInvalidGetTransactionResponseProto,
-  testInvalidGetTransactionResponseProtoUnsupportedType,
-} from './fakes/fake-xrp-protobufs'
+import XRPAccountSet from '../../src/XRP/model/xrp-account-set'
+import { testAccountSetProtoAllFields } from './fakes/fake-xrp-transaction-type-protobufs'
 
 describe('Protobuf Conversions - Transaction Types', function (): void {
   // AccountSet
@@ -58,9 +8,12 @@ describe('Protobuf Conversions - Transaction Types', function (): void {
   it('Convert AccountSet protobuf to XRPAccountSet object', function (): void {
     // GIVEN an AccountSet protocol buffer with all fields set.
     // WHEN the protocol buffer is converted to a native Typescript type.
-    const accountSet = XRPAccountSet.from()
+    const accountSet = XRPAccountSet.from(testAccountSetProtoAllFields)
 
     // THEN the AccountSet converted as expected.
-    assert.deepEqual()
+    assert.deepEqual(
+      accountSet?.clearFlag,
+      testAccountSetProtoAllFields.getClearFlag().getValue(),
+    )
   })
 })

--- a/test/XRP/xrp-transaction-type-proto-conversion-test.ts
+++ b/test/XRP/xrp-transaction-type-proto-conversion-test.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai'
+import bigInt from 'big-integer'
+import XRPCurrency from '../../src/XRP/model/xrp-currency'
+import XRPPathElement from '../../src/XRP/model/xrp-path-element'
+import XRPPath from '../../src/XRP/model/xrp-path'
+import XRPIssuedCurrency from '../../src/XRP/model/xrp-issued-currency'
+import XRPCurrencyAmount from '../../src/XRP/model/xrp-currency-amount'
+import XRPPayment from '../../src/XRP/model/xrp-payment'
+import XRPMemo from '../../src/XRP/model/xrp-memo'
+import XRPSigner from '../../src/XRP/model/xrp-signer'
+import XRPTransaction from '../../src/XRP/model/xrp-transaction'
+import { Utils } from '../../src'
+import {
+  testAddress,
+  testPublicKey,
+  testTransactionSignature,
+  testSequence,
+  testFee,
+  testMemoData,
+  testMemoFormat,
+  testMemoType,
+  testAccountTransactionID,
+  testFlags,
+  testSourceTag,
+  testLastLedgerSequence,
+  testTransactionHash,
+  expectedTimestamp,
+  testIsValidated,
+  testLedgerIndex,
+  testCurrencyProto,
+  testPathElementProto,
+  testEmptyPathElementProto,
+  testEmptyPathProto,
+  testPathProtoOneElement,
+  testPathProtoThreeElements,
+  testIssuedCurrencyProto,
+  testCurrencyAmountProtoDrops,
+  testCurrencyAmountProtoIssuedCurrency,
+  testPaymentProtoAllFieldsSet,
+  testPaymentProtoMandatoryFieldsOnly,
+  testMemoProtoAllFields,
+  testEmptyMemoProto,
+  testSignerProto,
+  testGetTransactionResponseProto,
+  testGetTransactionResponseProtoMandatoryOnly,
+  testInvalidIssuedCurrencyProto,
+  testInvalidCurrencyAmountProto,
+  testInvalidPaymentProtoBadAmount,
+  testInvalidPaymentProtoBadDeliverMin,
+  testInvalidPaymentProtoBadSendMax,
+  testInvalidGetTransactionResponseProto,
+  testInvalidGetTransactionResponseProtoUnsupportedType,
+} from './fakes/fake-xrp-protobufs'
+
+describe('Protobuf Conversions - Transaction Types', function (): void {
+  // AccountSet
+
+  it('Convert AccountSet protobuf to XRPAccountSet object', function (): void {
+    // GIVEN an AccountSet protocol buffer with all fields set.
+    // WHEN the protocol buffer is converted to a native Typescript type.
+    const accountSet = XRPAccountSet.from()
+
+    // THEN the AccountSet converted as expected.
+    assert.deepEqual()
+  })
+})


### PR DESCRIPTION
## High Level Overview of Change
This PR implements the class `XRPAccountSet` - a native Typescript class to wrap the [`AccountSet` protocol buffer](https://github.com/ripple/rippled/blob/3d86b49dae8173344b39deb75e53170a9b6c5284/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L100).  See also: https://xrpl.org/accountset.html.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Effort to implement additional [XRPL transaction types](https://xrpl.org/transaction-types.html) beyond `Payment` in the SDK.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
`XRPAccountSet` class and conversion unit tests now exist.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Unit tests added to verify conversion.  CI passes.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

## Future Tasks
<!--
For future tasks related to PR.
-->
Remaining transaction types & all three SDKs.
Implementation and exposure of client methods for submitting additional transaction types.