### PR TITLE
Attempt to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,8 @@ jobs:
           name: 'Install Java'
           command: |
             sudo apt update
-            sudo apt install apt-transport-https ca-certificates wget dirmngr gnupg software-properties-common
-            wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
-            sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-            sudo apt update
-            sudo apt install adoptopenjdk-8-hotspot
+            wget https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/pool/main/a/adoptopenjdk-14-hotspot/adoptopenjdk-14-hotspot_14.0.0+36-2_amd64.deb
+            sudo apt install ./adoptopenjdk-14-hotspot_14.0.0+36-2_amd64.deb 
 
       - run:
           name: 'Install protoc plugin'


### PR DESCRIPTION
## High Level Overview of Change

Fix build

### Context of Change

The build is broken because AdoptJDK is broken globally. Here's the issue tracking it:
https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1399

This is a workaround from the issue. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

We can actually build. 

## Test Plan

CI
