### PR TITLE
create a send money details wrapper

### DIFF
--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -34,7 +34,7 @@ import { XRPNetworkClient } from './xrp-network-client'
 import isNode from '../Common/utils'
 import XRPError from './xrp-error'
 import { LedgerSpecifier } from './Generated/web/org/xrpl/rpc/v1/ledger_pb'
-import SendMoneyDetails from './model/send-money-details'
+import SendXrpDetails from './model/send-xrp-details'
 
 /** A margin to pad the current ledger sequence with when submitting transactions. */
 const maxLedgerVersionOffset = 10
@@ -164,7 +164,7 @@ class DefaultXRPClient implements XRPClientDecorator {
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async sendWithDetails(
-    sendMoneyDetails: SendMoneyDetails,
+    sendMoneyDetails: SendXrpDetails,
   ): Promise<string> {
     const {
       amount: drops,

--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -34,7 +34,7 @@ import { XRPNetworkClient } from './xrp-network-client'
 import isNode from '../Common/utils'
 import XRPError from './xrp-error'
 import { LedgerSpecifier } from './Generated/web/org/xrpl/rpc/v1/ledger_pb'
-import { XRPMemo } from './model'
+import SendMoneyDetails from './model/send-money-details'
 
 /** A margin to pad the current ledger sequence with when submitting transactions. */
 const maxLedgerVersionOffset = 10
@@ -138,18 +138,40 @@ class DefaultXRPClient implements XRPClientDecorator {
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
-   * @param drops A `BigInteger`, number or numeric string representing the number of drops to send.
+   * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destinationAddress A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
-   * @param memos An optional list of memos to add to the transaction.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async send(
-    drops: BigInteger | number | string,
+    amount: BigInteger | number | string,
     destinationAddress: string,
     sender: Wallet,
-    memos?: Array<XRPMemo>,
   ): Promise<string> {
+    return this.sendWithDetails({
+      amount,
+      destination: destinationAddress,
+      sender,
+    })
+  }
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination Pay ID, allowing
+   * for additional details to be specified for use with supplementary features of the XRP
+   * ledger.
+   *
+   * @param sendMoneyDetails - a wrapper object containing details for constructing a transaction.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  public async sendWithDetails(
+    sendMoneyDetails: SendMoneyDetails,
+  ): Promise<string> {
+    const {
+      amount: drops,
+      sender,
+      destination: destinationAddress,
+      memos,
+    } = sendMoneyDetails
     if (!Utils.isValidXAddress(destinationAddress)) {
       throw XRPError.xAddressRequired
     }

--- a/src/XRP/model/send-money-details.ts
+++ b/src/XRP/model/send-money-details.ts
@@ -1,0 +1,15 @@
+import { BigInteger } from 'big-integer'
+import { Wallet } from 'xpring-common-js'
+import XRPMemo from './xrp-memo'
+
+/**
+ * Describes the fine grained details for sending money over the XRP ledger. The
+ * destination field may be a PayID, XAddress, or other type of address. Handling
+ * of the given destination type is the responsibility of the client.
+ */
+export default interface SendMoneyDetails {
+  amount: BigInteger | number | string
+  destination: string
+  sender: Wallet
+  memos?: Array<XRPMemo>
+}

--- a/src/XRP/model/send-xrp-details.ts
+++ b/src/XRP/model/send-xrp-details.ts
@@ -7,7 +7,7 @@ import XRPMemo from './xrp-memo'
  * destination field may be a PayID, XAddress, or other type of address. Handling
  * of the given destination type is the responsibility of the client.
  */
-export default interface SendMoneyDetails {
+export default interface SendXrpDetails {
   amount: BigInteger | number | string
   destination: string
   sender: Wallet

--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -6,7 +6,7 @@ import TransactionStatus from './transaction-status'
 import XRPTransaction from './model/xrp-transaction'
 import { XRPError } from '..'
 import { XRPErrorType } from './xrp-error'
-import XRPMemo from './model/xrp-memo'
+import SendMoneyDetails from './model/send-money-details'
 
 async function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
@@ -32,16 +32,23 @@ class ReliableSubmissionXRPClient implements XRPClientDecorator {
     amount: string | number | BigInteger,
     destination: string,
     sender: Wallet,
-    memos?: Array<XRPMemo>,
   ): Promise<string> {
-    const ledgerCloseTimeMs = 4 * 1000
-
-    // Submit a transaction hash and wait for a ledger to close.
-    const transactionHash = await this.decoratedClient.send(
+    return this.sendWithDetails({
       amount,
       destination,
       sender,
-      memos,
+    })
+  }
+
+  public async sendWithDetails(
+    sendMoneyDetails: SendMoneyDetails,
+  ): Promise<string> {
+    const { sender } = sendMoneyDetails
+    const ledgerCloseTimeMs = 4 * 1000
+
+    // Submit a transaction hash and wait for a ledger to close.
+    const transactionHash = await this.decoratedClient.sendWithDetails(
+      sendMoneyDetails,
     )
     await sleep(ledgerCloseTimeMs)
 

--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -6,7 +6,7 @@ import TransactionStatus from './transaction-status'
 import XRPTransaction from './model/xrp-transaction'
 import { XRPError } from '..'
 import { XRPErrorType } from './xrp-error'
-import SendMoneyDetails from './model/send-money-details'
+import SendXrpDetails from './model/send-xrp-details'
 
 async function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
@@ -41,7 +41,7 @@ class ReliableSubmissionXRPClient implements XRPClientDecorator {
   }
 
   public async sendWithDetails(
-    sendMoneyDetails: SendMoneyDetails,
+    sendMoneyDetails: SendXrpDetails,
   ): Promise<string> {
     const { sender } = sendMoneyDetails
     const ledgerCloseTimeMs = 4 * 1000

--- a/src/XRP/xrp-client-decorator.ts
+++ b/src/XRP/xrp-client-decorator.ts
@@ -3,7 +3,7 @@ import { BigInteger } from 'big-integer'
 import TransactionStatus from './transaction-status'
 import RawTransactionStatus from './raw-transaction-status'
 import XRPTransaction from './model/xrp-transaction'
-import { XRPMemo } from './model'
+import SendMoneyDetails from './model/send-money-details'
 
 /** A decorator interface for XRPClients. */
 export interface XRPClientDecorator {
@@ -33,15 +33,23 @@ export interface XRPClientDecorator {
    * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
-   * @param memos An optional list of memos to add to the transaction.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   send(
     amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
-    memos?: Array<XRPMemo>,
   ): Promise<string>
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination Pay ID, allowing
+   * for additional details to be specified for use with supplementary features of the XRP
+   * ledger.
+   *
+   * @param sendMoneyDetails - a wrapper object containing details for constructing a transaction.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  sendWithDetails(sendMoneyDetails: SendMoneyDetails): Promise<string>
 
   /**
    * Retrieve the latest validated ledger sequence on the XRP Ledger.

--- a/src/XRP/xrp-client-decorator.ts
+++ b/src/XRP/xrp-client-decorator.ts
@@ -3,7 +3,7 @@ import { BigInteger } from 'big-integer'
 import TransactionStatus from './transaction-status'
 import RawTransactionStatus from './raw-transaction-status'
 import XRPTransaction from './model/xrp-transaction'
-import SendMoneyDetails from './model/send-money-details'
+import SendXrpDetails from './model/send-xrp-details'
 
 /** A decorator interface for XRPClients. */
 export interface XRPClientDecorator {
@@ -49,7 +49,7 @@ export interface XRPClientDecorator {
    * @param sendMoneyDetails - a wrapper object containing details for constructing a transaction.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
-  sendWithDetails(sendMoneyDetails: SendMoneyDetails): Promise<string>
+  sendWithDetails(sendMoneyDetails: SendXrpDetails): Promise<string>
 
   /**
    * Retrieve the latest validated ledger sequence on the XRP Ledger.

--- a/src/XRP/xrp-client-interface.ts
+++ b/src/XRP/xrp-client-interface.ts
@@ -4,6 +4,7 @@ import TransactionStatus from './transaction-status'
 import XRPLNetwork from '../Common/xrpl-network'
 import XRPTransaction from './model/xrp-transaction'
 import XRPMemo from './model/xrp-memo'
+import SendMoneyDetails from './model/send-money-details'
 
 /**
  * An interface describing XRPClient.
@@ -46,6 +47,16 @@ export default interface XRPClientInterface {
     sender: Wallet,
     memos?: Array<XRPMemo>,
   ): Promise<string>
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination Pay ID, allowing
+   * for additional details to be specified for use with supplementary features of the XRP
+   * ledger.
+   *
+   * @param sendMoneyDetails - a wrapper object containing details for constructing a transaction.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  sendWithDetails(sendMoneyDetails: SendMoneyDetails): Promise<string>
 
   /**
    * Check if an address exists on the XRP Ledger.

--- a/src/XRP/xrp-client-interface.ts
+++ b/src/XRP/xrp-client-interface.ts
@@ -4,7 +4,7 @@ import TransactionStatus from './transaction-status'
 import XRPLNetwork from '../Common/xrpl-network'
 import XRPTransaction from './model/xrp-transaction'
 import XRPMemo from './model/xrp-memo'
-import SendMoneyDetails from './model/send-money-details'
+import SendXrpDetails from './model/send-xrp-details'
 
 /**
  * An interface describing XRPClient.
@@ -56,7 +56,7 @@ export default interface XRPClientInterface {
    * @param sendMoneyDetails - a wrapper object containing details for constructing a transaction.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
-  sendWithDetails(sendMoneyDetails: SendMoneyDetails): Promise<string>
+  sendWithDetails(sendMoneyDetails: SendXrpDetails): Promise<string>
 
   /**
    * Check if an address exists on the XRP Ledger.

--- a/src/XRP/xrp-client.ts
+++ b/src/XRP/xrp-client.ts
@@ -7,7 +7,7 @@ import DefaultXRPClient from './default-xrp-client'
 import XRPClientInterface from './xrp-client-interface'
 import XRPTransaction from './model/xrp-transaction'
 import XRPLNetwork from '../Common/xrpl-network'
-import SendMoneyDetails from './model/send-money-details'
+import SendXrpDetails from './model/send-xrp-details'
 
 /**
  * XRPClient is a client which interacts with the Xpring platform.
@@ -91,7 +91,7 @@ class XRPClient implements XRPClientInterface {
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async sendWithDetails(
-    sendMoneyDetails: SendMoneyDetails,
+    sendMoneyDetails: SendXrpDetails,
   ): Promise<string> {
     return this.decoratedClient.sendWithDetails(sendMoneyDetails)
   }

--- a/src/XRP/xrp-client.ts
+++ b/src/XRP/xrp-client.ts
@@ -7,7 +7,7 @@ import DefaultXRPClient from './default-xrp-client'
 import XRPClientInterface from './xrp-client-interface'
 import XRPTransaction from './model/xrp-transaction'
 import XRPLNetwork from '../Common/xrpl-network'
-import { XRPMemo } from './model'
+import SendMoneyDetails from './model/send-money-details'
 
 /**
  * XRPClient is a client which interacts with the Xpring platform.
@@ -68,16 +68,32 @@ class XRPClient implements XRPClientInterface {
    * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
-   * @param memos An optional list of memos to add to the transaction.
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async send(
     amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
-    memos?: Array<XRPMemo>,
   ): Promise<string> {
-    return this.decoratedClient.send(amount, destination, sender, memos)
+    return this.sendWithDetails({
+      amount,
+      destination,
+      sender,
+    })
+  }
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination Pay ID, allowing
+   * for additional details to be specified for use with supplementary features of the XRP
+   * ledger.
+   *
+   * @param sendMoneyDetails - a wrapper object containing details for constructing a transaction.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  public async sendWithDetails(
+    sendMoneyDetails: SendMoneyDetails,
+  ): Promise<string> {
+    return this.decoratedClient.sendWithDetails(sendMoneyDetails)
   }
 
   /**

--- a/src/Xpring/xpring-client.ts
+++ b/src/Xpring/xpring-client.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'xpring-common-js'
 import { BigInteger } from 'big-integer'
 import XRPPayIDClientInterface from '../PayID/xrp-pay-id-client-interface'
 import XpringError from './xpring-error'
-import SendMoneyDetails from '../XRP/model/send-money-details'
+import SendXrpDetails from '../XRP/model/send-xrp-details'
 import XRPClientInterface from '../XRP/xrp-client-interface'
 
 /**
@@ -57,7 +57,7 @@ export default class XpringClient {
    * @returns A promise which resolves to a string representing the hash of the submitted transaction.
    */
   public async sendWithDetails(
-    sendMoneyDetails: SendMoneyDetails,
+    sendMoneyDetails: SendXrpDetails,
   ): Promise<string> {
     const {
       amount,

--- a/test/XRP/default-xrp-client-test.ts
+++ b/test/XRP/default-xrp-client-test.ts
@@ -283,12 +283,12 @@ describe('Default XRP Client', function (): void {
     const memos = [iForgotToPickUpCarlMemo]
 
     // WHEN the account makes a transaction with a memo.
-    const transactionHash = await xrpClient.send(
+    const transactionHash = await xrpClient.sendWithDetails({
       amount,
-      destinationAddress,
-      wallet,
+      destination: destinationAddress,
+      sender: wallet,
       memos,
-    )
+    })
 
     // THEN the transaction hash exists and finds the transaction with the memo.
     const expectedTransactionHash = Utils.toHex(

--- a/test/XRP/fakes/fake-xrp-client.ts
+++ b/test/XRP/fakes/fake-xrp-client.ts
@@ -5,7 +5,7 @@ import { Wallet, XRPLNetwork } from '../../../src/index'
 import RawTransactionStatus from '../../../src/XRP/raw-transaction-status'
 import XRPTransaction from '../../../src/XRP/model/xrp-transaction'
 import Result from '../../Common/Helpers/result'
-import SendMoneyDetails from '../../../src/XRP/model/send-money-details'
+import SendXrpDetails from '../../../src/XRP/model/send-xrp-details'
 
 class FakeXRPClient implements XRPClientDecorator {
   public constructor(
@@ -36,7 +36,7 @@ class FakeXRPClient implements XRPClientDecorator {
     return FakeXRPClient.returnOrThrow(this.sendValue)
   }
 
-  async sendWithDetails(_sendMoneyDetails: SendMoneyDetails): Promise<string> {
+  async sendWithDetails(_sendMoneyDetails: SendXrpDetails): Promise<string> {
     return FakeXRPClient.returnOrThrow(this.sendValue)
   }
 

--- a/test/XRP/fakes/fake-xrp-client.ts
+++ b/test/XRP/fakes/fake-xrp-client.ts
@@ -5,6 +5,7 @@ import { Wallet, XRPLNetwork } from '../../../src/index'
 import RawTransactionStatus from '../../../src/XRP/raw-transaction-status'
 import XRPTransaction from '../../../src/XRP/model/xrp-transaction'
 import Result from '../../Common/Helpers/result'
+import SendMoneyDetails from '../../../src/XRP/model/send-money-details'
 
 class FakeXRPClient implements XRPClientDecorator {
   public constructor(
@@ -32,6 +33,10 @@ class FakeXRPClient implements XRPClientDecorator {
     _destination: string,
     _sender: Wallet,
   ): Promise<string> {
+    return FakeXRPClient.returnOrThrow(this.sendValue)
+  }
+
+  async sendWithDetails(_sendMoneyDetails: SendMoneyDetails): Promise<string> {
     return FakeXRPClient.returnOrThrow(this.sendValue)
   }
 

--- a/test/XRP/xrp-client-integration-test.ts
+++ b/test/XRP/xrp-client-integration-test.ts
@@ -71,12 +71,18 @@ describe('XRPClient Integration Tests', function (): void {
   it('Send XRP with memo - Web Shim', async function (): Promise<void> {
     this.timeout(timeoutMs)
 
-    const result = await xrpWebClient.send(amount, recipientAddress, wallet, [
+    const memos = [
       iForgotToPickUpCarlMemo,
       noDataMemo,
       noFormatMemo,
       noTypeMemo,
-    ])
+    ]
+    const result = await xrpWebClient.sendWithDetails({
+      amount,
+      destination: recipientAddress,
+      sender: wallet,
+      memos,
+    })
     assert.exists(result)
 
     const transaction = await xrpClient.getPayment(result)
@@ -98,13 +104,18 @@ describe('XRPClient Integration Tests', function (): void {
 
   it('Send XRP with memo - rippled', async function (): Promise<void> {
     this.timeout(timeoutMs)
-
-    const result = await xrpClient.send(amount, recipientAddress, wallet, [
+    const memos = [
       iForgotToPickUpCarlMemo,
       noDataMemo,
       noFormatMemo,
       noTypeMemo,
-    ])
+    ]
+    const result = await xrpClient.sendWithDetails({
+      amount,
+      destination: recipientAddress,
+      sender: wallet,
+      memos,
+    })
     assert.exists(result)
 
     const transaction = await xrpClient.getPayment(result)

--- a/test/Xpring/xpring-client-integration-test.ts
+++ b/test/Xpring/xpring-client-integration-test.ts
@@ -50,16 +50,22 @@ describe('Xpring Integration Tests', function (): void {
   it('Send XRP TestNet with memos', async function (): Promise<void> {
     this.timeout(timeoutMs)
 
-    // GIVEN a Pay ID that will resolve.
+    // GIVEN a Pay ID that will resolve and some memos.
     const payID = 'alice$dev.payid.xpring.money'
-
-    // WHEN XRP is sent to the Pay ID, including a memo.
-    const transactionHash = await xpringClient.send(10, payID, wallet, [
+    const memos = [
       iForgotToPickUpCarlMemo,
       noDataMemo,
       noFormatMemo,
       noTypeMemo,
-    ])
+    ]
+
+    // WHEN XRP is sent to the Pay ID, including a memo.
+    const transactionHash = await xpringClient.sendWithDetails({
+      amount: 10,
+      destination: payID,
+      sender: wallet,
+      memos,
+    })
 
     // THEN a transaction hash is returned and the memos are present.
     assert.exists(transactionHash)


### PR DESCRIPTION
Signed-off-by: Ian Simpson <ian.g.simpson@gmail.com>

## High Level Overview of Change

Wrap the additional details for memos on `send`

### Context of Change

After a discussion with Keefer, he mentioned a desire to keep the `send` method on the various clients as minimal as possible. This is an attempt to add an additional method that can accommodate what may end up being a growing list of details as we support more features of the XRP ledger.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Before: `send` could accept an optional argument of `memos`
After: a new `sendWithDetails` method and `SendMoneyDetails` interface exist for additional details.

## Test Plan

Tests have been updated to validate this behavior.
