### PR TITLE
Generalizes logic in DefaultXrpClient::enableDepositAuth

### DIFF
--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -86,8 +86,19 @@ export default class ReliableSubmissionXrpClient implements XrpClientDecorator {
 
   public async enableDepositAuth(wallet: Wallet): Promise<TransactionResult> {
     const result = await this.decoratedClient.enableDepositAuth(wallet)
-    const transactionHash = result.hash
+    return await this.awaitFinalTransactionResult(result.hash, wallet)
+  }
 
+  /**
+   * Waits for a transaction to complete and returns a TransactionResult.
+   *
+   * @param transactionHash The transaction to wait for.
+   * @param wallet The wallet sending the transaction.
+   */
+  private async awaitFinalTransactionResult(
+    transactionHash: string,
+    wallet: Wallet,
+  ): Promise<TransactionResult> {
     const rawTransactionStatus = await this.awaitFinalTransactionStatus(
       transactionHash,
       wallet,

--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -94,6 +94,9 @@ export default class ReliableSubmissionXrpClient implements XrpClientDecorator {
    *
    * @param transactionHash The transaction to wait for.
    * @param wallet The wallet sending the transaction.
+   *
+   * @returns A Promise resolving to a TransactionResult containing the results of the transaction associated with
+   * the given transaction hash.
    */
   private async awaitFinalTransactionResult(
     transactionHash: string,

--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -53,7 +53,7 @@ export default class ReliableSubmissionXrpClient implements XrpClientDecorator {
     const transactionHash = await this.decoratedClient.sendWithDetails(
       sendXrpDetails,
     )
-    await this.awaitFinalTransactionResult(transactionHash, sender)
+    await this.awaitFinalTransactionStatus(transactionHash, sender)
 
     return transactionHash
   }
@@ -88,7 +88,7 @@ export default class ReliableSubmissionXrpClient implements XrpClientDecorator {
     const result = await this.decoratedClient.enableDepositAuth(wallet)
     const transactionHash = result.hash
 
-    const rawTransactionStatus = await this.awaitFinalTransactionResult(
+    const rawTransactionStatus = await this.awaitFinalTransactionStatus(
       transactionHash,
       wallet,
     )
@@ -116,7 +116,7 @@ export default class ReliableSubmissionXrpClient implements XrpClientDecorator {
     }
   }
 
-  private async awaitFinalTransactionResult(
+  private async awaitFinalTransactionStatus(
     transactionHash: string,
     sender: Wallet,
   ): Promise<RawTransactionStatus> {


### PR DESCRIPTION
## High Level Overview of Change
Renames awaitFinalTransactionResult to awaitFinalTransactionStatus and makes awaitFinalTransactionResult return a TransactionResult
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
DefaultXrpClient::enableDepositAuth has some logic that will be useful as we add more functionality that I want to use for DepositPreauth, but could imagine being used for other transaction types.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
enableDepositAuth uses awaitFinalTransactionResult
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
