### PR TITLE
Update `xpring-common-js` to v6.2.2

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -11,8 +11,8 @@ module.exports = {
   // Warn if test exceed 75ms duration
   slow: 75,
 
-  // Fail if tests exceed 10000ms
-  timeout: 10000,
+  // Fail if tests exceed 20000ms (20 sec)
+  timeout: 20000,
 
   // Check for global variable leaks
   'check-leaks': true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2667,15 +2667,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3445,11 +3436,6 @@
         "through2": "^2.0.1",
         "yargs": "^15.3.1"
       }
-    },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -6238,7 +6224,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -8190,11 +8177,6 @@
         "regenerate": "^1.4.0"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
     "regenerator-transform": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
@@ -8457,24 +8439,13 @@
       }
     },
     "ripple-binary-codec": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-0.2.6.tgz",
-      "integrity": "sha512-k0efyjpcde7p+rJ9PXW9tJSYsUDdlC9Z9xU7OPM7fJiHVKlR1E7nfu0jqw9vVXtTG3tujqKeEgtcb8yaa7rMXA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.0.1.tgz",
+      "integrity": "sha512-y6pMZbCuBrd89fHabo16TTOdoL9XmSxZyKADJhBrvVFtTfN7ILC+139peWmvxWwEgnp9PKcZtn8RTuAIWYkQYg==",
       "requires": {
-        "babel-runtime": "^6.6.1",
-        "bn.js": "^5.1.1",
-        "create-hash": "^1.1.2",
+        "create-hash": "^1.2.0",
         "decimal.js": "^10.2.0",
-        "inherits": "^2.0.1",
-        "lodash": "^4.17.15",
-        "ripple-address-codec": "^4.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
-        }
+        "ripple-address-codec": "^4.1.1"
       }
     },
     "ripple-keypairs": {
@@ -8490,9 +8461,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
         }
       }
     },
@@ -10678,29 +10649,17 @@
       "integrity": "sha512-BDtiD0i2iKPK/S8OAZfpk6tyzEDnKKSjxWHcMBVmh+LuqJ8A32qXTyOx+TVOg2dKvq6zGBq2sgKPkEeRs1qTRA=="
     },
     "xpring-common-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-6.1.0.tgz",
-      "integrity": "sha512-korkdsYxx/29rIFZ1CBWePOD2S0UnrUELZXuk1O83VFL/x9kbDct5/wkjbG9+ZpPyD1jLh+ngzYSdNN/0K1PDw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/xpring-common-js/-/xpring-common-js-6.2.2.tgz",
+      "integrity": "sha512-pV/zprQZvRAxXN91kOAQURbNZ6cW3+ouq5LRwVTSU4djZ0AIO4EQ4li0XzVmwpYvDDlMMYV4KGKZIqYqGBYL/w==",
       "requires": {
         "bip32": "2.0.5",
         "bip39": "^3.0.2",
-        "google-protobuf": "3.12.4",
-        "grpc-web": "1.2.0",
+        "google-protobuf": "3.13.0",
+        "grpc-web": "1.2.1",
         "ripple-address-codec": "4.1.1",
-        "ripple-binary-codec": "0.2.6",
+        "ripple-binary-codec": "1.0.1",
         "ripple-keypairs": "^1.0.0"
-      },
-      "dependencies": {
-        "google-protobuf": {
-          "version": "3.12.4",
-          "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.12.4.tgz",
-          "integrity": "sha512-ItTn8YepDQMHEMHloUPH+FDaTPiHTnbsMvP50aXfbI65IK3AA5+wXlHSygJH8xz+h1g4gu7V+CK5X1/SaGITsA=="
-        },
-        "grpc-web": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.2.0.tgz",
-          "integrity": "sha512-QS0RF+xiWnMEiHWyA0A0I8JYYJLOiF/DGEpRQ7vJDOzEZYfmNqI7d7d29sYBbNfTi+arVh2JpeGIX7ch24a+tA=="
-        }
       }
     },
     "xregexp": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "google-protobuf": "^3.12.2",
     "grpc-web": "1.2.1",
     "xhr2": "0.2.0",
-    "xpring-common-js": "6.1.0"
+    "xpring-common-js": "6.2.2"
   },
   "nyc": {
     "extension": [

--- a/src/PayID/pay-id-client.ts
+++ b/src/PayID/pay-id-client.ts
@@ -158,7 +158,7 @@ export default class PayIdClient {
    * Parse a payID to a host and path.
    */
   private static parsePayId(payId: string): PayIDComponents {
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw PayIdError.invalidPayId
     }

--- a/src/PayID/xrp-pay-id-client.ts
+++ b/src/PayID/xrp-pay-id-client.ts
@@ -9,7 +9,8 @@ import XrpPayIdClientInterface from './xrp-pay-id-client-interface'
 /**
  * Provides functionality for XRP in the PayID protocol.
  */
-export default class XrpPayIdClient extends PayIdClient
+export default class XrpPayIdClient
+  extends PayIdClient
   implements XrpPayIdClientInterface {
   /**
    * @param xrplNetwork The XRP Ledger network that this client attaches to.

--- a/test/PayID/pay-id-client.test.ts
+++ b/test/PayID/pay-id-client.test.ts
@@ -32,7 +32,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIDComponents = PayIdUtils.parsePayID(payId)
+    const payIDComponents = PayIdUtils.parsePayId(payId)
     if (!payIDComponents) {
       throw new Error('Test precondition failed: Could not generate a PayID')
     }
@@ -75,7 +75,7 @@ describe('PayIdClient', function (): void {
     const payIdClient = new PayIdClient()
     const network = XrplNetwork.Test
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not parse PayID')
     }
@@ -164,7 +164,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not parse PayID')
     }
@@ -189,7 +189,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIDComponents = PayIdUtils.parsePayID(payId)
+    const payIDComponents = PayIdUtils.parsePayId(payId)
     if (!payIDComponents) {
       throw new Error('Test precondition failed: Could not generate a PayID')
     }
@@ -243,7 +243,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a PayID')
     }
@@ -287,7 +287,7 @@ describe('PayIdClient', function (): void {
     const payId = 'georgewashington$xpring.money'
     const payIdClient = new PayIdClient()
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not parse PayID')
     }

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -11,7 +11,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the host and path are set correctly.
     assert.equal(payIDComponents?.host, host)
@@ -25,7 +25,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the host and path are set correctly.
     assert.equal(payIDComponents?.host, host)
@@ -39,7 +39,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -50,7 +50,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `georgewashington@xpring.money`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -63,7 +63,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -76,7 +76,7 @@ describe('PayIdUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayId(rawPayID)
 
     // THEN the PayID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -87,6 +87,6 @@ describe('PayIdUtils', function (): void {
     const rawPayID = 'ZA̡͊͠͝LGΌIS̯͈͕̹̘̱ͮ$TO͇̹̺ͅƝ̴ȳ̳TH̘Ë͖́̉ ͠P̯͍̭O̚N̐Y̡'
 
     // WHEN it is parsed to components THEN the result is undefined
-    assert.isUndefined(PayIdUtils.parsePayID(rawPayID))
+    assert.isUndefined(PayIdUtils.parsePayId(rawPayID))
   })
 })

--- a/test/PayID/xrp-pay-id-client.test.ts
+++ b/test/PayID/xrp-pay-id-client.test.ts
@@ -21,7 +21,7 @@ describe('XRP PayID Client', function (): void {
     const replyHeaders = {
       'content-type': 'application/xrpl-testnet+json',
     }
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }
@@ -57,7 +57,7 @@ describe('XRP PayID Client', function (): void {
     const classicAddress = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
     const xAddress = XrpUtils.encodeXAddress(classicAddress, undefined, true)
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }
@@ -101,7 +101,7 @@ describe('XRP PayID Client', function (): void {
       'content-type': 'application/xrpl-testnet+json',
     }
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }
@@ -140,7 +140,7 @@ describe('XRP PayID Client', function (): void {
       'content-type': 'application/xrpl-testnet+json',
     }
 
-    const payIdComponents = PayIdUtils.parsePayID(payId)
+    const payIdComponents = PayIdUtils.parsePayId(payId)
     if (!payIdComponents) {
       throw new Error('Test precondition failed: Could not generate a Pay ID')
     }

--- a/test/XRP/helpers/xrp-test-utils.ts
+++ b/test/XRP/helpers/xrp-test-utils.ts
@@ -1,6 +1,6 @@
 import { GetAccountTransactionHistoryResponse } from '../../../src/XRP/Generated/web/org/xrpl/rpc/v1/get_account_transaction_history_pb'
 import XrpTransaction from '../../../src/XRP/model/xrp-transaction'
-import { Wallet, XrplNetwork } from 'xpring-common-js'
+import { WalletFactory, Wallet, XrplNetwork } from 'xpring-common-js'
 import { XrpUtils, XrpError, XrpErrorType } from '../../../src/XRP'
 import XrpMemo from '../../../src/XRP/model/xrp-memo'
 import bigInt from 'big-integer'
@@ -41,9 +41,10 @@ export default class XRPTestUtils {
    * Generates a random wallet and funds it using the XRPL Testnet faucet.
    */
   static async randomWalletFromFaucet(): Promise<Wallet> {
-    const timeoutInSeconds = 20
+    const timeoutInSeconds = 40
 
-    const wallet = Wallet.generateRandomWallet()?.wallet
+    const walletFactory = new WalletFactory(XrplNetwork.Test)
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     if (!wallet) {
       throw new XrpError(
         XrpErrorType.Unknown,

--- a/test/XRP/xrp-client-integration.test.ts
+++ b/test/XRP/xrp-client-integration.test.ts
@@ -6,9 +6,6 @@ import XrpClient from '../../src/XRP/xrp-client'
 import GrpcNetworkClient from '../../src/XRP/grpc-xrp-network-client'
 
 import XRPTestUtils, {
-  expectedNoDataMemo,
-  expectedNoFormatMemo,
-  expectedNoTypeMemo,
   iForgotToPickUpCarlMemo,
   noDataMemo,
   noFormatMemo,
@@ -100,9 +97,9 @@ describe('XrpClient Integration Tests', function (): void {
 
     assert.deepEqual(transaction?.memos, [
       iForgotToPickUpCarlMemo,
-      expectedNoDataMemo,
-      expectedNoFormatMemo,
-      expectedNoTypeMemo,
+      noDataMemo,
+      noFormatMemo,
+      noTypeMemo,
     ])
   })
 
@@ -133,9 +130,9 @@ describe('XrpClient Integration Tests', function (): void {
 
     assert.deepEqual(transaction?.memos, [
       iForgotToPickUpCarlMemo,
-      expectedNoDataMemo,
-      expectedNoFormatMemo,
-      expectedNoTypeMemo,
+      noDataMemo,
+      noFormatMemo,
+      noTypeMemo,
     ])
   })
 

--- a/test/Xpring/xpring-client-integration.test.ts
+++ b/test/Xpring/xpring-client-integration.test.ts
@@ -5,9 +5,6 @@ import XrpPayIdClient from '../../src/PayID/xrp-pay-id-client'
 import XpringClient from '../../src/Xpring/xpring-client'
 import XrpClient from '../../src/XRP/xrp-client'
 import XRPTestUtils, {
-  expectedNoDataMemo,
-  expectedNoFormatMemo,
-  expectedNoTypeMemo,
   iForgotToPickUpCarlMemo,
   noDataMemo,
   noFormatMemo,
@@ -80,9 +77,9 @@ describe('Xpring Integration Tests', function (): void {
 
     assert.deepEqual(transaction?.memos, [
       iForgotToPickUpCarlMemo,
-      expectedNoDataMemo,
-      expectedNoFormatMemo,
-      expectedNoTypeMemo,
+      noDataMemo,
+      noFormatMemo,
+      noTypeMemo,
     ])
   })
 })


### PR DESCRIPTION
## High Level Overview of Change
This PR finally updates to the latest version of `xpring-common-js` in `xpring-js` after a few release cycles.  Couldn't rely on dependabot for this one because there were a few breaking changes in x-c-js that required manual intervention.  Note that the updates to the integration tests are due to the fact that the old version of the `ripple-binary-codec` actually gave `undefined` values default values, which in the case of memos involved an empty string.  This is *not* ideal behavior and has been remedied in `r-b-c` v1.0.1, which simply removes `undefined`s before blobing and signing, hence the new expected values from the ledger.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Release

## Before / After
`xpring-js` running latest version of `xpring-common-js`
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
Get this version of `xpring-common-js` to work in Java and Swift 