### PR TITLE
Move off Deprecated APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1547,19 +1547,6 @@
         }
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.0.tgz",
-      "integrity": "sha512-/vSHUDYizSOhrOJdjYxPNGfb4a3ibO8zd4nUKo/QBFOmxosT3cVUV7KIg8Dwi6TXlr667G7YPqFK9+VSZOorNA==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/types": "3.9.0",
-        "@typescript-eslint/typescript-estree": "3.9.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^2.0.0"
-      }
-    },
     "@typescript-eslint/parser": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.9.1.tgz",
@@ -1638,60 +1625,6 @@
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-rb6LDr+dk9RVVXO/NJE8dT1pGlso3voNdEIN8ugm4CWM5w5GimbThCMiMl4da1t5u3YwPWEwOnKAULCZgBtBHg==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.0.tgz",
-      "integrity": "sha512-N+158NKgN4rOmWVfvKOMoMFV5n8XxAliaKkArm/sOypzQ0bUL8MSnOEBW3VFIeffb/K5ce/cAV0yYhR7U4ALAA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "3.9.0",
-        "@typescript-eslint/visitor-keys": "3.9.0",
-        "debug": "^4.1.1",
-        "glob": "^7.1.6",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
-        }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.0.tgz",
-      "integrity": "sha512-O1qeoGqDbu0EZUC/MZ6F1WHTIzcBVhGqDj3LhTnj65WUA548RXVxUHbYhAW9bZWfb2rnX9QsbbP5nmeJ5Z4+ng==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@webassemblyjs/ast": {

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -158,7 +158,7 @@ export default class PayIdClient {
    * Parse a payID to a host and path.
    */
   private static parsePayId(payId: string): PayIDComponents {
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw PayIdError.invalidPayId
     }

--- a/test/PayID/pay-id-client.test.ts
+++ b/test/PayID/pay-id-client.test.ts
@@ -32,7 +32,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIDComponents = PayIdUtils.parsePayID(payId)
+    const payIDComponents = PayIdUtils.parsePayId(payId)
     if (!payIDComponents) {
       throw new Error('Test precondition failed: Could not generate a PayID')
     }
@@ -75,7 +75,7 @@ describe('PayIdClient', function (): void {
     const payIdClient = new PayIdClient()
     const network = XrplNetwork.Test
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not parse PayID')
     }
@@ -164,7 +164,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not parse PayID')
     }
@@ -189,7 +189,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIDComponents = PayIdUtils.parsePayID(payId)
+    const payIDComponents = PayIdUtils.parsePayId(payId)
     if (!payIDComponents) {
       throw new Error('Test precondition failed: Could not generate a PayID')
     }
@@ -243,7 +243,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a PayID')
     }
@@ -287,7 +287,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not parse PayID')
     }

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -11,7 +11,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the host and path are set correctly.
     assert.equal(payIDComponents?.host, host)
@@ -25,7 +25,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the host and path are set correctly.
     assert.equal(payIDComponents?.host, host)
@@ -39,7 +39,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -50,7 +50,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `georgewashington@xpring.money`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -63,7 +63,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -76,7 +76,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -87,6 +87,6 @@ describe('PayIdUtils', function (): void {
     const rawPayID = 'ZA̡͊͠͝LGΌIS̯͈͕̹̘̱ͮ$TO͇̹̺ͅƝ̴ȳ̳TH̘Ë͖́̉ ͠P̯͍̭O̚N̐Y̡'
 
     // WHEN it is parsed to components THEN the result is undefined
-    assert.isUndefined(PayIdUtils.parsePayID(rawPayID))
+    assert.isUndefined(PayIdUtils.parsePayId(rawPayID))
   })
 })

--- a/test/PayID/xrp-pay-id-client.test.ts
+++ b/test/PayID/xrp-pay-id-client.test.ts
@@ -21,7 +21,7 @@ describe('XRP PayID Client', function (): void {
     const replyHeaders = {
       'content-type': 'application/xrpl-testnet+json',
     }
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }
@@ -57,7 +57,7 @@ describe('XRP PayID Client', function (): void {
     const classicAddress = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
     const xAddress = XrpUtils.encodeXAddress(classicAddress, undefined, true)
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }
@@ -101,7 +101,7 @@ describe('XRP PayID Client', function (): void {
       'content-type': 'application/xrpl-testnet+json',
     }
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }
@@ -140,7 +140,7 @@ describe('XRP PayID Client', function (): void {
       'content-type': 'application/xrpl-testnet+json',
     }
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }

--- a/test/XRP/xrp-utils.test.ts
+++ b/test/XRP/xrp-utils.test.ts
@@ -26,7 +26,7 @@ describe('xrp-drops-conversion', function (): void {
       'test.xrp.xpring.io:50051',
       XrplNetwork.Test,
     )
-    const balance = await xrpClient.getBalance(wallet!.getAddress())
+    const balance = await xrpClient.getBalance(wallet.getAddress())
     assert.isTrue(balance > bigInt('0'))
   })
 


### PR DESCRIPTION
## High Level Overview of Change

Migrate from `parsePayID` to `parsePayId`.

### Context of Change

xpring-common-js removes the deprecated method and we need to migrate in client side libraries. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

This library has an upgrade path to the latest version of xpring-common-js.

## Test Plan

CI
