### PR TITLE
Adds New `XrpError` Type Specific to Protocol Buffer Conversions

### DIFF
--- a/src/XRP/xrp-error.ts
+++ b/src/XRP/xrp-error.ts
@@ -33,10 +33,11 @@ export default class XrpError extends Error {
 
   /**
    * Encountered a protocol buffer formatted in contradiction to the logic of the XRPL.
+   * @see xrpl.org for XRPL documentation.
    */
   static malformedProtobuf = new XrpError(
     XrpErrorType.MalformedProtobuf,
-    'Encountered a protocol buffer formatted in contradiction to the XRPL business logic',
+    'Encountered a protocol buffer in unexpected format.  See xrpl.org for XRPL documentation.',
   )
 
   /**

--- a/src/XRP/xrp-error.ts
+++ b/src/XRP/xrp-error.ts
@@ -4,6 +4,7 @@
 export enum XrpErrorType {
   InvalidInput,
   PaymentConversionFailure,
+  MalformedProtobuf,
   MalformedResponse,
   SigningError,
   Unknown,
@@ -28,6 +29,14 @@ export default class XrpError extends Error {
   static paymentConversionFailure = new XrpError(
     XrpErrorType.PaymentConversionFailure,
     'Could not convert payment transaction: (transaction). Please file a bug at https://github.com/xpring-eng/Xpring-JS/issues',
+  )
+
+  /**
+   * Encountered a protocol buffer formatted in contradiction to the logic of the XRPL.
+   */
+  static malformedProtobuf = new XrpError(
+    XrpErrorType.MalformedProtobuf,
+    'Encountered a protocol buffer formatted in contradiction to the XRPL business logic',
   )
 
   /**


### PR DESCRIPTION
## High Level Overview of Change
This PR adds a new type to the `XrpError` class in preparation for throwing descriptive errors from the Protobuf wrapper classes.  Note that while a pre-packaged `XrpError.malformedProtobuf` object exists as a static attribute with default error message on `XrpError`, we encourage the use of custom instances of `XrpError` with type `XrpTransactionType.MalformedProtobuf` and a more descriptive error message. 

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
We are about to audit our Protobuf wrapper classes in `xpring-js` for more robust logic checks, more useful throwing behavior, and more descriptive errors.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)


## Before / After
`XrpErrorType` has a new enum member, `XrpError` has a new static attribute.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI passes
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
