### PR TITLE
Feature: DNS TXT record support for PayID lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 _Read this in other languages: [日本語](README-ja.md)._
 
+# PayID-DNS extension
+
+This version of Xpring-JS will attempt to look up PayID information in a DNS TXT record before reverting to http/s protocol.
+
+For example requesting PayID `richard$payid.link` for `xrpl-mainnet` will first attempt to retreive a TXT record at `xrpl-mainnet.richard._payid.payid.link`. 
+
+If a JSON payload is available on that TXT record it will be processed using [PayID-Sign](https://github.com/codetsunami/payid-sign) to check authenticity, and, if verified, will be returned in place of the regular PayID http/s lookup.
+
+This provides an alternative to running a http/s server for seldom changed crypto addresses while maintaining the benefits of PayID as a universal cryptocurrency address-book. It also provides a DDoS resistant way to ensure a PayID is always available.
+
+To generate a JSON payload for your own DNS TXT record PayID please use the tool here: [PayID-Sign Commandline Tool](https://github.com/codetsunami/payid-sign-cmdline)
+
 # Xpring-JS
 
 Xpring-JS is the JavaScript client side library of the Xpring SDK.

--- a/README.md
+++ b/README.md
@@ -4,18 +4,6 @@
 
 _Read this in other languages: [日本語](README-ja.md)._
 
-# PayID-DNS extension
-
-This version of Xpring-JS will attempt to look up PayID information in a DNS TXT record before reverting to http/s protocol.
-
-For example requesting PayID `richard$payid.link` for `xrpl-mainnet` will first attempt to retreive a TXT record at `xrpl-mainnet.richard._payid.payid.link`. 
-
-If a JSON payload is available on that TXT record it will be processed using [PayID-Sign](https://github.com/codetsunami/payid-sign) to check authenticity, and, if verified, will be returned in place of the regular PayID http/s lookup.
-
-This provides an alternative to running a http/s server for seldom changed crypto addresses while maintaining the benefits of PayID as a universal cryptocurrency address-book. It also provides a DDoS resistant way to ensure a PayID is always available.
-
-To generate a JSON payload for your own DNS TXT record PayID please use the tool here: [PayID-Sign Commandline Tool](https://github.com/codetsunami/payid-sign-cmdline)
-
 # Xpring-JS
 
 Xpring-JS is the JavaScript client side library of the Xpring SDK.
@@ -483,6 +471,17 @@ const payId = 'alice$dev.payid.xpring.money'
 // Send XRP to the given PayID.
 const transactionHash = await xpringClient.send(amount, payId, wallet)
 ```
+# PayID-DNS extension
+
+This version of Xpring-JS will attempt to look up PayID information in a DNS TXT record before reverting to http/s protocol.
+
+For example requesting PayID `richard$payid.link` for `xrpl-mainnet` will first attempt to retreive a TXT record at `xrpl-mainnet.richard._payid.payid.link`. 
+
+If a JSON payload is available on that TXT record it will be processed using [PayID-Sign](https://github.com/codetsunami/payid-sign) to check authenticity, and, if verified, will be returned in place of the regular PayID http/s lookup.
+
+This provides an alternative to running a http/s server for seldom changed crypto addresses while maintaining the benefits of PayID as a universal cryptocurrency address-book. It also provides a DDoS resistant way to ensure a PayID is always available.
+
+To generate a JSON payload for your own DNS TXT record PayID please use the tool here: [PayID-Sign Commandline Tool](https://github.com/codetsunami/payid-sign-cmdline)
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xpring-js",
+  "name": "xpring-js-dns",
   "version": "5.0.0",
   "description": "XpringJS provides a Javascript based SDK for interacting with the Ripple Ledger.",
   "main": "build/index.js",
@@ -51,6 +51,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
+    "payid-sign": ">=1.0.2",
     "@grpc/grpc-js": "^1.1.1",
     "axios": "^0.19.2",
     "big-integer": "^1.6.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "xpring-js-dns",
-  "version": "5.0.0",
+  "name": "xpring-js",
+  "version": "5.1.0",
   "description": "XpringJS provides a Javascript based SDK for interacting with the Ripple Ledger.",
   "main": "build/index.js",
   "repository": {

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -2,6 +2,8 @@
 import { PayIdUtils } from 'xpring-common-js'
 import PayIdError, { PayIdErrorType } from './pay-id-error'
 import { Address, DefaultApi, CryptoAddressDetails } from './Generated/api'
+import * as PayIDSign from 'payid-sign'
+import * as dns from 'dns'
 
 const PAYID_API_VERSION = '1.0'
 
@@ -67,12 +69,28 @@ export default class PayIdClient {
   }
 
   /**
+   * Look up a DNS txt record and return as a promise
+   *
+   * @param domain the domain name to look up for example arthur._payid.mydomain.com
+   */
+  private async lookupDnsTxt(
+    domain:string
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+        dns.resolveTxt(domain, (err: any | null, addresses: string[][]) => {
+            if(err) reject(err)
+            resolve(addresses[0].join(''))
+        })
+    })
+  }
+
+  /**
    * Return an array of {@link Address}es that match the inputs.
    *
    * @param payId The PayID to resolve.
    * @param network The network to resolve on.
    */
-  private async addressesForPayIdAndNetwork(
+  public async addressesForPayIdAndNetwork(
     payId: string,
     network: string,
   ): Promise<Array<Address>> {
@@ -83,6 +101,24 @@ export default class PayIdClient {
 
     // Swagger API adds the leading '/' in path automatically because it is part of the endpoint.
     const path = payIdComponents.path.substring(1)
+
+    // First check if there is a DNS entry for this PayID, and use it preferentially if there is
+    const identifier = path.replace(/\+.+$/,'')
+    const domain = network + "." + identifier + "._payid." + payIdComponents.host
+    try {
+        const payload = await this.lookupDnsTxt(domain);
+        // execution to here is a DNS hit so process the DNS txt payload
+        if (PayIDSign.verify_signed_payid( identifier + '$' + payIdComponents.host, payload )) {
+            // if the DNS payload is not verified we will fall through to regular protocol,
+            // however if it is verified we will now return based on the DNS payload
+            var ret = JSON.parse(payload)
+            delete ret['signature'] 
+            delete ret['publicKey']
+            return [ret]
+        } 
+    } catch (error) {
+        // this is a DNS miss, so continue executing along the normal path
+    }
 
     const api = new DefaultApi(undefined, basePath)
 


### PR DESCRIPTION
## High Level Overview of Change

Add a secondary lookup path for PayIDs using JSON payloads held in TXT records in the global domain name system, signed using the public key of the cryptocurrency address to which the PayID points.

### Context of Change

PayID currently relies on the provision of a http/s service which must be actively run and maintained to support lookups for what is often essentially a static address-book of cryptocurrency addresses. This has a couple of drawbacks for adoption: 

Firstly: Cost. The net benefit of having a PayID is unlikely to be greater than the cost of running and maintaining a PayID server for the vast majority of users.

Secondly: Availability. If a PayID server is DDoS attacked or goes offline for any other reason a PayID becomes unusable. High availability is essential for adoption.

Providing a secondary lookup path for PayID addresses using the existing DNS system is therefore desirable.

However in order to protect against various long standing DNS attacks, such as cache poisoning, it is important to provide a way to verify information stored in a DNS TXT record. For this I have created a small library and command line utility for signing and verifying PayIDs using the public key of the crypto address the PayID points to: [PayID-Sign Tool](https://github.com/codetsunami/payid-sign-cmdline)

To use simply create a JSON payload with the above tool and then place it on a TXT record according to the following schema:
```
<network>-<mainnet|testnet>.<payid-identifier>._payid.<payid-host>
```
For example: `xrpl-mainnet.richard._payid.payid.link`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Before: PayIDs could only be looked up using the RFC http/s protocol
After: Resolving a PayID now first tries a DNS TXT record lookup, if one is found it attempts to cryptographically verify it, and if it is valid it is returned instead. If anything goes wrong revert to original protocol.

## Test Plan

Use [PayID-Sign Tool](https://github.com/codetsunami/payid-sign-cmdline) to create a JSON payload
Set the JSON payload into TXT record on a domain you own according to the following schema: 
```
<network>-<mainnet|testnet>.<payid-identifier>._payid.<your domain>
```

Run a lookup using this library on that PayID.

## Future Tasks
Test suite using a fake DNS resolver. 
Similar updates to other PayID client libraries.

## Other Notes
Please consider this contribution my entry into your [hackathon](https://payid.devpost.com/)
