### PR TITLE
Adds `peerAccount` Optional Param to `IssuedCurrencyClient::getTrustLines`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,13 +1999,13 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.4.1.tgz",
-      "integrity": "sha512-O+8Utz8pb4OmcA+Nfi5THQnQpHSD2sDUNw9AxNHpuYOo326HZTtG8gsfT+EAYuVrFNaLyNb2QnUNkmTRDskuRA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.5.0.tgz",
+      "integrity": "sha512-mjb/gwNcmDKNt+6mb7Aj/TjKzIJjOPcoCJpjBQC9ZnTRnBt1p4q5dJSSmIqAtsZ/Pff5N+hJlbiPc5bl6QN4OQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.4.1",
-        "@typescript-eslint/scope-manager": "4.4.1",
+        "@typescript-eslint/experimental-utils": "4.5.0",
+        "@typescript-eslint/scope-manager": "4.5.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -2014,28 +2014,28 @@
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.4.1.tgz",
-          "integrity": "sha512-2oD/ZqD4Gj41UdFeWZxegH3cVEEH/Z6Bhr/XvwTtGv66737XkR4C9IqEkebCuqArqBJQSj4AgNHHiN1okzD/wQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.5.0.tgz",
+          "integrity": "sha512-C0cEO0cTMPJ/w4RA/KVe4LFFkkSh9VHoFzKmyaaDWAnPYIEzVCtJ+Un8GZoJhcvq+mPFXEsXa01lcZDHDG6Www==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.4.1",
-            "@typescript-eslint/visitor-keys": "4.4.1"
+            "@typescript-eslint/types": "4.5.0",
+            "@typescript-eslint/visitor-keys": "4.5.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.4.1.tgz",
-          "integrity": "sha512-KNDfH2bCyax5db+KKIZT4rfA8rEk5N0EJ8P0T5AJjo5xrV26UAzaiqoJCxeaibqc0c/IvZxp7v2g3difn2Pn3w==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.5.0.tgz",
+          "integrity": "sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g==",
           "dev": true
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.1.tgz",
-          "integrity": "sha512-H2JMWhLaJNeaylSnMSQFEhT/S/FsJbebQALmoJxMPMxLtlVAMy2uJP/Z543n9IizhjRayLSqoInehCeNW9rWcw==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.5.0.tgz",
+          "integrity": "sha512-UHq4FSa55NDZqscRU//O5ROFhHa9Hqn9KWTEvJGTArtTQp5GKv9Zqf6d/Q3YXXcFv4woyBml7fJQlQ+OuqRcHA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.4.1",
+            "@typescript-eslint/types": "4.5.0",
             "eslint-visitor-keys": "^2.0.0"
           }
         },
@@ -2069,43 +2069,43 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.4.1.tgz",
-      "integrity": "sha512-Nt4EVlb1mqExW9cWhpV6pd1a3DkUbX9DeyYsdoeziKOpIJ04S2KMVDO+SEidsXRH/XHDpbzXykKcMTLdTXH6cQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.5.0.tgz",
+      "integrity": "sha512-bW9IpSAKYvkqDGRZzayBXIgPsj2xmmVHLJ+flGSoN0fF98pGoKFhbunIol0VF2Crka7z984EEhFi623Rl7e6gg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.4.1",
-        "@typescript-eslint/types": "4.4.1",
-        "@typescript-eslint/typescript-estree": "4.4.1",
+        "@typescript-eslint/scope-manager": "4.5.0",
+        "@typescript-eslint/types": "4.5.0",
+        "@typescript-eslint/typescript-estree": "4.5.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.4.1.tgz",
-          "integrity": "sha512-2oD/ZqD4Gj41UdFeWZxegH3cVEEH/Z6Bhr/XvwTtGv66737XkR4C9IqEkebCuqArqBJQSj4AgNHHiN1okzD/wQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.5.0.tgz",
+          "integrity": "sha512-C0cEO0cTMPJ/w4RA/KVe4LFFkkSh9VHoFzKmyaaDWAnPYIEzVCtJ+Un8GZoJhcvq+mPFXEsXa01lcZDHDG6Www==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.4.1",
-            "@typescript-eslint/visitor-keys": "4.4.1"
+            "@typescript-eslint/types": "4.5.0",
+            "@typescript-eslint/visitor-keys": "4.5.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.4.1.tgz",
-          "integrity": "sha512-KNDfH2bCyax5db+KKIZT4rfA8rEk5N0EJ8P0T5AJjo5xrV26UAzaiqoJCxeaibqc0c/IvZxp7v2g3difn2Pn3w==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.5.0.tgz",
+          "integrity": "sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.4.1.tgz",
-          "integrity": "sha512-wP/V7ScKzgSdtcY1a0pZYBoCxrCstLrgRQ2O9MmCUZDtmgxCO/TCqOTGRVwpP4/2hVfqMz/Vw1ZYrG8cVxvN3g==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.5.0.tgz",
+          "integrity": "sha512-gN1mffq3zwRAjlYWzb5DanarOPdajQwx5MEWkWCk0XvqC8JpafDTeioDoow2L4CA/RkYZu7xEsGZRhqrTsAG8w==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.4.1",
-            "@typescript-eslint/visitor-keys": "4.4.1",
+            "@typescript-eslint/types": "4.5.0",
+            "@typescript-eslint/visitor-keys": "4.5.0",
             "debug": "^4.1.1",
             "globby": "^11.0.1",
             "is-glob": "^4.0.1",
@@ -2115,12 +2115,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.1.tgz",
-          "integrity": "sha512-H2JMWhLaJNeaylSnMSQFEhT/S/FsJbebQALmoJxMPMxLtlVAMy2uJP/Z543n9IizhjRayLSqoInehCeNW9rWcw==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.5.0.tgz",
+          "integrity": "sha512-UHq4FSa55NDZqscRU//O5ROFhHa9Hqn9KWTEvJGTArtTQp5GKv9Zqf6d/Q3YXXcFv4woyBml7fJQlQ+OuqRcHA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.4.1",
+            "@typescript-eslint/types": "4.5.0",
             "eslint-visitor-keys": "^2.0.0"
           }
         },

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -68,7 +68,7 @@ export default class IssuedCurrencyClient {
    * @see https://xrpl.org/trust-lines-and-issuing.html
    *
    * @param account The account for which to retrieve associated trust lines, encoded as an X-Address.
-   * @param peerAccount (Optional) The address of a second account. If provided, show only lines of trust connecting the two accounts.
+   * @param peerAccount (Optional) The address of a second account. If provided, show only trust lines connecting the two accounts.
    * @see https://xrpaddress.info/
    * @returns An array of TrustLine objects, representing all trust lines associated with this account.
    */

--- a/src/XRP/network-clients/json-network-client-interface.ts
+++ b/src/XRP/network-clients/json-network-client-interface.ts
@@ -4,5 +4,8 @@ import { AccountLinesResponse } from '../shared/rippled-json-rpc-schema'
  * The JsonNetworkClientInterface defines the calls available via the rippled JSON-RPC.
  */
 export interface JsonNetworkClientInterface {
-  getAccountLines(account: string): Promise<AccountLinesResponse>
+  getAccountLines(
+    account: string,
+    peerAccount?: string,
+  ): Promise<AccountLinesResponse>
 }

--- a/src/XRP/network-clients/json-rpc-network-client.ts
+++ b/src/XRP/network-clients/json-rpc-network-client.ts
@@ -3,12 +3,14 @@ import {
   JsonRpcRequestOptions,
 } from '../shared/rippled-json-rpc-schema'
 import axios, { AxiosInstance, AxiosResponse } from 'axios'
+import { JsonNetworkClientInterface } from './json-network-client-interface'
 
 /**
  * A network client for interacting with the rippled JSON RPC.
  * @see https://xrpl.org/rippled-api.html
  */
-export default class JsonRpcNetworkClient {
+export default class JsonRpcNetworkClient
+  implements JsonNetworkClientInterface {
   private readonly axiosInstance: AxiosInstance
 
   /**

--- a/src/XRP/network-clients/json-rpc-network-client.ts
+++ b/src/XRP/network-clients/json-rpc-network-client.ts
@@ -63,15 +63,17 @@ export default class JsonRpcNetworkClient {
    *
    * @param account The XRPL account to query for trust lines.
    */
-  public async getAccountLines(account: string): Promise<AccountLinesResponse> {
-    // TODO: consider an option for including the 'peer' param in the request, which limits the returned trust lines to only
-    // those shared between the two accounts. (This would have to be an argument to the method here and in i-c-client too.)
+  public async getAccountLines(
+    account: string,
+    peerAccount?: string,
+  ): Promise<AccountLinesResponse> {
     const accountLinesRequest = {
       method: 'account_lines',
       params: [
         {
           account: account,
           ledger_index: 'validated',
+          peer: peerAccount,
         },
       ],
     }

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -50,6 +50,9 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     assert.isTrue(trustLines.length > 0)
   })
 
+  // TODO: (amiecorso) implement an integration test that includes the peerAccount param when we have control over establishing
+  // specific trustlines.  Can't otherwise verify correctness.
+
   it('getTrustLines - account not found', async function (): Promise<void> {
     this.timeout(timeoutMs)
     // GIVEN a valid address that doesn't actually exist on the ledger

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -54,7 +54,7 @@ describe('Issued Currency Client', function (): void {
     assert.deepEqual(trustLines, expectedTrustLines)
   })
 
-  it('getTrustLines - invalid account', async function (done): Promise<void> {
+  it('getTrustLines - invalid account', async function (): Promise<void> {
     // GIVEN an IssuedCurrencyClient
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
@@ -70,12 +70,9 @@ describe('Issued Currency Client', function (): void {
       assert.typeOf(error, 'Error')
       assert.equal(error, XrpError.xAddressRequired)
     }
-    done()
   })
 
-  it('getTrustLines - invalid peerAccount', async function (done): Promise<
-    void
-  > {
+  it('getTrustLines - invalid peerAccount', async function (): Promise<void> {
     // GIVEN an IssuedCurrencyClient
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
@@ -91,10 +88,9 @@ describe('Issued Currency Client', function (): void {
       assert.typeOf(error, 'Error')
       assert.equal(error, XrpError.xAddressRequired)
     }
-    done()
   })
 
-  it('getTrustLines - account not found error response', async function (done): Promise<
+  it('getTrustLines - account not found error response', async function (): Promise<
     void
   > {
     // GIVEN an IssuedCurrencyClient with faked networking that will return an error response for getAccountLines
@@ -121,10 +117,9 @@ describe('Issued Currency Client', function (): void {
     } catch (error) {
       assert.typeOf(error, 'Error')
     }
-    done()
   })
 
-  it('getTrustLines - invalid params error response', async function (done): Promise<
+  it('getTrustLines - invalid params error response', async function (): Promise<
     void
   > {
     // GIVEN an IssuedCurrencyClient with faked networking that will return an error response for getAccountLines
@@ -151,7 +146,6 @@ describe('Issued Currency Client', function (): void {
     } catch (error) {
       assert.typeOf(error, 'Error')
     }
-    done()
   })
 
   it('requireAuthorizedTrustlines - successful response', async function (): Promise<

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -54,7 +54,7 @@ describe('Issued Currency Client', function (): void {
     assert.deepEqual(trustLines, expectedTrustLines)
   })
 
-  it('getTrustLines - invalid account', function (done): void {
+  it('getTrustLines - invalid account', async function (done): Promise<void> {
     // GIVEN an IssuedCurrencyClient
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
@@ -64,14 +64,18 @@ describe('Issued Currency Client', function (): void {
 
     // WHEN getTrustLines is called with an invalid address THEN an error is propagated.
     const address = 'malformedAddress'
-    issuedCurrencyClient.getTrustLines(address).catch((error) => {
+    try {
+      await issuedCurrencyClient.getTrustLines(address)
+    } catch (error) {
       assert.typeOf(error, 'Error')
       assert.equal(error, XrpError.xAddressRequired)
-      done()
-    })
+    }
+    done()
   })
 
-  it('getTrustLines - invalid peerAccount', function (done): void {
+  it('getTrustLines - invalid peerAccount', async function (done): Promise<
+    void
+  > {
     // GIVEN an IssuedCurrencyClient
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
@@ -79,18 +83,20 @@ describe('Issued Currency Client', function (): void {
       XrplNetwork.Test,
     )
 
-    // WHEN getTrustLines is called with an invalid peerAccount address THEN an error is propagated.
+    // WHEN getTrustLines is called with an invalid peerAccount address THEN an error is thrown.
     const peerAddress = 'malformedAddress'
-    issuedCurrencyClient
-      .getTrustLines(testAddress, peerAddress)
-      .catch((error) => {
-        assert.typeOf(error, 'Error')
-        assert.equal(error, XrpError.xAddressRequired)
-        done()
-      })
+    try {
+      await issuedCurrencyClient.getTrustLines(testAddress, peerAddress)
+    } catch (error) {
+      assert.typeOf(error, 'Error')
+      assert.equal(error, XrpError.xAddressRequired)
+    }
+    done()
   })
 
-  it('getTrustLines - account not found error response', function (done): void {
+  it('getTrustLines - account not found error response', async function (done): Promise<
+    void
+  > {
     // GIVEN an IssuedCurrencyClient with faked networking that will return an error response for getAccountLines
     const accountNotFoundResponse: AccountLinesResponse = {
       result: {
@@ -109,15 +115,18 @@ describe('Issued Currency Client', function (): void {
       fakeErroringJsonClient,
       XrplNetwork.Test,
     )
-    // WHEN getTrustLines is called THEN an error is propagated.
-    issuedCurrencyClient.getTrustLines(testAddress).catch((error) => {
+    // WHEN getTrustLines is called THEN an error is thrown.
+    try {
+      await issuedCurrencyClient.getTrustLines(testAddress)
+    } catch (error) {
       assert.typeOf(error, 'Error')
-      assert.equal(error, XrpError.accountNotFound)
-      done()
-    })
+    }
+    done()
   })
 
-  it('getTrustLines - invalid params error response', function (done): void {
+  it('getTrustLines - invalid params error response', async function (done): Promise<
+    void
+  > {
     // GIVEN an IssuedCurrencyClient with faked networking that will return an error response for getAccountLines
     const invalidParamsResponse: AccountLinesResponse = {
       result: {
@@ -136,18 +145,13 @@ describe('Issued Currency Client', function (): void {
       fakeErroringJsonClient,
       XrplNetwork.Test,
     )
-    // WHEN getTrustLines is called THEN an error is propagated.
-    issuedCurrencyClient.getTrustLines(testAddress).catch((error) => {
+    // WHEN getTrustLines is called THEN an error is thrown.
+    try {
+      await issuedCurrencyClient.getTrustLines(testAddress)
+    } catch (error) {
       assert.typeOf(error, 'Error')
-      // TODO: why doesn't this work?
-      // I get: AssertionError: expected [Error: invalidParams] to deeply equal [Error: invalidParams]
-      // ( and same when I use assert.equal instead of assert.deepEqual)
-      // assert.deepEqual(
-      //   error,
-      //   new XrpError(XrpErrorType.Unknown, 'invalidParams'),
-      // )
-      done()
-    })
+    }
+    done()
   })
 
   it('requireAuthorizedTrustlines - successful response', async function (): Promise<


### PR DESCRIPTION
## High Level Overview of Change
The [`account_lines`](https://xrpl.org/account_lines.html) RPC allows for an optional `peer` field in the request, which, if provided, limits the results returned only to trust lines established between the querying account and the provided peer account.  This is a useful feature that is best to implement at the network layer in order to avoid an excessive amount of data between unnecessarily returned over the network.  

This PR implements that option in the `IssuedCurrencyClient`'s `getTrustLines` method.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
IOU effort
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
Optional `peer` option available as `peerAccount` param.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Added some unit tests to check that our method correctly validates the format of the peer address. 
Integration tests will be easier to write when we have more complete IOU functionality.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
Add integration tests that specifically test for the filtering effect of the peer option.  Let's do this once we're able to establish and authorize trustlines using the `IssuedCurrencyClient`, so that we can control what we're evaluating.
