### PR TITLE
(4/4) Add `AllNetworksPayIdClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `XrpPayIdClient` replaces the now deprecated `XRPPayIDClient`.
 - A new value, `Unknown` is added to the `XpringErrorType` enum.
 - A new class, `SingleNetworkPayIdClient`, replaces the functionality in `PayIdClient` and `PayIDClient`.
+- A new class, `AllNetworksPayIdClient`, resolves all possible addresses for a PayId.
 
 ### Deprecated
 

--- a/src/PayID/all-networks-pay-id-client.ts
+++ b/src/PayID/all-networks-pay-id-client.ts
@@ -1,0 +1,29 @@
+import PayIdClientImpl from './pay-id-client-impl'
+import { Address } from './Generated/api'
+
+/**
+ * A client for PayID protocol which resolves all addresses for a given PayID.
+ */
+export default class AllNetworksPayIdClient {
+  private readonly wrappedPayIdClient: PayIdClientImpl
+
+  /**
+   * Initialize a new AllNetworksPayIdClient.
+
+   * @param useHttps Whether to cuse HTTPS when making PayID requests. Most users should set this to 'true' to avoid
+   *                 Man-in-the-Middle attacks. Exposed as an option for testing purposes. Defaults to true.
+   */
+  public constructor(useHttps = true) {
+    this.wrappedPayIdClient = new PayIdClientImpl('payid', useHttps)
+  }
+
+  /**
+   * Retrieve all addresses associated with a PayID.
+   *
+   * @param payId The PayID to resolve for an address.
+   * @returns An array of addresses.
+   */
+  async allAddressesForPayId(payId: string): Promise<Array<Address>> {
+    return this.wrappedPayIdClient.addressForPayId(payId)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 export { PaymentRequest, PaymentResult, AccountBalance, IlpClient } from './ILP'
 export { default as PayIdClient, PayIDClient } from './PayID/pay-id-client'
 export { default as SingleNetworkPayIdClient } from './PayID/single-network-pay-id-client'
+export { default as AllNetworksPayIdClient } from './PayID/all-networks-pay-id-client'
 export {
   PayIDErrorType,
   PayIdErrorType,

--- a/test/PayID/all-networks-pay-id-client.test.ts
+++ b/test/PayID/all-networks-pay-id-client.test.ts
@@ -1,0 +1,86 @@
+import { assert } from 'chai'
+import nock from 'nock'
+import { PayIdUtils } from 'xpring-common-js'
+import PayIdError, { PayIdErrorType } from '../../src/PayID/pay-id-error'
+import AllNetworksPayIdClient from '../../src/PayID/all-networks-pay-id-client'
+
+describe('AllNetworkPayIdClient', function (): void {
+  afterEach(function () {
+    // Clean nock after each test.
+    nock.cleanAll()
+  })
+
+  it('allAddressesForPayId - invalid Pay ID', function (done): void {
+    // GIVEN an AllNetworksPayIdClient and an invalid PayID.
+    const invalidPayID = 'xpring.money/georgewashington' // Does not start with '$'
+    const payIdClient = new AllNetworksPayIdClient()
+
+    // WHEN addresses are resolved THEN an invalid Pay ID error is thrown.
+    payIdClient.allAddressesForPayId(invalidPayID).catch((error) => {
+      assert.equal((error as PayIdError).errorType, PayIdErrorType.InvalidPayId)
+      done()
+    })
+  })
+
+  it('allAddressesForPayId - successful response - match found', async function () {
+    // GIVEN a AllNetworksPayIdClient, valid PayID and mocked networking to return a set of matches for the PayID.
+    const payId = 'georgewashington$xpring.money'
+    const payIdClient = new AllNetworksPayIdClient()
+
+    const payIdComponents = PayIdUtils.parsePayID(payId)
+    if (!payIdComponents) {
+      throw new Error('Test precondition failed: Could not generate a Pay ID')
+    }
+
+    const addresses = [
+      {
+        addressDetailsType: 'CryptoAddressDetails',
+        addressDetails: {
+          address: 'X7cBcY4bdTTzk3LHmrKAK6GyrirkXfLHGFxzke5zTmYMfw4',
+        },
+      },
+      {
+        addressDetailsType: 'CryptoAddressDetails',
+        addressDetails: {
+          address: 'XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD28Sq49uo34VyjnmK5H',
+        },
+      },
+    ]
+
+    nock('https://xpring.money').get('/georgewashington').reply(200, {
+      addresses: addresses,
+    })
+
+    // WHEN all addresses are resolved.
+    const resolvedAddresses = await payIdClient.allAddressesForPayId(payId)
+
+    // THEN the returned data is as expected.
+    assert.deepEqual(addresses, resolvedAddresses)
+  })
+
+  it('xrpAddressForPayId - successful response - match not found', function (done) {
+    // GIVEN a AllNetworksPayIdClient, valid PayID and mocked networking to return a 404 for the payID.
+    const payId = 'georgewashington$xpring.money'
+    const payIdClient = new AllNetworksPayIdClient()
+
+    const payIdComponents = PayIdUtils.parsePayID(payId)
+    if (!payIdComponents) {
+      throw new Error('Test precondition failed: Could not parse Pay ID')
+    }
+    nock('https://xpring.money').get('/georgewashington').reply(404, {})
+
+    // WHEN addresses are resolved
+    payIdClient.allAddressesForPayId(payId).catch((error) => {
+      // THEN an unexpected response is thrown with the details of the error.
+      assert.equal(
+        (error as PayIdError).errorType,
+        PayIdErrorType.MappingNotFound,
+      )
+
+      const { message } = error
+      assert.include(message, payId)
+
+      done()
+    })
+  })
+})

--- a/test/PayID/pay-id-integration.test.ts
+++ b/test/PayID/pay-id-integration.test.ts
@@ -3,6 +3,7 @@ import PayIdError, { PayIdErrorType } from '../../src/PayID/pay-id-error'
 import PayIdClient from '../../src/PayID/pay-id-client'
 import XrpPayIdClient from '../../src/PayID/xrp-pay-id-client'
 import XrplNetwork from '../../src/Common/xrpl-network'
+import AllNetworksPayIdClient from '../../src/PayID/all-networks-pay-id-client'
 
 // A timeout for these tests.
 const timeoutMs = 60 * 1000 // 1 minute
@@ -136,5 +137,17 @@ describe('PayID Integration Tests', function (): void {
       'some_invoice_hash',
       'some_transaction_hash',
     )
+  })
+
+  it('resolves all addresses', async function (): Promise<void> {
+    // GIVEN a PayID with multiple addresses.
+    const payId = 'alice$dev.payid.xpring.money'
+    const payIdClient = new AllNetworksPayIdClient()
+
+    // WHEN the PayID is resolved to a set of addresses.
+    const addresses = await payIdClient.allAddressesForPayId(payId)
+
+    // THEN multiple results are returned.
+    assert(addresses.length > 1)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

This new class can resolve PayIDs to addresses on all networks. 

### Context of Change

This simply wraps a `PayIdClientImpl` with the correct mime type. 

Add unit / integration tests. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Clients can resolve all addresses. 

## Test Plan

CI. New unit and integration tests are provided to prove correctness. 