### PR TITLE
Implements `enableNoFreeze` on `IssuedCurrencyClient`

### DIFF
--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -215,7 +215,7 @@ export default class IssuedCurrencyClient {
   }
 
   /**
-   * Enable No Freeze for this XRPL account.
+   * Permanently enable No Freeze for this XRPL account.
    *
    * @see https://xrpl.org/freezes.html#no-freeze
    *

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -213,4 +213,20 @@ export default class IssuedCurrencyClient {
       wallet,
     )
   }
+
+  /**
+   * Enable No Freeze for this XRPL account.
+   *
+   * @see https://xrpl.org/freezes.html#no-freeze
+   *
+   * @param wallet The wallet associated with the XRPL account enabling No Freeze and that will sign the request.
+   * @returns A promise which resolves to a TransactionResult object that represents the result of this transaction.
+   */
+  public async enableNoFreeze(wallet: Wallet): Promise<TransactionResult> {
+    return this.coreXrplClient.changeFlag(
+      AccountSetFlag.asfNoFreeze,
+      true,
+      wallet,
+    )
+  }
 }

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -230,4 +230,19 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     assert.exists(transactionHash2)
     assert.equal(transactionStatus2, TransactionStatus.Succeeded)
   })
+
+  it('enableNoFreeze - rippled', async function (): Promise<void> {
+    this.timeout(timeoutMs)
+    // GIVEN an existing testnet account
+    // WHEN enableNoFreeze is called
+    const result = await issuedCurrencyClient.enableNoFreeze(wallet)
+
+    // THEN the transaction was successfully submitted and the correct flag was set on the account.
+    await XRPTestUtils.verifyFlagModification(
+      wallet,
+      rippledGrpcUrl,
+      result,
+      AccountRootFlag.LSF_NO_FREEZE,
+    )
+  })
 })

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -406,4 +406,45 @@ describe('Issued Currency Client', function (): void {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
     })
   })
+
+  it('enableNoFreeze - successful response', async function (): Promise<void> {
+    // GIVEN an IssuedCurrencyClient with mocked networking that will return a successful hash for submitTransaction
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      fakeSucceedingGrpcClient,
+      fakeSucceedingJsonClient,
+      XrplNetwork.Test,
+    )
+
+    // WHEN enableNoFreeze is called
+    const result = await issuedCurrencyClient.enableNoFreeze(this.wallet)
+    const transactionHash = result.hash
+
+    // THEN a transaction hash exists and is the expected hash
+    const expectedTransactionHash = Utils.toHex(
+      FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
+    )
+
+    assert.exists(transactionHash)
+    assert.strictEqual(transactionHash, expectedTransactionHash)
+  })
+
+  it('enableNoFreeze - submission failure', function (): void {
+    // GIVEN an IssuedCurrencyClient which will fail to submit a transaction.
+    const failureResponses = new FakeXRPNetworkClientResponses(
+      FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
+      FakeXRPNetworkClientResponses.defaultFeeResponse(),
+      FakeXRPNetworkClientResponses.defaultError,
+    )
+    const failingNetworkClient = new FakeXRPNetworkClient(failureResponses)
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      failingNetworkClient,
+      fakeSucceedingJsonClient,
+      XrplNetwork.Test,
+    )
+
+    // WHEN enableNoFreeze is attempted THEN an error is propagated.
+    issuedCurrencyClient.enableNoFreeze(this.wallet).catch((error) => {
+      assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
+    })
+  })
 })


### PR DESCRIPTION
## High Level Overview of Change

This PR adds the method `enableNoFreeze` to the `IssuedCurrencyClient`, which permanently enables No Freeze on the specified account. This is achieved by submitting an AccountSet transaction with a set flag set to 6 (see https://xrpl.org/accountset.html#accountset-flags).

### Context of Change

Part of the IOU effort. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

`enableNoFreeze` exposed on `IssuedCurrencyClient`

## Test Plan

CI passes. Wrote unit tests for the function that has full codecov and passes. 
