### PR TITLE
Implements `setTransferFee` on `IssuedCurrencyClient`

### DIFF
--- a/test/XRP/helpers/xrp-test-utils.ts
+++ b/test/XRP/helpers/xrp-test-utils.ts
@@ -11,6 +11,7 @@ import GrpcNetworkClient from '../../../src/XRP/network-clients/grpc-xrp-network
 import bigInt from 'big-integer'
 import XrpClient from '../../../src/XRP/xrp-client'
 import axios from 'axios'
+import { AccountRoot } from '../../../src/XRP/Generated/node/org/xrpl/rpc/v1/ledger_objects_pb'
 
 /**
  * Convenience class for utility functions used in test cases for XrpClient infrastructure.
@@ -111,17 +112,10 @@ export default class XRPTestUtils {
     )
   }
 
-  static async verifyFlagModification(
+  static async getAccountData(
     wallet: Wallet,
     rippledGrpcUrl: string,
-    result: TransactionResult,
-    accountRootFlag: number,
-    checkTrue = true,
-  ): Promise<void> {
-    // THEN the transaction was successfully submitted and the correct flag was set on the account.
-    const transactionHash = result.hash
-    const transactionStatus = result.status
-
+  ): Promise<AccountRoot> {
     // get the account data and check the flag bitmap
     const networkClient = new GrpcNetworkClient(rippledGrpcUrl)
     const account = networkClient.AccountAddress()
@@ -144,6 +138,21 @@ export default class XRPTestUtils {
     if (!accountData) {
       throw XrpError.malformedResponse
     }
+
+    return accountData
+  }
+
+  static async verifyFlagModification(
+    wallet: Wallet,
+    rippledGrpcUrl: string,
+    result: TransactionResult,
+    accountRootFlag: number,
+    checkTrue = true,
+  ): Promise<void> {
+    // THEN the transaction was successfully submitted and the correct flag was set on the account.
+    const transactionHash = result.hash
+    const transactionStatus = result.status
+    const accountData = await this.getAccountData(wallet, rippledGrpcUrl)
 
     const flags = accountData.getFlags()?.getValue()
 

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -239,4 +239,63 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     assert.exists(transactionHash2)
     assert.equal(transactionStatus2, TransactionStatus.Succeeded)
   })
+
+  it('setTransferFee - rippled', async function (): Promise<void> {
+    this.timeout(timeoutMs)
+    // GIVEN an existing testnet account
+    // WHEN setTransferFee is called
+    const expectedTransferFee = 1000000123
+    const result = await issuedCurrencyClient.setTransferFee(
+      expectedTransferFee,
+      wallet,
+    )
+
+    const transactionHash = result.hash
+    const transactionStatus = result.status
+
+    const accountData = await this.getAccountData(wallet, rippledGrpcUrl)
+    const transferRate = accountData.getTransferRate()?.getValue()
+
+    // THEN the transaction was successfully submitted and the correct transfer rate was set on the account.
+    assert.exists(transactionHash)
+    assert.equal(transactionStatus, TransactionStatus.Succeeded)
+    assert.equal(transferRate, expectedTransferFee)
+  })
+
+  it('setTransferFee - bad transferRate values', async function (): Promise<
+    void
+  > {
+    this.timeout(timeoutMs)
+
+    const lowTransferFee = 12345
+    const highTransferFee = 9876543210
+
+    // GIVEN an existing testnet account
+    // WHEN setTransferFee is called on a too-low transfer fee
+    const result = await issuedCurrencyClient.setTransferFee(
+      lowTransferFee,
+      wallet,
+    )
+
+    const transactionHash = result.hash
+    const transactionStatus = result.status
+
+    // THEN the transaction fails.
+    assert.exists(transactionHash)
+    assert.equal(transactionStatus, TransactionStatus.Failed)
+
+    // GIVEN an existing testnet account
+    // WHEN setTransferFee is called on a too-high transfer fee
+    const result2 = await issuedCurrencyClient.setTransferFee(
+      highTransferFee,
+      wallet,
+    )
+
+    const transactionHash2 = result2.hash
+    const transactionStatus2 = result2.status
+
+    // THEN the transaction fails.
+    assert.exists(transactionHash2)
+    assert.equal(transactionStatus2, TransactionStatus.Failed)
+  })
 })

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -406,4 +406,54 @@ describe('Issued Currency Client', function (): void {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
     })
   })
+
+  it('setTransferFee - successful response', async function (): Promise<void> {
+    // GIVEN an IssuedCurrencyClient with mocked networking that will return a successful hash for submitTransaction
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      fakeSucceedingGrpcClient,
+      fakeSucceedingJsonClient,
+      XrplNetwork.Test,
+    )
+
+    const transferFee = 1000000012
+
+    // WHEN setTransferFee is called
+    const result = await issuedCurrencyClient.setTransferFee(
+      transferFee,
+      this.wallet,
+    )
+    const transactionHash = result.hash
+
+    // THEN a transaction hash exists and is the expected hash
+    const expectedTransactionHash = Utils.toHex(
+      FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
+    )
+
+    assert.exists(transactionHash)
+    assert.strictEqual(transactionHash, expectedTransactionHash)
+  })
+
+  it('setTransferFee - submission failure', function (): void {
+    // GIVEN an IssuedCurrencyClient which will fail to submit a transaction.
+    const failureResponses = new FakeXRPNetworkClientResponses(
+      FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeXRPNetworkClientResponses.defaultFeeResponse(),
+      FakeXRPNetworkClientResponses.defaultError,
+    )
+    const failingNetworkClient = new FakeXRPNetworkClient(failureResponses)
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      failingNetworkClient,
+      fakeSucceedingJsonClient,
+      XrplNetwork.Test,
+    )
+
+    const transferFee = 1000000012
+
+    // WHEN setTransferFee is attempted THEN an error is propagated.
+    issuedCurrencyClient
+      .setTransferFee(transferFee, this.wallet)
+      .catch((error) => {
+        assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
+      })
+  })
 })


### PR DESCRIPTION
## High Level Overview of Change

This PR adds the method `setTransferFee` to the `IssuedCurrencyClient`, which applies a given transfer fee to IOUs issued by the specified account. This is achieved by submitting an AccountSet transaction with a `TransferRate` set to the requested transfer fee. 

### Context of Change

Part of the IOU effort. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

`setTransferFee` exposed on `IssuedCurrencyClient`

## Test Plan

CI passes. Wrote unit tests for the function that has full codecov and passes. 
