### PR TITLE
[Experiment] X-address for `XRPAccountDelete`

### DIFF
--- a/src/XRP/model/xrp-account-delete.ts
+++ b/src/XRP/model/xrp-account-delete.ts
@@ -1,7 +1,10 @@
+import { Utils } from 'xpring-common-js'
 import { AccountDelete } from '../Generated/web/org/xrpl/rpc/v1/transaction_pb'
+import XRPLNetwork from '../../Common/xrpl-network'
 
 /*
  * Represents an AccountDelete transaction on the XRP Ledger.
+ *
  * An AccountDelete transaction deletes an account and any objects it owns in the XRP Ledger,
  * if possible, sending the account's remaining XRP to a specified destination account.
  *
@@ -18,25 +21,29 @@ export default class XRPAccountDelete {
    */
   public static from(
     accountDelete: AccountDelete,
+    xrplNetwork: XRPLNetwork,
   ): XRPAccountDelete | undefined {
-    // TODO(amiecorso): decide whether the existence of `destination` needs to be policed here
-    //                  via returning undefined or throwing an error
-    // TODO(amiecorso): should this object have an X-address version of this information?
     const destination = accountDelete.getDestination()?.getValue()?.getAddress()
+    if (!destination) {
+      return undefined
+    }
     const destinationTag = accountDelete.getDestinationTag()?.getValue()
 
-    return new XRPAccountDelete(destination, destinationTag)
+    const destinationXAddress = Utils.encodeXAddress(
+      destination,
+      destinationTag,
+      xrplNetwork == XRPLNetwork.Test,
+    )
+    if (!destinationXAddress) {
+      return undefined
+    }
+    return new XRPAccountDelete(destinationXAddress)
   }
 
   /**
-   *
-   * @param destination The address of an account to receive any leftover XRP after deleting the sending account.
-   *                    Must be a funded account in the ledger, and must not be the sending account.
-   * @param destinationTag (Optional) Arbitrary destination tag that identifies a hosted recipient ors
-   *                       other information for the recipient of the deleted account's leftover XRP.
+   * @param destinationXAddress The address and destination tag of an account to receive any leftover XRP after deleting the
+   *                            sending account, encoded as an X-address (see https://xrpaddress.info/).
+   *                            Must be a funded account in the ledger, and must not be the sending account.
    */
-  private constructor(
-    readonly destination?: string,
-    readonly destinationTag?: number,
-  ) {}
+  private constructor(readonly destinationXAddress: string) {}
 }

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -409,7 +409,7 @@ testInvalidGetAccountTransactionHistoryResponse.setTransactionsList(
 const testXRPTransaction = XRPTransaction.from(
   testGetTransactionResponseProto,
   XRPLNetwork.Test,
-)!!
+)!
 
 export {
   testCurrencyName,

--- a/test/XRP/xrp-transaction-type-proto-conversion.test.ts
+++ b/test/XRP/xrp-transaction-type-proto-conversion.test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai'
 
+import { Utils } from 'xpring-common-js'
 import XRPAccountSet from '../../src/XRP/model/xrp-account-set'
 import XRPAccountDelete from '../../src/XRP/model/xrp-account-delete'
 import {
@@ -8,6 +9,9 @@ import {
   testAccountDeleteProto,
   testAccountDeleteProtoNoTag,
 } from './fakes/fake-xrp-transaction-type-protobufs'
+import XRPLNetwork from '../../src/Common/xrpl-network'
+import { Account } from '../../src/XRP/Generated/web/org/xrpl/rpc/v1/common_pb'
+import { AccountDelete } from '../../src/XRP/Generated/web/org/xrpl/rpc/v1/transaction_pb'
 
 describe('Protobuf Conversions - Transaction Types', function (): void {
   // AccountSet
@@ -69,29 +73,46 @@ describe('Protobuf Conversions - Transaction Types', function (): void {
   it('Convert AccountDelete protobuf with all fields to XRPAccountDelete object', function (): void {
     // GIVEN an AccountDelete protocol buffer with all fields set.
     // WHEN the protocol buffer is converted to a native Typescript type.
-    const accountDelete = XRPAccountDelete.from(testAccountDeleteProto)
+    const accountDelete = XRPAccountDelete.from(
+      testAccountDeleteProto,
+      XRPLNetwork.Test,
+    )
 
     // THEN the AccountDelete converted as expected.
-    assert.deepEqual(
-      accountDelete?.destination,
+    const expectedXAddress = Utils.encodeXAddress(
       testAccountDeleteProto.getDestination()?.getValue()?.getAddress(),
+      testAccountDeleteProto.getDestinationTag()?.getValue(),
+      true,
     )
-    assert.deepEqual(
-      accountDelete?.destination,
-      testAccountDeleteProto.getDestination()?.getValue()?.getAddress(),
-    )
+    assert.deepEqual(accountDelete?.destinationXAddress, expectedXAddress)
   })
 
   it('Convert AccountDelete protobuf with no tag to XRPAccountDelete object', function (): void {
     // GIVEN an AccountDelete protocol buffer with only destination field set.
     // WHEN the protocol buffer is converted to a native Typescript type.
-    const accountDelete = XRPAccountDelete.from(testAccountDeleteProtoNoTag)
+    const accountDelete = XRPAccountDelete.from(
+      testAccountDeleteProtoNoTag,
+      XRPLNetwork.Test,
+    )
 
     // THEN the AccountDelete converted as expected.
-    assert.deepEqual(
-      accountDelete?.destination,
+    const expectedXAddress = Utils.encodeXAddress(
       testAccountDeleteProtoNoTag.getDestination()?.getValue()?.getAddress(),
+      testAccountDeleteProtoNoTag.getDestinationTag()?.getValue(),
+      true,
     )
-    assert.isUndefined(accountDelete?.destinationTag)
+    assert.deepEqual(accountDelete?.destinationXAddress, expectedXAddress)
+  })
+
+  it('Convert AccountDelete protobuf to XRPAccountDelete object - missing destination field', function (): void {
+    // GIVEN an AccountDelete protocol buffer missing the destination field.
+    // WHEN the protocol buffer is converted to a native Typescript type.
+    const accountDelete = XRPAccountDelete.from(
+      new AccountDelete(),
+      XRPLNetwork.Test,
+    )
+
+    // THEN the result is undefined.
+    assert.isUndefined(accountDelete)
   })
 })

--- a/test/XRP/xrp-transaction-type-proto-conversion.test.ts
+++ b/test/XRP/xrp-transaction-type-proto-conversion.test.ts
@@ -10,7 +10,6 @@ import {
   testAccountDeleteProtoNoTag,
 } from './fakes/fake-xrp-transaction-type-protobufs'
 import XRPLNetwork from '../../src/Common/xrpl-network'
-import { Account } from '../../src/XRP/Generated/web/org/xrpl/rpc/v1/common_pb'
 import { AccountDelete } from '../../src/XRP/Generated/web/org/xrpl/rpc/v1/transaction_pb'
 
 describe('Protobuf Conversions - Transaction Types', function (): void {
@@ -80,7 +79,7 @@ describe('Protobuf Conversions - Transaction Types', function (): void {
 
     // THEN the AccountDelete converted as expected.
     const expectedXAddress = Utils.encodeXAddress(
-      testAccountDeleteProto.getDestination()?.getValue()?.getAddress(),
+      testAccountDeleteProto.getDestination()?.getValue()?.getAddress()!,
       testAccountDeleteProto.getDestinationTag()?.getValue(),
       true,
     )
@@ -97,7 +96,7 @@ describe('Protobuf Conversions - Transaction Types', function (): void {
 
     // THEN the AccountDelete converted as expected.
     const expectedXAddress = Utils.encodeXAddress(
-      testAccountDeleteProtoNoTag.getDestination()?.getValue()?.getAddress(),
+      testAccountDeleteProtoNoTag.getDestination()?.getValue()?.getAddress()!,
       testAccountDeleteProtoNoTag.getDestinationTag()?.getValue(),
       true,
     )

--- a/test/XRP/xrp-transaction-type-proto-conversion.test.ts
+++ b/test/XRP/xrp-transaction-type-proto-conversion.test.ts
@@ -79,7 +79,7 @@ describe('Protobuf Conversions - Transaction Types', function (): void {
 
     // THEN the AccountDelete converted as expected.
     const expectedXAddress = Utils.encodeXAddress(
-      testAccountDeleteProto.getDestination()?.getValue()?.getAddress()!,
+      testAccountDeleteProto.getDestination()!.getValue()!.getAddress()!,
       testAccountDeleteProto.getDestinationTag()?.getValue(),
       true,
     )
@@ -96,7 +96,7 @@ describe('Protobuf Conversions - Transaction Types', function (): void {
 
     // THEN the AccountDelete converted as expected.
     const expectedXAddress = Utils.encodeXAddress(
-      testAccountDeleteProtoNoTag.getDestination()?.getValue()?.getAddress()!,
+      testAccountDeleteProtoNoTag.getDestination()!.getValue()!.getAddress()!,
       testAccountDeleteProtoNoTag.getDestinationTag()?.getValue(),
       true,
     )


### PR DESCRIPTION
Check out the diff between this and the original `AccountDelete` branch... I'd rather implement X-addresses now instead of leaving TODOs and having to deprecate fields after the fact.  Do you think I should do it this way with an only-x-address, should we have all the fields available side-by-side?  I'm inclined to say that if we're doing X-addresses at all it should be the only option, because safety is the whole point, right?