### PR TITLE
Implements `enableGlobalFreeze` on `IssuedCurrencyClient`

### DIFF
--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -223,6 +223,10 @@ export default class IssuedCurrencyClient {
    * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
    */
   public async enableGlobalFreeze(wallet: Wallet): Promise<TransactionResult> {
-    return this.changeFlag(AccountSetFlag.asfGlobalFreeze, true, wallet)
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfGlobalFreeze,
+      true,
+      wallet,
+    )
   }
 }

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -206,6 +206,15 @@ export default class IssuedCurrencyClient {
    * @param wallet The wallet associated with the XRPL account disabling Require Destination and that will sign the request.
    * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
    */
+  public async allowNoDestinationTag(
+    wallet: Wallet,
+  ): Promise<TransactionResult> {
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfRequireDest,
+      false,
+      wallet,
+    )
+  }
 
   /**
    * Set the Transfer Fees for an issuing account.

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -213,4 +213,16 @@ export default class IssuedCurrencyClient {
       wallet,
     )
   }
+
+  /**
+   * Enable Global Freeze for this XRPL account.
+   *
+   * @see https://xrpl.org/freezes.html#global-freeze
+   *
+   * @param wallet The wallet associated with the XRPL account enabling Global Freeze and that will sign the request.
+   * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
+   */
+  public async enableGlobalFreeze(wallet: Wallet): Promise<TransactionResult> {
+    return this.changeFlag(AccountSetFlag.asfGlobalFreeze, true, wallet)
+  }
 }

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -163,7 +163,9 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
 
   // TODO: Once required IOU functionality exists in SDK, add integration tests that successfully establish an unauthorized trustline to this account.
 
-  it('requireDestinationTags - rippled', async function (): Promise<void> {
+  it('requireDestinationTags/allowNoDestinationTag - rippled', async function (): Promise<
+    void
+  > {
     this.timeout(timeoutMs)
     // GIVEN an existing testnet account
     // WHEN requireDestinationTags is called
@@ -229,5 +231,20 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     // THEN the transaction succeeds.
     assert.exists(transactionHash2)
     assert.equal(transactionStatus2, TransactionStatus.Succeeded)
+  })
+
+  it('enableGlobalFreeze - rippled', async function (): Promise<void> {
+    this.timeout(timeoutMs)
+    // GIVEN an existing testnet account
+    // WHEN enableGlobalFreeze is called
+    const result = await issuedCurrencyClient.enableGlobalFreeze(wallet)
+
+    // THEN the transaction was successfully submitted and the correct flag was set on the account.
+    await XRPTestUtils.verifyFlagModification(
+      wallet,
+      rippledGrpcUrl,
+      result,
+      AccountRootFlag.LSF_GLOBAL_FREEZE,
+    )
   })
 })

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -406,4 +406,47 @@ describe('Issued Currency Client', function (): void {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
     })
   })
+
+  it('enableGlobalFreeze - successful response', async function (): Promise<
+    void
+  > {
+    // GIVEN an IssuedCurrencyClient with mocked networking that will return a successful hash for submitTransaction
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      fakeSucceedingGrpcClient,
+      fakeSucceedingJsonClient,
+      XrplNetwork.Test,
+    )
+
+    // WHEN enableGlobalFreeze is called
+    const result = await issuedCurrencyClient.enableGlobalFreeze(this.wallet)
+    const transactionHash = result.hash
+
+    // THEN a transaction hash exists and is the expected hash
+    const expectedTransactionHash = Utils.toHex(
+      FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
+    )
+
+    assert.exists(transactionHash)
+    assert.strictEqual(transactionHash, expectedTransactionHash)
+  })
+
+  it('enableGlobalFreeze - submission failure', function (): void {
+    // GIVEN an IssuedCurrencyClient which will fail to submit a transaction.
+    const failureResponses = new FakeXRPNetworkClientResponses(
+      FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeXRPNetworkClientResponses.defaultFeeResponse(),
+      FakeXRPNetworkClientResponses.defaultError,
+    )
+    const failingNetworkClient = new FakeXRPNetworkClient(failureResponses)
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      failingNetworkClient,
+      fakeSucceedingJsonClient,
+      XrplNetwork.Test,
+    )
+
+    // WHEN enableGlobalFreeze is attempted THEN an error is propagated.
+    issuedCurrencyClient.enableGlobalFreeze(this.wallet).catch((error) => {
+      assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
+    })
+  })
 })


### PR DESCRIPTION
## High Level Overview of Change

This PR adds the method `enableGlobalFreeze` to the `IssuedCurrencyClient`, which enables Global Freeze on the specified account. This is achieved by submitting an AccountSet transaction with a set flag set to 7 (see https://xrpl.org/accountset.html#accountset-flags).

### Context of Change

Part of the IOU effort. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

`enableGlobalFreeze` exposed on `IssuedCurrencyClient`

## Test Plan

CI passes. Wrote unit tests for the function that has full codecov and passes. 
