### PR TITLE
Audits `XrpMemo` Protobuf Wrapper

### DIFF
--- a/src/XRP/model/xrp-memo.ts
+++ b/src/XRP/model/xrp-memo.ts
@@ -1,3 +1,4 @@
+import { XrpError, XrpErrorType } from '..'
 import { Memo } from '../Generated/web/org/xrpl/rpc/v1/transaction_pb'
 import { stringToUint8Array } from '../../Common/utils'
 
@@ -23,10 +24,16 @@ export default class XrpMemo {
    * @return an XrpMemo with its fields set via the analogous protobuf fields.
    * @see https://github.com/ripple/rippled/blob/develop/src/ripple/proto/org/xrpl/rpc/v1/transaction.proto#L80
    */
-  public static from(memo: Memo): XrpMemo | undefined {
+  public static from(memo: Memo): XrpMemo {
     const data = memo.getMemoData()?.getValue_asU8()
     const format = memo.getMemoFormat()?.getValue_asU8()
     const type = memo.getMemoType()?.getValue_asU8()
+    if (!data && !format && !type) {
+      throw new XrpError(
+        XrpErrorType.MalformedProtobuf,
+        'Memo protobuf missing all fields (requires at least one field).',
+      )
+    }
     return new XrpMemo(data, format, type)
   }
 

--- a/test/XRP/xrp-protocol-buffer-conversion.test.ts
+++ b/test/XRP/xrp-protocol-buffer-conversion.test.ts
@@ -361,13 +361,10 @@ describe('Protocol Buffer Conversion', function (): void {
 
   it('Convert Memo with no fields set', function (): void {
     // GIVEN a memo with no fields set.
-    // WHEN the protocol buffer is converted to a native TypeScript type
-    const memo = XrpMemo.from(testEmptyMemoProto)
-
-    // THEN all fields are undefined.
-    assert.isUndefined(memo?.data)
-    assert.isUndefined(memo?.format)
-    assert.isUndefined(memo?.type)
+    // WHEN the protocol buffer is converted to a native TypeScript type THEN an error is thrown.
+    assert.throws(() => {
+      XrpMemo.from(testEmptyMemoProto)
+    }, XrpError)
   })
 
   // Signer


### PR DESCRIPTION
## High Level Overview of Change

This PR adds additional logic validations and descriptive error throwing to the class `XrpMemo`.

### Context of Change

Another component of our attempt to make protobuf wrapper classes as safe and informative as possible. An SDK safety net.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

`XrpMemo` performs logic/error checking, based on the business logic in the docs.

## Test Plan

Existing tests were edited to properly account for the new errors and to confirm that the errors are correctly thrown. CI passes.

## Future Tasks
This is part of a series, with all subtasks listed here: https://app.asana.com/0/1188384817180008/1193021408531788/f
