### PR TITLE
Creates `XrpClient::sendXrp` (which returns a `TransactionResult`) and Deprecates `XrpClient::send`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a sender to send XRP to the specified XRPL account that has enabled Deposit Authorization.
   (See https://xrpl.org/depositpreauth.html)
 
-- A new method `authorizeSendingAccount` is added to `XrpClient` which authorizes
-  senders to send XRP to the specified XRPL account.
+- A new method `authorizeSendingAccount` is added to `XrpClient` which authorizes a
+  sender to send XRP to the specified XRPL account that has enabled Deposit Authorization.
   (See https://xrpl.org/depositpreauth.html)
 
 ## 5.1.2 - 2020-10-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Method `sendXrp` of class `XrpClient` replaces now deprecated `send`. `sendXrp` returns a `TransactionResult` that
+  contains more granular information about the final outcome of a submitted transaction.
+
+- Method `sendXrpWithDetails` of class `XrpClient` replaces now deprecated `sendWithDetails`.  `sendXrpWithDetails` returns
+  a `TransactionResult` that contains more granular infomration about the final outcome of a submitted transaction.
+
+### Deprecated
+
+- Method `send` of class `XrpClient` is deprecated and will be removed in two release cycles.
+  Use `sendXrp` instead.
+
+- Method `sendWithDetails` of class `XrpClient` is deprecated and will be removed in two release cycles.
+  Use `sendXrpWithDetails` instead.
+
 - A new method `authorizeSendingAccount` is added to `XrpClient` which authorizes
   senders to send XRP to the specified XRPL account.
   (See https://xrpl.org/depositpreauth.html)

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ const destinationAddress = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
 const generationResult = Wallet.generateRandomWallet();
 const senderWallet = generationResult.wallet;
 
-const transactionHash = await xrpClient.send(amount, destinationAddress, senderWallet);
+const transactionResult = await xrpClient.sendXrp(amount, destinationAddress, senderWallet);
 ```
 
 **Note:** The above example will yield an "Account not found." error because

--- a/src/XRP/core-xrpl-client.ts
+++ b/src/XRP/core-xrpl-client.ts
@@ -279,7 +279,7 @@ export default class CoreXrplClient implements CoreXrplClientInterface {
           transactionStatus,
           isValidated,
         )
-      : TransactionResult.getPendingTransactionResult(
+      : TransactionResult.createPendingTransactionResult(
           transactionHash,
           transactionStatus,
           isValidated,

--- a/src/XRP/core-xrpl-client.ts
+++ b/src/XRP/core-xrpl-client.ts
@@ -274,7 +274,7 @@ export default class CoreXrplClient implements CoreXrplClientInterface {
     // TODO: add logic to this method to investigate the transaction's last ledger sequence,
     // the XRPL latest ledger sequence, and make a more granular distinction in case of yet-unvalidated txn??
     return isValidated
-      ? TransactionResult.getFinalTransactionResult(
+      ? TransactionResult.createFinalTransactionResult(
           transactionHash,
           transactionStatus,
           isValidated,
@@ -332,7 +332,7 @@ export default class CoreXrplClient implements CoreXrplClientInterface {
     const finalStatus = lastLedgerPassed
       ? TransactionStatus.LastLedgerSequenceExpired
       : this.getFinalTransactionStatus(rawTransactionStatus)
-    return TransactionResult.getFinalTransactionResult(
+    return TransactionResult.createFinalTransactionResult(
       transactionHash,
       finalStatus,
       rawTransactionStatus.isValidated,

--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -134,17 +134,17 @@ export default class DefaultXrpClient implements XrpClientDecorator {
   /**
    * Send the given amount of XRP from the source wallet to the destination address.
    *
-   * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
+   * @param amount A `BigInteger`, number or numeric string representing the number of drops of XRP to send.
    * @param destinationAddress A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
-   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   * @returns A promise which resolves to a TransactionResult representing the pending outcome of the submitted transaction.
    */
-  public async send(
+  public async sendXrp(
     amount: BigInteger | number | string,
     destinationAddress: string,
     sender: Wallet,
-  ): Promise<string> {
-    return this.sendWithDetails({
+  ): Promise<TransactionResult> {
+    return await this.sendXrpWithDetails({
       amount,
       destination: destinationAddress,
       sender,
@@ -156,11 +156,11 @@ export default class DefaultXrpClient implements XrpClientDecorator {
    * for additional details to be specified for use with supplementary features of the XRP ledger.
    *
    * @param sendXrpDetails - a wrapper object containing details for constructing a transaction.
-   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   * @returns A promise which resolves to a TransactionResult representing the pending outcome of the submitted transaction.
    */
-  public async sendWithDetails(
+  public async sendXrpWithDetails(
     sendXrpDetails: SendXrpDetails,
-  ): Promise<string> {
+  ): Promise<TransactionResult> {
     const {
       amount: drops,
       sender,
@@ -219,7 +219,15 @@ export default class DefaultXrpClient implements XrpClientDecorator {
         .forEach((memo) => transaction.addMemos(memo))
     }
 
-    return this.coreXrplClient.signAndSubmitTransaction(transaction, sender)
+    const transactionHash = await this.coreXrplClient.signAndSubmitTransaction(
+      transaction,
+      sender,
+    )
+    return TransactionResult.getPendingTransactionResult(
+      transactionHash,
+      TransactionStatus.Pending,
+      false,
+    )
   }
 
   /**

--- a/src/XRP/default-xrp-client.ts
+++ b/src/XRP/default-xrp-client.ts
@@ -223,7 +223,7 @@ export default class DefaultXrpClient implements XrpClientDecorator {
       transaction,
       sender,
     )
-    return TransactionResult.getPendingTransactionResult(
+    return TransactionResult.createPendingTransactionResult(
       transactionHash,
       TransactionStatus.Pending,
       false,

--- a/src/XRP/reliable-submission-xrp-client.ts
+++ b/src/XRP/reliable-submission-xrp-client.ts
@@ -68,32 +68,32 @@ export default class ReliableSubmissionXrpClient implements XrpClientDecorator {
     return this.decoratedClient.getPaymentStatus(transactionHash)
   }
 
-  public async send(
+  public async sendXrp(
     amount: string | number | BigInteger,
     destination: string,
     sender: Wallet,
-  ): Promise<string> {
-    return this.sendWithDetails({
+  ): Promise<TransactionResult> {
+    return this.sendXrpWithDetails({
       amount,
       destination,
       sender,
     })
   }
 
-  public async sendWithDetails(
+  public async sendXrpWithDetails(
     sendXrpDetails: SendXrpDetails,
-  ): Promise<string> {
+  ): Promise<TransactionResult> {
     const { sender } = sendXrpDetails
 
-    const transactionHash = await this.decoratedClient.sendWithDetails(
+    const pendingTransactionResult = await this.decoratedClient.sendXrpWithDetails(
       sendXrpDetails,
     )
-    await this.coreXrplClient.waitForFinalTransactionOutcome(
-      transactionHash,
+    const finalTransactionResult = await this.coreXrplClient.getFinalTransactionResultAsync(
+      pendingTransactionResult.hash,
       sender,
     )
 
-    return transactionHash
+    return finalTransactionResult
   }
 
   public async accountExists(address: string): Promise<boolean> {

--- a/src/XRP/shared/transaction-result.ts
+++ b/src/XRP/shared/transaction-result.ts
@@ -33,7 +33,7 @@ export default class TransactionResult {
    * @param status The result of the transaction.
    * @param validated Whether this transaction (and status) are included in a validated ledger.
    */
-  public static getFinalTransactionResult(
+  public static createFinalTransactionResult(
     hash: string,
     status: TransactionStatus,
     validated: boolean,

--- a/src/XRP/shared/transaction-result.ts
+++ b/src/XRP/shared/transaction-result.ts
@@ -14,7 +14,7 @@ export default class TransactionResult {
    * @param status The result of the transaction.
    * @param validated Whether this transaction (and status) are included in a validated ledger.
    */
-  public static getPendingTransactionResult(
+  public static createPendingTransactionResult(
     hash: string,
     status: TransactionStatus,
     validated: boolean,

--- a/src/XRP/xrp-client-decorator.ts
+++ b/src/XRP/xrp-client-decorator.ts
@@ -39,13 +39,13 @@ export default interface XrpClientDecorator {
    * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
-   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   * @returns A promise which resolves to a TransactionResult representing the outcome of the submitted transaction.
    */
-  send(
+  sendXrp(
     amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
-  ): Promise<string>
+  ): Promise<TransactionResult>
 
   /**
    * Send the given amount of XRP from the source wallet to the destination PayID, allowing
@@ -53,9 +53,9 @@ export default interface XrpClientDecorator {
    * ledger.
    *
    * @param sendXrpDetails - a wrapper object containing details for constructing a transaction.
-   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   * @returns A promise which resolves to a TransactionResult representing the outcome of the submitted transaction.
    */
-  sendWithDetails(sendXrpDetails: SendXrpDetails): Promise<string>
+  sendXrpWithDetails(sendXrpDetails: SendXrpDetails): Promise<TransactionResult>
 
   /**
    * Check if an address exists on the XRP Ledger.

--- a/src/XRP/xrp-client-interface.ts
+++ b/src/XRP/xrp-client-interface.ts
@@ -40,24 +40,24 @@ export default interface XrpClientInterface {
    * @param destination A destination address to send the drops to.
    * @param sender The wallet that XRP will be sent from and which will sign the request.
    * @param memos An optional list of memos to add to the transaction.
-   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   * @returns A promise which resolves to a TransactionResult representing the final outcome of the submitted transaction.
    */
-  send(
+  sendXrp(
     amount: BigInteger | number | string,
     destination: string,
     sender: Wallet,
     memos?: Array<XrpMemo>,
-  ): Promise<string>
+  ): Promise<TransactionResult>
 
   /**
-   * Send the given amount of XRP from the source wallet to the destination PayID, allowing
+   * Send the given amount of XRP from the source wallet to a destination, allowing
    * for additional details to be specified for use with supplementary features of the XRP
    * ledger.
    *
    * @param sendXrpDetails - a wrapper object containing details for constructing a transaction.
-   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   * @returns A promise which resolves to a TransactionResult representing the final outcome of the submitted transaction.
    */
-  sendWithDetails(sendXrpDetails: SendXrpDetails): Promise<string>
+  sendXrpWithDetails(sendXrpDetails: SendXrpDetails): Promise<TransactionResult>
 
   /**
    * Check if an address exists on the XRP Ledger.

--- a/src/XRP/xrp-client.ts
+++ b/src/XRP/xrp-client.ts
@@ -125,7 +125,7 @@ export default class XrpClient implements XrpClientInterface {
   }
 
   /**
-   * Send the given amount of XRP from the source wallet to the destination PayID, allowing
+   * Send the given amount of XRP from the source wallet to a destination, allowing
    * for additional details to be specified for use with supplementary features of the XRP
    * ledger.
    *

--- a/src/XRP/xrp-client.ts
+++ b/src/XRP/xrp-client.ts
@@ -63,6 +63,8 @@ export default class XrpClient implements XrpClientInterface {
   }
 
   /**
+   * @deprecated Use method `sendXrp` instead.
+   *
    * Send the given amount of XRP from the source wallet to the destination address.
    *
    * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
@@ -75,7 +77,47 @@ export default class XrpClient implements XrpClientInterface {
     destination: string,
     sender: Wallet,
   ): Promise<string> {
-    return this.sendWithDetails({
+    const transactionResult = await this.sendXrpWithDetails({
+      amount,
+      destination,
+      sender,
+    })
+    return transactionResult.hash
+  }
+
+  /**
+   * @deprecated Use method `sendXrpWithDetails` instead.
+   *
+   * Send the given amount of XRP from the source wallet to the destination PayID, allowing
+   * for additional details to be specified for use with supplementary features of the XRP
+   * ledger.
+   *
+   * @param sendXrpDetails - a wrapper object containing details for constructing a transaction.
+   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   */
+  public async sendWithDetails(
+    sendXrpDetails: SendXrpDetails,
+  ): Promise<string> {
+    const transactionResult = await this.decoratedClient.sendXrpWithDetails(
+      sendXrpDetails,
+    )
+    return transactionResult.hash
+  }
+
+  /**
+   * Send the given amount of XRP from the source wallet to the destination address.
+   *
+   * @param amount A `BigInteger`, number or numeric string representing the number of drops to send.
+   * @param destination A destination address to send the drops to.
+   * @param sender The wallet that XRP will be sent from and which will sign the request.
+   * @returns A promise which resolves to a TransactionResult representing the final outcome of the submitted transaction.
+   */
+  public async sendXrp(
+    amount: BigInteger | number | string,
+    destination: string,
+    sender: Wallet,
+  ): Promise<TransactionResult> {
+    return this.sendXrpWithDetails({
       amount,
       destination,
       sender,
@@ -88,12 +130,12 @@ export default class XrpClient implements XrpClientInterface {
    * ledger.
    *
    * @param sendXrpDetails - a wrapper object containing details for constructing a transaction.
-   * @returns A promise which resolves to a string representing the hash of the submitted transaction.
+   * @returns A promise which resolves to a TransactionResult representing the final outcome of the submitted transaction.
    */
-  public async sendWithDetails(
+  public async sendXrpWithDetails(
     sendXrpDetails: SendXrpDetails,
-  ): Promise<string> {
-    return this.decoratedClient.sendWithDetails(sendXrpDetails)
+  ): Promise<TransactionResult> {
+    return this.decoratedClient.sendXrpWithDetails(sendXrpDetails)
   }
 
   /**

--- a/src/Xpring/xpring-client.ts
+++ b/src/Xpring/xpring-client.ts
@@ -75,13 +75,13 @@ export default class XpringClient {
     )
 
     // Transact XRP to the resolved address.
-    const transactionHash = await this.xrpClient.sendWithDetails({
+    const transactionResult = await this.xrpClient.sendXrpWithDetails({
       amount,
       destination: destinationAddress,
       sender,
       memoList,
     })
 
-    return transactionHash
+    return transactionResult.hash
   }
 }

--- a/test/XRP/core-xrpl-client.test.ts
+++ b/test/XRP/core-xrpl-client.test.ts
@@ -106,7 +106,7 @@ describe('Common XRPL Client', function (): void {
       wallet,
     )
     // THEN it returns and the result is as expected.
-    const expectedTransactionResult = TransactionResult.getFinalTransactionResult(
+    const expectedTransactionResult = TransactionResult.createFinalTransactionResult(
       transactionHash,
       TransactionStatus.Succeeded,
       true,
@@ -219,7 +219,7 @@ describe('Common XRPL Client', function (): void {
     )
 
     // THEN it returns and the result is as expected.
-    const expectedResult = TransactionResult.getFinalTransactionResult(
+    const expectedResult = TransactionResult.createFinalTransactionResult(
       transactionHash,
       TransactionStatus.LastLedgerSequenceExpired,
       false,

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -301,7 +301,7 @@ describe('Default XRP Client', function (): void {
     const memoList = [iForgotToPickUpCarlMemo]
 
     // WHEN the account makes a transaction with a memo.
-    const transactionHash = await xrpClient.sendWithDetails({
+    const transactionResult = await xrpClient.sendXrpWithDetails({
       amount,
       destination: destinationAddress,
       sender: wallet,
@@ -313,8 +313,8 @@ describe('Default XRP Client', function (): void {
       FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
     )
 
-    assert.exists(transactionHash)
-    assert.strictEqual(transactionHash, expectedTransactionHash)
+    assert.exists(transactionResult.hash)
+    assert.strictEqual(transactionResult.hash, expectedTransactionHash)
   })
 
   it('Send XRP Transaction - success with BigInteger', async function () {
@@ -328,7 +328,7 @@ describe('Default XRP Client', function (): void {
     const amount = bigInt('10')
 
     // WHEN the account makes a transaction.
-    const transactionHash = await xrpClient.send(
+    const transactionResult = await xrpClient.sendXrp(
       amount,
       destinationAddress,
       wallet,
@@ -339,8 +339,8 @@ describe('Default XRP Client', function (): void {
       FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
     )
 
-    assert.exists(transactionHash)
-    assert.strictEqual(transactionHash, expectedTransactionHash)
+    assert.exists(transactionResult.hash)
+    assert.strictEqual(transactionResult.hash, expectedTransactionHash)
   })
 
   it('Send XRP Transaction - success with number', async function () {
@@ -354,7 +354,7 @@ describe('Default XRP Client', function (): void {
     const amount = 10
 
     // WHEN the account makes a transaction.
-    const transactionHash = await xrpClient.send(
+    const transactionResult = await xrpClient.sendXrp(
       amount,
       destinationAddress,
       wallet,
@@ -365,8 +365,8 @@ describe('Default XRP Client', function (): void {
       FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
     )
 
-    assert.exists(transactionHash)
-    assert.strictEqual(transactionHash, expectedTransactionHash)
+    assert.exists(transactionResult.hash)
+    assert.strictEqual(transactionResult.hash, expectedTransactionHash)
   })
 
   it('Send XRP Transaction - success with string', async function () {
@@ -380,7 +380,7 @@ describe('Default XRP Client', function (): void {
     const amount = '10'
 
     // WHEN the account makes a transaction.
-    const transactionHash = await xrpClient.send(
+    const transactionResult = await xrpClient.sendXrp(
       amount,
       destinationAddress,
       wallet,
@@ -391,8 +391,8 @@ describe('Default XRP Client', function (): void {
       FakeXRPNetworkClientResponses.defaultSubmitTransactionResponse().getHash_asU8(),
     )
 
-    assert.exists(transactionHash)
-    assert.strictEqual(transactionHash, expectedTransactionHash)
+    assert.exists(transactionResult.hash)
+    assert.strictEqual(transactionResult.hash, expectedTransactionHash)
   })
 
   it('Send XRP Transaction - failure with invalid string', function (done) {
@@ -406,7 +406,7 @@ describe('Default XRP Client', function (): void {
     const amount = 'not_a_number'
 
     // WHEN the account makes a transaction THEN an error is propagated.
-    xrpClient.send(amount, destinationAddress, wallet).catch((error) => {
+    xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.typeOf(error, 'Error')
       done()
     })
@@ -431,7 +431,7 @@ describe('Default XRP Client', function (): void {
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xrpClient.send(amount, destinationAddress, wallet).catch((error) => {
+    xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.typeOf(error, 'Error')
       assert.equal(
         error.message,
@@ -452,7 +452,7 @@ describe('Default XRP Client', function (): void {
     const amount = bigInt('10')
 
     // WHEN the account makes a transaction THEN an error is thrown.
-    xrpClient.send(amount, destinationAddress, wallet).catch((error) => {
+    xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.equal((error as XrpError).errorType, XrpErrorType.XAddressRequired)
       done()
     })
@@ -477,7 +477,7 @@ describe('Default XRP Client', function (): void {
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xrpClient.send(amount, destinationAddress, wallet).catch((error) => {
+    xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
       done()
     })
@@ -502,7 +502,7 @@ describe('Default XRP Client', function (): void {
     const amount = bigInt('10')
 
     // WHEN a payment is attempted THEN an error is propagated.
-    xrpClient.send(amount, destinationAddress, wallet).catch((error) => {
+    xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
       done()
     })

--- a/test/XRP/fakes/fake-xrp-client.ts
+++ b/test/XRP/fakes/fake-xrp-client.ts
@@ -12,13 +12,14 @@ class FakeXrpClient implements XrpClientDecorator {
   public constructor(
     public getBalanceValue: Result<BigInteger>,
     public getPaymentStatusValue: Result<TransactionStatus>,
-    public transactionHash: Result<string>,
+    public transactionResult: Result<TransactionResult>,
     public accountExistsValue: Result<boolean>,
     public paymentHistoryValue: Result<Array<XrpTransaction>>,
     public getPaymentValue: Result<XrpTransaction>,
     public enableDepositAuthValue: Result<TransactionResult>,
     public authorizeSendingAccountValue: Result<TransactionResult>,
     public unauthorizeSendingAccountValue: Result<TransactionResult>,
+    public transactionHash: Result<string> = 'deadbeef',
     public readonly network: XrplNetwork = XrplNetwork.Test,
   ) {}
 
@@ -40,6 +41,20 @@ class FakeXrpClient implements XrpClientDecorator {
 
   async sendWithDetails(_sendXrpDetails: SendXrpDetails): Promise<string> {
     return FakeXrpClient.returnOrThrow(this.transactionHash)
+  }
+
+  async sendXrp(
+    _amount: BigInteger | number | string,
+    _destination: string,
+    _sender: Wallet,
+  ): Promise<TransactionResult> {
+    return FakeXrpClient.returnOrThrow(this.transactionResult)
+  }
+
+  async sendXrpWithDetails(
+    _sendXrpDetails: SendXrpDetails,
+  ): Promise<TransactionResult> {
+    return FakeXrpClient.returnOrThrow(this.transactionResult)
   }
 
   async accountExists(_address: string): Promise<boolean> {

--- a/test/XRP/fakes/fake-xrp-client.ts
+++ b/test/XRP/fakes/fake-xrp-client.ts
@@ -19,6 +19,7 @@ class FakeXrpClient implements XrpClientDecorator {
     public enableDepositAuthValue: Result<TransactionResult>,
     public authorizeSendingAccountValue: Result<TransactionResult>,
     public unauthorizeSendingAccountValue: Result<TransactionResult>,
+    // TODO: remove `transactionHash` from constructor once `XpringClient` is deprecated and tests are removed.
     public transactionHash: Result<string> = 'deadbeef',
     public readonly network: XrplNetwork = XrplNetwork.Test,
   ) {}
@@ -31,6 +32,7 @@ class FakeXrpClient implements XrpClientDecorator {
     return FakeXrpClient.returnOrThrow(this.getPaymentStatusValue)
   }
 
+  // TODO: remove `send` and `sendWithDetails` once `XpringClient` has been deprecated and tests removed.
   async send(
     _amount: BigInteger | number | string,
     _destination: string,

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -70,7 +70,7 @@ describe('Reliable Submission XRP Client', function (): void {
     )
   })
 
-  it('Get Account Balance - Response Not Modified', async function () {
+  it('getAccountBalance - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXrpClient` decorating a `FakeXrpClient` WHEN a balance is retrieved.
     const returnedValue = await this.reliableSubmissionClient.getBalance(
       testAddress,
@@ -80,7 +80,7 @@ describe('Reliable Submission XRP Client', function (): void {
     assert.deepEqual(returnedValue, fakedGetBalanceValue)
   })
 
-  it('Get Payment Status - Response Not Modified', async function () {
+  it('getPaymentStatus - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXrpClient` decorating a `FakeXrpClient` WHEN a transaction status is retrieved.
     const returnedValue = await this.reliableSubmissionClient.getPaymentStatus(
       testAddress,
@@ -90,7 +90,7 @@ describe('Reliable Submission XRP Client', function (): void {
     assert.deepEqual(returnedValue, fakedTransactionStatusValue)
   })
 
-  it('Send - Returns when the transaction is validated', async function () {
+  it('sendXrp - Returns when the transaction is validated', async function () {
     // Increase timeout because `setTimeout` is only accurate to 1500ms.
     this.timeout(5000)
 
@@ -101,17 +101,17 @@ describe('Reliable Submission XRP Client', function (): void {
     const { wallet } = Wallet.generateRandomWallet()!
 
     // WHEN a reliable send is submitted
-    const transactionHash = await this.reliableSubmissionClient.send(
+    const transactionResult = await this.reliableSubmissionClient.sendXrp(
       '1',
       testAddress,
       wallet,
     )
 
     // THEN the function returns
-    assert.deepEqual(transactionHash, fakedSendValue)
+    assert.deepEqual(transactionResult, fakedSendValue)
   })
 
-  it('Payment History - Response Not Modified', async function () {
+  it('paymentHistory - Response Not Modified', async function () {
     // GIVEN a `ReliableSubmissionXrpClient` decorating a `FakeXrpClient` WHEN transaction history is retrieved.
     const returnedValue = await this.reliableSubmissionClient.paymentHistory(
       testAddress,
@@ -121,7 +121,7 @@ describe('Reliable Submission XRP Client', function (): void {
     assert.deepEqual(returnedValue, fakedTransactionHistoryValue)
   })
 
-  it('Enable Deposit Auth - Returns when the transaction is validated', async function () {
+  it('enableDepositAuth - Returns when the transaction is validated', async function () {
     // Increase timeout because `setTimeout` is only accurate to 1500ms.
     this.timeout(5000)
 

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -17,7 +17,7 @@ const transactionHash = 'DEADBEEF'
 
 const fakedGetBalanceValue = bigInt(10)
 const fakedTransactionStatusValue = TransactionStatus.Succeeded
-const fakedSendValue = TransactionResult.getFinalTransactionResult(
+const fakedSendValue = TransactionResult.createFinalTransactionResult(
   transactionHash,
   TransactionStatus.Succeeded,
   true,
@@ -29,7 +29,7 @@ const fakedAccountExistsValue = true
 const fakedFullPaymentValue = true
 const fakedTransactionHistoryValue = [testXrpTransaction]
 const fakedGetPaymentValue = testXrpTransaction
-const fakedTransactionResultValue = TransactionResult.getFinalTransactionResult(
+const fakedTransactionResultValue = TransactionResult.createFinalTransactionResult(
   transactionHash,
   TransactionStatus.Succeeded,
   true,

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -17,7 +17,11 @@ const transactionHash = 'DEADBEEF'
 
 const fakedGetBalanceValue = bigInt(10)
 const fakedTransactionStatusValue = TransactionStatus.Succeeded
-const fakedSendValue = transactionHash
+const fakedSendValue = TransactionResult.getFinalTransactionResult(
+  transactionHash,
+  TransactionStatus.Succeeded,
+  true,
+)
 const fakedRawTransactionStatusLastLedgerSequenceValue = 20
 const fakedRawTransactionStatusValidatedValue = true
 const fakedRawTransactionStatusTransactionStatusCode = transactionStatusCodeSuccess

--- a/test/Xpring/xpring-client.test.ts
+++ b/test/Xpring/xpring-client.test.ts
@@ -51,6 +51,7 @@ describe('Xpring Client', function (): void {
   it('send - success', async function (): Promise<void> {
     // GIVEN a XpringClient composed of a fake PayIDClient and a fake XrpClient which will both succeed.
     const expectedTransactionHash = fakeTransactionHash
+
     const xrpClient = new FakeXrpClient(
       fakeBalance,
       fakePaymentStatus,
@@ -61,6 +62,7 @@ describe('Xpring Client', function (): void {
       fakedSuccessfulTransactionResult,
       fakedSuccessfulTransactionResult,
       fakedSuccessfulTransactionResult,
+      expectedTransactionHash,
     )
 
     const resolvedXRPAddress = 'r123'
@@ -113,6 +115,7 @@ describe('Xpring Client', function (): void {
       fakedSuccessfulTransactionResult,
       fakedSuccessfulTransactionResult,
       fakedSuccessfulTransactionResult,
+      xrpError,
     )
 
     const resolvedXRPAddress = 'r123'

--- a/test/Xpring/xpring-client.test.ts
+++ b/test/Xpring/xpring-client.test.ts
@@ -18,6 +18,11 @@ import TransactionResult from '../../src/XRP/shared/transaction-result'
 const fakeBalance = bigInt(10)
 const fakePaymentStatus = TransactionStatus.Succeeded
 const fakeTransactionHash = 'deadbeefdeadbeefdeadbeef'
+const fakeSendXrpValue = TransactionResult.getFinalTransactionResult(
+  fakeTransactionHash,
+  TransactionStatus.Succeeded,
+  true,
+)
 const fakeAccountExistsResult = true
 const fakePaymentHistoryValue = []
 const fakeGetPaymentValue = testXrpTransaction
@@ -49,7 +54,7 @@ describe('Xpring Client', function (): void {
     const xrpClient = new FakeXrpClient(
       fakeBalance,
       fakePaymentStatus,
-      expectedTransactionHash,
+      fakeSendXrpValue,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,
       fakeGetPaymentValue,
@@ -72,11 +77,10 @@ describe('Xpring Client', function (): void {
 
   it('send - failure in PayID', function (done): void {
     // GIVEN a XpringClient composed of a PayIDClient which will throw an error.
-    const expectedTransactionHash = 'deadbeefdeadbeefdeadbeef'
     const xrpClient = new FakeXrpClient(
       fakeBalance,
       fakePaymentStatus,
-      expectedTransactionHash,
+      fakedSuccessfulTransactionResult,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,
       fakeGetPaymentValue,
@@ -155,7 +159,7 @@ describe('Xpring Client', function (): void {
     const xrpClient = new FakeXrpClient(
       fakeBalance,
       fakePaymentStatus,
-      fakeTransactionHash,
+      fakedSuccessfulTransactionResult,
       fakeAccountExistsResult,
       fakePaymentHistoryValue,
       fakeGetPaymentValue,

--- a/test/Xpring/xpring-client.test.ts
+++ b/test/Xpring/xpring-client.test.ts
@@ -18,7 +18,7 @@ import TransactionResult from '../../src/XRP/shared/transaction-result'
 const fakeBalance = bigInt(10)
 const fakePaymentStatus = TransactionStatus.Succeeded
 const fakeTransactionHash = 'deadbeefdeadbeefdeadbeef'
-const fakeSendXrpValue = TransactionResult.getFinalTransactionResult(
+const fakeSendXrpValue = TransactionResult.createFinalTransactionResult(
   fakeTransactionHash,
   TransactionStatus.Succeeded,
   true,
@@ -26,7 +26,7 @@ const fakeSendXrpValue = TransactionResult.getFinalTransactionResult(
 const fakeAccountExistsResult = true
 const fakePaymentHistoryValue = []
 const fakeGetPaymentValue = testXrpTransaction
-const fakedSuccessfulTransactionResult = TransactionResult.getFinalTransactionResult(
+const fakedSuccessfulTransactionResult = TransactionResult.createFinalTransactionResult(
   fakeTransactionHash,
   TransactionStatus.Succeeded,
   true,


### PR DESCRIPTION
## High Level Overview of Change
As best described [here](https://app.asana.com/0/1188384810103401/1198302721476927/f), the original `send` method on the `XrpClient` only returns a transaction hash.  The hash is returned when the outcome of the transaction is final (i.e. either the transaction was included in a validated ledger, was malformed to begin with, or has not yet been included AND its `lastLedgerSequence` field expired (surpassed by most recent validated ledger index)) - however, simply returning a hash makes it unclear which of these outcomes occurred.  Originally, it was intended that a user use `getPaymentStatus` on the resultant transaction hash to query the outcome of the transaction, however even this only returned either `TransactionStatus.Pending` (<-- an inaccurate and misleading status) or `TransactionStatus.Succeeded` / `TransactionStatus.Failed`.  It is unclear whether the transaction is on a validated ledger, and unclear why or why not.

Other transaction-sending methods use a `TransactionResult` object, which returns information about the transaction's status, inclusion or exclusion from a validated ledger, and whether or not this result is final.

This PR creates a new method: `XrpClient::sendXrp` (identical to `XrpClient::send` apart from the return value, which is a `TransactionResult` and it deprecates `XrpClient::send`, which will be removed from the SDK after two release cycles.

The renamed method is also important now that IOU work is poised to establish a `sendIssuance` or something along those lines (send no longer refers only to XRP).


<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change that only restructures code)


## Before / After
`sendXrp` exists and returns an informative `TransactionResult`.  `send` is deprecated.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Existing tests have been refactored to test the new method.  At the top level, `send` now simply wraps a call to `sendXrp`.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
