### PR TITLE
Refactors `enableDepositAuth` and related flag-changing functions

### DIFF
--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -12,12 +12,10 @@ import {
   MemoData,
   MemoFormat,
   MemoType,
-  SetFlag,
   Authorize,
   Unauthorize,
 } from './Generated/web/org/xrpl/rpc/v1/common_pb'
 import {
-  AccountSet,
   Memo,
   Payment,
   Transaction,
@@ -322,25 +320,14 @@ export default class DefaultXrpClient implements XrpClientDecorator {
    * @see https://xrpl.org/depositauth.html
    *
    * @param wallet The wallet associated with the XRPL account enabling Deposit Authorization and that will sign the request.
-   * @returns A promise which resolves to a TransactionResult object that contains the hash of the submitted AccountSet transaction,
-   *          the preliminary status, and whether the transaction has been included in a validated ledger yet.
+   * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
    */
   public async enableDepositAuth(wallet: Wallet): Promise<TransactionResult> {
-    const setFlag = new SetFlag()
-    setFlag.setValue(AccountSetFlag.asfDepositAuth)
-
-    const accountSet = new AccountSet()
-    accountSet.setSetFlag(setFlag)
-
-    const transaction = await this.coreXrplClient.prepareBaseTransaction(wallet)
-    transaction.setAccountSet(accountSet)
-
-    const transactionHash = await this.coreXrplClient.signAndSubmitTransaction(
-      transaction,
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfDepositAuth,
+      true,
       wallet,
     )
-
-    return await this.coreXrplClient.getTransactionResult(transactionHash)
   }
 
   /**

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -207,6 +207,10 @@ export default class IssuedCurrencyClient {
   public async allowNoDestinationTag(
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfRequireDest, false, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfRequireDest,
+      false,
+      wallet,
+    )
   }
 }

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -10,8 +10,6 @@ import { AccountLinesResponse } from './shared/rippled-json-rpc-schema'
 import { JsonNetworkClientInterface } from './network-clients/json-network-client-interface'
 import { XrpError } from './shared'
 import { AccountSetFlag } from './shared/account-set-flag'
-import { SetFlag, ClearFlag } from './Generated/web/org/xrpl/rpc/v1/common_pb'
-import { AccountSet } from './Generated/web/org/xrpl/rpc/v1/transaction_pb'
 import TransactionResult from './shared/transaction-result'
 
 /**
@@ -64,44 +62,6 @@ export default class IssuedCurrencyClient {
   }
 
   /**
-   * Helper function. Sets/clears a flag value.
-   * @param flag The desired flag that is being changed.
-   * @param enable Whether the flag is being enabled (true if enabling, false if disabling).
-   * @param wallet The wallet associated with the XRPL account enabling Require Authorization and that will sign the request.
-   * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
-   */
-  private async changeFlag(
-    flag: number,
-    enable: boolean,
-    wallet: Wallet,
-  ): Promise<TransactionResult> {
-    const accountSet = new AccountSet()
-
-    if (enable) {
-      const setFlag = new SetFlag()
-      setFlag.setValue(flag)
-      accountSet.setSetFlag(setFlag)
-    } else {
-      const clearFlag = new ClearFlag()
-      clearFlag.setValue(flag)
-      accountSet.setClearFlag(clearFlag)
-    }
-
-    const transaction = await this.coreXrplClient.prepareBaseTransaction(wallet)
-    transaction.setAccountSet(accountSet)
-
-    const transactionHash = await this.coreXrplClient.signAndSubmitTransaction(
-      transaction,
-      wallet,
-    )
-
-    return await this.coreXrplClient.getFinalTransactionResultAsync(
-      transactionHash,
-      wallet,
-    )
-  }
-
-  /**
    * Retrieves information about an account's trust lines, which maintain balances of all non-XRP currencies and assets.
    * @see https://xrpl.org/trust-lines-and-issuing.html
    *
@@ -143,7 +103,11 @@ export default class IssuedCurrencyClient {
   public async requireAuthorizedTrustlines(
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfRequireAuth, true, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfRequireAuth,
+      true,
+      wallet,
+    )
   }
 
   /**
@@ -157,7 +121,11 @@ export default class IssuedCurrencyClient {
   public async allowUnauthorizedTrustlines(
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfRequireAuth, false, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfRequireAuth,
+      false,
+      wallet,
+    )
   }
 
   /**
@@ -169,7 +137,11 @@ export default class IssuedCurrencyClient {
    * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
    */
   public async enableRippling(wallet: Wallet): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfDefaultRipple, true, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfDefaultRipple,
+      true,
+      wallet,
+    )
   }
 
   /**
@@ -182,7 +154,11 @@ export default class IssuedCurrencyClient {
    * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
    */
   public async disallowIncomingXrp(wallet: Wallet): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfDisallowXRP, true, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfDisallowXRP,
+      true,
+      wallet,
+    )
   }
 
   /**
@@ -195,7 +171,11 @@ export default class IssuedCurrencyClient {
    * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
    */
   public async allowIncomingXrp(wallet: Wallet): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfDisallowXRP, false, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfDisallowXRP,
+      false,
+      wallet,
+    )
   }
 
   /**
@@ -209,6 +189,10 @@ export default class IssuedCurrencyClient {
   public async requireDestinationTags(
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfRequireDest, true, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfRequireDest,
+      true,
+      wallet,
+    )
   }
 }


### PR DESCRIPTION
## High Level Overview of Change

This PR moves `changeFlag` from `issuedCurrencyClient` to `coreXrplClient`, refactors `enableDepositAuth` in `defaultXrpClient` to use `changeFlag`, and likewise refactors the tests for `enableDepositAuth` to use `verifyFlagModification`. Basically, it modifies old methods to use new helper functions. 

### Context of Change

The IOU client needs a bunch of flag-changing methods. In order to make those cleaner, helper functions were created. We can now use those helper functions to simplify code elsewhere. 

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

Moving functions around/simplifying code

## Test Plan

CI passes. 