### PR TITLE
ESLint 2/X - Clean up some tests

### DIFF
--- a/test/XRP/rippled-flags.test.ts
+++ b/test/XRP/rippled-flags.test.ts
@@ -1,12 +1,14 @@
-/* eslint-disable no-bitwise */
+/* eslint-disable no-bitwise -- Explicitly testing bitwise flags in this file */
 import { assert } from 'chai'
+
 import RippledFlags from '../../src/XRP/rippled-flags'
 import 'mocha'
 
 describe('rippled flags', function (): void {
   it('check - flag present', function (): void {
     // GIVEN a set of flags that contains the tfPartialPayment flag.
-    const flags = RippledFlags.TF_PARTIAL_PAYMENT | 1 | 4 // 1 and 4 are arbitrarily chosen numbers.
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- 1 and 4 are arbitrary chosen
+    const flags = RippledFlags.TF_PARTIAL_PAYMENT | 1 | 4
 
     // WHEN the presence of tfPartialPayment is checked THEN the flag is reported as present.
     assert.isTrue(
@@ -16,7 +18,8 @@ describe('rippled flags', function (): void {
 
   it('check - flag notpresent', function (): void {
     // GIVEN a set of flags that does not contain the tfPartialPayment flag.
-    const flags = 1 | 4 // 1 and 4 are arbitrarily chosen numbers.
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- 1 and 4 are arbitrary chosen
+    const flags = 1 | 4
 
     // WHEN the presence of tfPartialPayment is checked THEN the flag is reported as not present.
     assert.isFalse(

--- a/test/XRP/xrp-transaction-type-proto-conversion.test.ts
+++ b/test/XRP/xrp-transaction-type-proto-conversion.test.ts
@@ -1,5 +1,7 @@
 import { assert } from 'chai'
+
 import XRPAccountSet from '../../src/XRP/model/xrp-account-set'
+
 import {
   testAccountSetProtoAllFields,
   testAccountSetProtoOneFieldSet,

--- a/test/Xpring/xpring-client-integration.test.ts
+++ b/test/Xpring/xpring-client-integration.test.ts
@@ -1,9 +1,10 @@
 import { assert } from 'chai'
 import { Wallet } from 'xpring-common-js'
-import XpringClient from '../../src/Xpring/xpring-client'
-import XRPPayIDClient from '../../src/PayID/xrp-pay-id-client'
-import XRPClient from '../../src/XRP/xrp-client'
+
 import XRPLNetwork from '../../src/Common/xrpl-network'
+import XRPPayIDClient from '../../src/PayID/xrp-pay-id-client'
+import XpringClient from '../../src/Xpring/xpring-client'
+import XRPClient from '../../src/XRP/xrp-client'
 import {
   expectedNoDataMemo,
   expectedNoFormatMemo,
@@ -15,7 +16,8 @@ import {
 } from '../XRP/helpers/xrp-test-utils'
 
 // A timeout for these tests.
-const timeoutMs = 60 * 1000 // 1 minute
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- 1 minute in milliseconds
+const timeoutMs = 60 * 1000
 
 // The network to conduct tests on.
 const network = XRPLNetwork.Test
@@ -50,7 +52,8 @@ describe('Xpring Integration Tests', function (): void {
   it('Send XRP TestNet with memos', async function (): Promise<void> {
     this.timeout(timeoutMs)
 
-    // GIVEN a Pay ID that will resolve and some memos.
+    // GIVEN an amount, a PayID that will resolve, and some memos.
+    const amount = 10
     const payID = 'alice$dev.payid.xpring.money'
     const memos = [
       iForgotToPickUpCarlMemo,
@@ -61,7 +64,7 @@ describe('Xpring Integration Tests', function (): void {
 
     // WHEN XRP is sent to the Pay ID, including a memo.
     const transactionHash = await xpringClient.sendWithDetails({
-      amount: 10,
+      amount,
       destination: payID,
       sender: wallet,
       memos,

--- a/test/Xpring/xpring-client.test.ts
+++ b/test/Xpring/xpring-client.test.ts
@@ -12,6 +12,10 @@ import FakeXRPClient from '../XRP/fakes/fake-xrp-client'
 import { testXRPTransaction } from '../XRP/fakes/fake-xrp-protobufs'
 
 /* Default values for the fake XRP Client. These values must be provided but are not varied in testing. */
+/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/naming-convention --
+ * The 'magic-numbers' rule isn't smart enough to know this isn't really a magic number, and is just being fed to a wrapper,
+ * and we don't need to use our boolean variable prefix convention because we use a "fake" prefix for all of these variables.
+ */
 const fakeBalance = bigInt(10)
 const fakePaymentStatus = TransactionStatus.Succeeded
 const fakeTransactionHash = 'deadbeefdeadbeefdeadbeef'
@@ -20,22 +24,23 @@ const fakeAccountExistsResult = true
 const fakeRawTransactionStatus = new RawTransactionStatus(
   true,
   'tesSUCCESS',
-  10,
+  fakeLastLedgerSequenceValue,
   true,
 )
 const fakePaymentHistoryValue = []
 const fakeGetPaymentValue = testXRPTransaction
+/* eslint-enable @typescript-eslint/no-magic-numbers, @typescript-eslint/naming-convention */
 
-/** An amount to send. */
+// An amount to send
 const amount = 10
 
-/** A fake wallet. */
+// A fake wallet
 const wallet = new FakeWallet('0123456789abcdef')
 
-/** An Pay ID to resolve. */
+// A PayID to resolve
 const payID = '$xpring.money/georgewashington'
 
-/** Errors to throw */
+// Errors to throw
 const payIDError = new Error('Error from PayID')
 const xrpError = new Error('Error from XRP')
 
@@ -160,10 +165,11 @@ describe('Xpring Client', function (): void {
 
     // WHEN a XpringClient is constructed THEN a mismatched network XpringError is thrown.
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const xpringClient = new XpringClient(payIDClient, xrpClient)
       assert.fail(
-        `Should not have been able to construct an instance of XpringClient but instead created: ${xpringClient}`,
+        `Should not have been able to construct an instance of XpringClient but instead created: ${JSON.stringify(
+          xpringClient,
+        )}`,
       )
     } catch (error) {
       assert.deepEqual(error, XpringError.mismatchedNetworks)


### PR DESCRIPTION
## High Level Overview of Change

Refactor some test files to be compliant with the new linting configuration.

### Context of Change

Part of migrating `xpring-js` to `xpring-eslint`.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

`npm run test` is still green and `npm run lint` yells at me a bit less locally.

<!--
## Future Tasks
For future tasks related to PR.
-->
