### PR TITLE
Refactors flag integration tests to take less time

### DIFF
--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -82,7 +82,9 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     assert.isEmpty(trustLines)
   })
 
-  it('requireAuthorizedTrustlines - rippled', async function (): Promise<void> {
+  it('requireAuthorizedTrustlines/allowUnauthorizedTrustlines - rippled', async function (): Promise<
+    void
+  > {
     this.timeout(timeoutMs)
     // GIVEN an existing testnet account
     // WHEN requireAuthorizedTrustlines is called
@@ -97,15 +99,10 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
       result,
       AccountRootFlag.LSF_REQUIRE_AUTH,
     )
-  })
 
-  it('allowUnauthorizedTrustlines - rippled', async function (): Promise<void> {
-    this.timeout(timeoutMs)
-    // GIVEN an existing testnet account that has enabled Require Authorized Trust Lines
-    await issuedCurrencyClient.requireAuthorizedTrustlines(wallet)
-
+    // GIVEN an existing testnet account with Require Authorization enabled
     // WHEN allowUnauthorizedTrustlines is called
-    const result = await issuedCurrencyClient.allowUnauthorizedTrustlines(
+    const result2 = await issuedCurrencyClient.allowUnauthorizedTrustlines(
       wallet,
     )
 
@@ -113,7 +110,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     await XRPTestUtils.verifyFlagModification(
       wallet,
       rippledGrpcUrl,
-      result,
+      result2,
       AccountRootFlag.LSF_REQUIRE_AUTH,
       false,
     )
@@ -134,7 +131,9 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     )
   })
 
-  it('disallowIncomingXrp - rippled', async function (): Promise<void> {
+  it('disallowIncomingXrp/allowIncomingXrp - rippled', async function (): Promise<
+    void
+  > {
     this.timeout(timeoutMs)
     // GIVEN an existing testnet account
     // WHEN disallowIncomingXrp is called
@@ -147,26 +146,22 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
       result,
       AccountRootFlag.LSF_DISALLOW_XRP,
     )
-  })
 
-  // TODO: Once required IOU functionality exists in SDK, add integration tests that successfully establish an unauthorized trustline to this account.
-
-  it('allowIncomingXrp - rippled', async function (): Promise<void> {
-    this.timeout(timeoutMs)
-    // GIVEN an existing testnet account
-    // WHEN disallowIncomingXrp is called, followed by allowIncomingXrp
+    // GIVEN an existing testnet account with Disallow XRP enabled
     await issuedCurrencyClient.disallowIncomingXrp(wallet)
-    const result = await issuedCurrencyClient.allowIncomingXrp(wallet)
+    const result2 = await issuedCurrencyClient.allowIncomingXrp(wallet)
 
     // THEN the transaction was successfully submitted and the flag should not be set on the account.
     await XRPTestUtils.verifyFlagModification(
       wallet,
       rippledGrpcUrl,
-      result,
+      result2,
       AccountRootFlag.LSF_DISALLOW_XRP,
       false,
     )
   })
+
+  // TODO: Once required IOU functionality exists in SDK, add integration tests that successfully establish an unauthorized trustline to this account.
 
   it('requireDestinationTags - rippled', async function (): Promise<void> {
     this.timeout(timeoutMs)

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -148,7 +148,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     )
 
     // GIVEN an existing testnet account with Disallow XRP enabled
-    await issuedCurrencyClient.disallowIncomingXrp(wallet)
+    // WHEN allowIncomingXrp is called
     const result2 = await issuedCurrencyClient.allowIncomingXrp(wallet)
 
     // THEN the transaction was successfully submitted and the flag should not be set on the account.
@@ -176,20 +176,16 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
       result,
       AccountRootFlag.LSF_REQUIRE_DEST_TAG,
     )
-  })
 
-  it('allowNoDestinationTag - rippled', async function (): Promise<void> {
-    this.timeout(timeoutMs)
-    // GIVEN an existing testnet account
-    // WHEN requireDestinationTags is called, followed by allowNoDestinationTag
-    await issuedCurrencyClient.requireDestinationTags(wallet)
-    const result = await issuedCurrencyClient.allowNoDestinationTag(wallet)
+    // GIVEN an existing testnet account with Require Destination Tags enabled
+    // WHEN allowNoDestinationTag is called
+    const result2 = await issuedCurrencyClient.allowNoDestinationTag(wallet)
 
     // THEN both transactions were successfully submitted and there should be no flag set on the account.
     await XRPTestUtils.verifyFlagModification(
       wallet,
       rippledGrpcUrl,
-      result,
+      result2,
       AccountRootFlag.LSF_REQUIRE_DEST_TAG,
       false,
     )


### PR DESCRIPTION
## High Level Overview of Change

The IOU flag tests involved some repeat computation, with separate tests for enabling and disabling the same flag. This PR combines those tests, so that computation doesn't need to be unnecessarily repeated. 

### Context of Change

Prevents repeated computations in the tests (such as generating wallets), thereby saving time without losing any testing ability.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Fewer/simpler tests with less repeated code. Faster test runtime. 

## Test Plan

CI passes. 
