### PR TITLE
Implements `requireAuthorizedTrustlines` on `IssuedCurrencyClient`

### DIFF
--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -76,7 +76,10 @@ export default class IssuedCurrencyClient {
       wallet,
     )
 
-    return await this.coreXrplClient.getTransactionResult(transactionHash)
+    return await this.coreXrplClient.getFinalTransactionResultAsync(
+      transactionHash,
+      wallet,
+    )
   }
 
   public shutUpCompiler(): void {

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -57,7 +57,7 @@ export default class IssuedCurrencyClient {
    *
    * @param wallet The wallet associated with the XRPL account enabling Require Authorization and that will sign the request.
    * @returns A promise which resolves to a TransactionResult object that contains the hash of the submitted AccountSet transaction,
-   *          the preliminary status, and whether the transaction has been included in a validated ledger yet.
+   *          the final status, and whether the transaction was included in a validated ledger.
    */
   public async requireAuthorizedTrustlines(
     wallet: Wallet,

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -56,8 +56,7 @@ export default class IssuedCurrencyClient {
    * @see https://xrpl.org/become-an-xrp-ledger-gateway.html#require-auth
    *
    * @param wallet The wallet associated with the XRPL account enabling Require Authorization and that will sign the request.
-   * @returns A promise which resolves to a TransactionResult object that contains the hash of the submitted AccountSet transaction,
-   *          the final status, and whether the transaction was included in a validated ledger.
+   * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
    */
   public async requireAuthorizedTrustlines(
     wallet: Wallet,

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -44,7 +44,7 @@ export default class IssuedCurrencyClient {
    * @param network The network this IssuedCurrencyClient is connecting to.
    */
   public constructor(
-    private readonly networkClient: XrpNetworkClient,
+    networkClient: XrpNetworkClient,
     readonly network: XrplNetwork,
   ) {
     this.coreXrplClient = new CoreXrplClient(networkClient, network)
@@ -80,9 +80,5 @@ export default class IssuedCurrencyClient {
       transactionHash,
       wallet,
     )
-  }
-
-  public shutUpCompiler(): void {
-    console.log(this.networkClient)
   }
 }

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -84,6 +84,5 @@ export default class IssuedCurrencyClient {
 
   public shutUpCompiler(): void {
     console.log(this.networkClient)
-    console.log(this.coreXrplClient)
   }
 }

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -1,0 +1,53 @@
+import { XrplNetwork } from 'xpring-common-js'
+import GrpcNetworkClient from './network-clients/grpc-xrp-network-client'
+import GrpcNetworkClientWeb from './network-clients/grpc-xrp-network-client.web'
+import { XrpNetworkClient } from './network-clients/xrp-network-client'
+import isNode from '../Common/utils'
+import CoreXrplClient from './core-xrpl-client'
+
+/**
+ * IssuedCurrencyClient is a client for working with Issued Currencies on the XRPL.
+ * @see https://xrpl.org/issued-currencies-overview.html
+ */
+export default class IssuedCurrencyClient {
+  private coreXrplClient: CoreXrplClient
+
+  /**
+   * Create a new IssuedCurrencyClient.
+   *
+   * The IssuedCurrencyClient will use gRPC to communicate with the given endpoint.
+   *
+   * @param grpcUrl The URL of the gRPC instance to connect to.
+   * @param network The network this IssuedCurrencyClient is connecting to.
+   * @param forceWeb If `true`, then we will use the gRPC-Web client even when on Node. Defaults to false. This is mainly for testing and in the future will be removed when we have browser testing.
+   */
+  public static issuedCurrencyClientWithEndpoint(
+    grpcUrl: string,
+    network: XrplNetwork,
+    forceWeb = false,
+  ): IssuedCurrencyClient {
+    return isNode() && !forceWeb
+      ? new IssuedCurrencyClient(new GrpcNetworkClient(grpcUrl), network)
+      : new IssuedCurrencyClient(new GrpcNetworkClientWeb(grpcUrl), network)
+  }
+
+  /**
+   * Create a new IssuedCurrencyClient with a custom network client implementation.
+   *
+   * In general, clients should prefer to call `issuedCurrencyClientWithEndpoint`. This constructor is provided to improve testability of this class.
+   *
+   * @param networkClient A network client which will manage remote RPCs to Rippled.
+   * @param network The network this IssuedCurrencyClient is connecting to.
+   */
+  public constructor(
+    private readonly networkClient: XrpNetworkClient,
+    readonly network: XrplNetwork,
+  ) {
+    this.coreXrplClient = new CoreXrplClient(networkClient, network)
+  }
+
+  public shutUpCompiler(): void {
+    console.log(this.networkClient)
+    console.log(this.coreXrplClient)
+  }
+}

--- a/src/XRP/shared/account-root-flags.ts
+++ b/src/XRP/shared/account-root-flags.ts
@@ -11,6 +11,7 @@
  */
 class AccountRootFlags {
   static LSF_DEPOSIT_AUTH = 1 << 24
+  static LSF_REQUIRE_AUTH = 1 << 18
 
   /**
    * Check if the given flag is set in the given set of bit-flags.

--- a/src/XRP/shared/account-root-flags.ts
+++ b/src/XRP/shared/account-root-flags.ts
@@ -10,8 +10,15 @@
  * @see https://xrpl.org/accountroot.html#accountroot-flags
  */
 class AccountRootFlags {
-  static LSF_DEPOSIT_AUTH = 1 << 24
-  static LSF_REQUIRE_AUTH = 1 << 18
+  static LSF_DEPOSIT_AUTH = 1 << 24 // 0x01000000, 16777216
+  static LSF_DEFAULT_RIPPLE = 1 << 23 // 0x00800000, 8388608
+  static LSF_GLOBAL_FREEZE = 1 << 22 // 0x00400000, 4194304
+  static LSF_NO_FREEZE = 1 << 21 // 0x00200000, 2097152
+  static LSF_DISABLE_MASTER = 1 << 20 // 0x00100000, 1048576
+  static LSF_DISALLOW_XRP = 1 << 19 // 0x00080000, 524288
+  static LSF_REQUIRE_AUTH = 1 << 18 // 0x00040000, 262144
+  static LSF_REQUIRE_DEST_TAG = 1 << 17 // 0x00020000, 131072
+  static LSF_PASSWORD_SPENT = 1 << 16 // 0x00010000, 65536
 
   /**
    * Check if the given flag is set in the given set of bit-flags.

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -1,0 +1,76 @@
+import { assert } from 'chai'
+import { XrplNetwork, XrpUtils } from 'xpring-common-js'
+import TransactionStatus from '../../src/XRP/shared/transaction-status'
+import IssuedCurrencyClient from '../../src/XRP/issued-currency-client'
+import GrpcNetworkClient from '../../src/XRP/network-clients/grpc-xrp-network-client'
+
+import XRPTestUtils from './helpers/xrp-test-utils'
+import { LedgerSpecifier } from '../../src/XRP/Generated/node/org/xrpl/rpc/v1/ledger_pb'
+import { XrpError } from '../../src/XRP'
+import { AccountRootFlag } from '../../src/XRP/shared'
+
+// A timeout for these tests.
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- 1 minute in milliseconds
+const timeoutMs = 60 * 1000
+
+// An IssuedCurrencyClient that makes requests. Uses rippled's gRPC implementation.
+const rippledUrl = 'test.xrp.xpring.io:50051'
+const issuedCurrencyClient = IssuedCurrencyClient.issuedCurrencyClientWithEndpoint(
+  rippledUrl,
+  XrplNetwork.Test,
+)
+
+describe('IssuedCurrencyClient Integration Tests', function (): void {
+  // Retry integration tests on failure.
+  this.retries(3)
+
+  // A Wallet with some balance on Testnet.
+  let wallet
+  before(async function () {
+    wallet = await XRPTestUtils.randomWalletFromFaucet()
+  })
+
+  it('requireAuthorizedTrustlines - rippled', async function (): Promise<void> {
+    this.timeout(timeoutMs)
+    // GIVEN an existing testnet account
+    // WHEN requireAuthorizedTrustlines is called
+    const result = await issuedCurrencyClient.requireAuthorizedTrustlines(
+      wallet,
+    )
+
+    // THEN the transaction was successfully submitted and the correct flag was set on the account.
+    const transactionHash = result.hash
+    const transactionStatus = result.status
+
+    // get the account data and check the flag bitmap
+    const networkClient = new GrpcNetworkClient(rippledUrl)
+    const account = networkClient.AccountAddress()
+    const classicAddress = XrpUtils.decodeXAddress(wallet.getAddress())
+    account.setAddress(classicAddress!.address)
+
+    const request = networkClient.GetAccountInfoRequest()
+    request.setAccount(account)
+
+    const ledger = new LedgerSpecifier()
+    ledger.setShortcut(LedgerSpecifier.Shortcut.SHORTCUT_VALIDATED)
+    request.setLedger(ledger)
+
+    const accountInfo = await networkClient.getAccountInfo(request)
+    if (!accountInfo) {
+      throw XrpError.malformedResponse
+    }
+
+    const accountData = accountInfo.getAccountData()
+    if (!accountData) {
+      throw XrpError.malformedResponse
+    }
+
+    const flags = accountData.getFlags()?.getValue()
+
+    assert.exists(transactionHash)
+    assert.equal(transactionStatus, TransactionStatus.Succeeded)
+    assert.isTrue(
+      AccountRootFlag.checkFlag(AccountRootFlag.LSF_REQUIRE_AUTH, flags!),
+    )
+  })
+})

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -1,0 +1,22 @@
+import { XrplNetwork } from 'xpring-common-js'
+import IssuedCurrencyClient from '../../src/XRP/issued-currency-client'
+import { FakeXRPNetworkClient } from './fakes/fake-xrp-network-client'
+import 'mocha'
+
+const fakeSucceedingNetworkClient = new FakeXRPNetworkClient()
+// const fakeErroringNetworkClient = new FakeXRPNetworkClient(
+//   FakeXRPNetworkClientResponses.defaultErrorResponses,
+// )
+
+describe('Default XRP Client', function (): void {
+  it('Dummy description', function (): void {
+    // GIVEN an IssuedCurrencyClient.
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      fakeSucceedingNetworkClient,
+      XrplNetwork.Test,
+    )
+
+    // WHEN the compiler is told to shut up THEN everything is fine.
+    issuedCurrencyClient.shutUpCompiler()
+  })
+})

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -16,11 +16,11 @@ const walletFactory = new WalletFactory(XrplNetwork.Test)
 
 describe('Default XRP Client', function (): void {
   })
-  it('Enable Deposit Auth - successful response', async function (): Promise<
+  it('requireAuthorizedTrustlines - successful response', async function (): Promise<
     void
   > {
-    // GIVEN a IssuedCurrencyClient with mocked networking that will return a successful hash for submitTransaction
     const xrpClient = new IssuedCurrencyClient(
+    // GIVEN an IssuedCurrencyClient with mocked networking that will return a successful hash for submitTransaction
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
@@ -40,10 +40,8 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionHash, expectedTransactionHash)
   })
 
-  it('Enable Deposit Auth - submission failure', async function (): Promise<
-    void
-  > {
-    // GIVEN a IssuedCurrencyClient which will fail to submit a transaction.
+  it('requireAuthorizedTrustlines - submission failure', function (): void {
+    // GIVEN an IssuedCurrencyClient which will fail to submit a transaction.
     const failureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
       FakeXRPNetworkClientResponses.defaultFeeResponse(),

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -15,20 +15,22 @@ const fakeSucceedingNetworkClient = new FakeXRPNetworkClient()
 const walletFactory = new WalletFactory(XrplNetwork.Test)
 
 describe('Default XRP Client', function (): void {
+  before(async function () {
+    this.wallet = (await walletFactory.generateRandomWallet())!.wallet
   })
   it('requireAuthorizedTrustlines - successful response', async function (): Promise<
     void
   > {
-    const xrpClient = new IssuedCurrencyClient(
     // GIVEN an IssuedCurrencyClient with mocked networking that will return a successful hash for submitTransaction
+    const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
 
-    const wallet = (await walletFactory.generateRandomWallet())!.wallet
-
     // WHEN requireAuthorizedTrustlines is called
-    const result = await xrpClient.requireAuthorizedTrustlines(wallet)
+    const result = await issuedCurrencyClient.requireAuthorizedTrustlines(
+      this.wallet,
+    )
     const transactionHash = result.hash
 
     // THEN a transaction hash exists and is the expected hash
@@ -48,15 +50,16 @@ describe('Default XRP Client', function (): void {
       FakeXRPNetworkClientResponses.defaultError,
     )
     const failingNetworkClient = new FakeXRPNetworkClient(failureResponses)
-    const xrpClient = new IssuedCurrencyClient(
+    const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN requireAuthorizedTrustlines is attempted THEN an error is propagated.
-    xrpClient.requireAuthorizedTrustlines(wallet).catch((error) => {
-      assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
-    })
+    issuedCurrencyClient
+      .requireAuthorizedTrustlines(this.wallet)
+      .catch((error) => {
+        assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
+      })
   })
 })

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -1,12 +1,18 @@
-import { XrplNetwork } from 'xpring-common-js'
+import { assert } from 'chai'
+
+import { Utils, WalletFactory, XrplNetwork } from 'xpring-common-js'
 import IssuedCurrencyClient from '../../src/XRP/issued-currency-client'
-import { FakeXRPNetworkClient } from './fakes/fake-xrp-network-client'
+import {
+  FakeXRPNetworkClient,
+  FakeXRPNetworkClientResponses,
+} from './fakes/fake-xrp-network-client'
 import 'mocha'
 
 const fakeSucceedingNetworkClient = new FakeXRPNetworkClient()
 // const fakeErroringNetworkClient = new FakeXRPNetworkClient(
 //   FakeXRPNetworkClientResponses.defaultErrorResponses,
 // )
+const walletFactory = new WalletFactory(XrplNetwork.Test)
 
 describe('Default XRP Client', function (): void {
   it('Dummy description', function (): void {
@@ -18,5 +24,50 @@ describe('Default XRP Client', function (): void {
 
     // WHEN the compiler is told to shut up THEN everything is fine.
     issuedCurrencyClient.shutUpCompiler()
+  })
+  it('Enable Deposit Auth - successful response', async function (): Promise<
+    void
+  > {
+    // GIVEN a IssuedCurrencyClient with mocked networking that will return a successful hash for submitTransaction
+    const xrpClient = new IssuedCurrencyClient(
+      fakeSucceedingNetworkClient,
+      XrplNetwork.Test,
+    )
+
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
+
+    // WHEN requireAuthorizedTrustlines is called
+    const result = await xrpClient.requireAuthorizedTrustlines(wallet)
+    const transactionHash = result.hash
+
+    // THEN a transaction hash exists and is the expected hash
+    const expectedTransactionHash = Utils.toHex(
+      FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
+    )
+
+    assert.exists(transactionHash)
+    assert.strictEqual(transactionHash, expectedTransactionHash)
+  })
+
+  it('Enable Deposit Auth - submission failure', async function (): Promise<
+    void
+  > {
+    // GIVEN a IssuedCurrencyClient which will fail to submit a transaction.
+    const failureResponses = new FakeXRPNetworkClientResponses(
+      FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeXRPNetworkClientResponses.defaultFeeResponse(),
+      FakeXRPNetworkClientResponses.defaultError,
+    )
+    const failingNetworkClient = new FakeXRPNetworkClient(failureResponses)
+    const xrpClient = new IssuedCurrencyClient(
+      failingNetworkClient,
+      XrplNetwork.Test,
+    )
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
+
+    // WHEN requireAuthorizedTrustlines is attempted THEN an error is propagated.
+    xrpClient.requireAuthorizedTrustlines(wallet).catch((error) => {
+      assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
+    })
   })
 })

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -15,15 +15,6 @@ const fakeSucceedingNetworkClient = new FakeXRPNetworkClient()
 const walletFactory = new WalletFactory(XrplNetwork.Test)
 
 describe('Default XRP Client', function (): void {
-  it('Dummy description', function (): void {
-    // GIVEN an IssuedCurrencyClient.
-    const issuedCurrencyClient = new IssuedCurrencyClient(
-      fakeSucceedingNetworkClient,
-      XrplNetwork.Test,
-    )
-
-    // WHEN the compiler is told to shut up THEN everything is fine.
-    issuedCurrencyClient.shutUpCompiler()
   })
   it('Enable Deposit Auth - successful response', async function (): Promise<
     void


### PR DESCRIPTION
## High Level Overview of Change

This PR adds the method `requireAuthorizedTrustlines` to the `IssuedCurrencyClient`, which enables Require Authorization on the specified account. This is achieved by submitting an AccountSet transaction with a set flag set to 2 (see https://xrpl.org/accountset.html#accountset-flags).

### Context of Change

Part of the IOU effort. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

`requireAuthorizedTrustlines` exposed on `IssuedCurrencyClient`

## Test Plan

CI passes. Wrote unit tests for the function that has full codecov and passes. 
