### PR TITLE
Creates `monitorAccountTransactions` on `IssuedCurrencyClient`

### DIFF
--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -220,7 +220,7 @@ export default class IssuedCurrencyClient {
       throw XrpError.xAddressRequired
     }
 
-    const id = 'monitor_transactions_${account}'
+    const id = `monitor_transactions_${account}`
 
     return await this.webSocketNetworkClient.subscribeToAccount(
       classicAddress.address,

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -38,10 +38,7 @@ import GatewayBalances, {
   gatewayBalancesFromResponse,
 } from './shared/gateway-balances'
 import TrustLine from './shared/trustline'
-import {
-  WebSocketStatusResponse,
-  TransactionResponse,
-} from './shared/rippled-web-socket-schema'
+import { TransactionResponse } from './shared/rippled-web-socket-schema'
 import { WebSocketNetworkClientInterface } from './network-clients/web-socket-network-client-interface'
 import WebSocketNetworkClient from './network-clients/web-socket-network-client'
 import { SendMax } from 'xpring-common-js/build/src/XRP/generated/org/xrpl/rpc/v1/common_pb'
@@ -215,7 +212,7 @@ export default class IssuedCurrencyClient {
   public async monitorAccountTransactions(
     account: string,
     callback: (data: TransactionResponse) => void,
-  ): Promise<WebSocketStatusResponse> {
+  ): Promise<boolean> {
     const classicAddress = XrpUtils.decodeXAddress(account)
     if (!classicAddress) {
       throw XrpError.xAddressRequired
@@ -223,11 +220,12 @@ export default class IssuedCurrencyClient {
 
     const id = `monitor_transactions_${account}`
 
-    return await this.webSocketNetworkClient.subscribeToAccount(
+    const response = await this.webSocketNetworkClient.subscribeToAccount(
       classicAddress.address,
       id,
       callback,
     )
+    return response.status === 'success'
   }
 
   /**

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -26,8 +26,8 @@ import { AccountLinesResponse } from './shared/rippled-json-rpc-schema'
 import TrustLine from './shared/trustline'
 import { TransferRate } from './Generated/node/org/xrpl/rpc/v1/common_pb'
 import {
-  WebSocketResponse,
   WebSocketStatusResponse,
+  WebSocketTransactionResponse,
 } from './shared/rippled-web-socket-schema'
 import { WebSocketNetworkClientInterface } from './network-clients/web-socket-network-client-interface'
 import WebSocketNetworkClient from './network-clients/web-socket-network-client'
@@ -117,7 +117,7 @@ export default class IssuedCurrencyClient {
 
   public async monitorIncomingPayments(
     account: string,
-    callback: (data: WebSocketResponse) => void,
+    callback: (data: WebSocketTransactionResponse) => void,
   ): Promise<WebSocketStatusResponse> {
     const id = 'monitor_transactions_' + account
     return await this.webSocketNetworkClient.subscribeToAccount(

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -40,7 +40,7 @@ import GatewayBalances, {
 import TrustLine from './shared/trustline'
 import {
   WebSocketStatusResponse,
-  WebSocketTransactionResponse,
+  TransactionResponse,
 } from './shared/rippled-web-socket-schema'
 import { WebSocketNetworkClientInterface } from './network-clients/web-socket-network-client-interface'
 import WebSocketNetworkClient from './network-clients/web-socket-network-client'
@@ -214,7 +214,7 @@ export default class IssuedCurrencyClient {
    */
   public async monitorAccountTransactions(
     account: string,
-    callback: (data: WebSocketTransactionResponse) => void,
+    callback: (data: TransactionResponse) => void,
   ): Promise<WebSocketStatusResponse> {
     const classicAddress = XrpUtils.decodeXAddress(account)
     if (!classicAddress) {

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -25,7 +25,6 @@ import TransactionResult from './shared/transaction-result'
 import { AccountLinesResponse } from './shared/rippled-json-rpc-schema'
 import TrustLine from './shared/trustline'
 import { TransferRate } from './Generated/node/org/xrpl/rpc/v1/common_pb'
-import { AccountSet } from './Generated/node/org/xrpl/rpc/v1/transaction_pb'
 import {
   WebSocketResponse,
   WebSocketStatusResponse,

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -219,12 +219,11 @@ export default class IssuedCurrencyClient {
     if (!classicAddress) {
       throw XrpError.xAddressRequired
     }
-    const address = classicAddress.address
 
-    const id = 'monitor_transactions_' + account
+    const id = 'monitor_transactions_${account}'
 
     return await this.webSocketNetworkClient.subscribeToAccount(
-      address,
+      classicAddress.address,
       id,
       callback,
     )

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -78,7 +78,7 @@ export default class IssuedCurrencyClient {
   public constructor(
     grpcNetworkClient: GrpcNetworkClientInterface,
     private readonly jsonNetworkClient: JsonNetworkClientInterface,
-    private readonly webSocketNetworkClient: WebSocketNetworkClientInterface,
+    readonly webSocketNetworkClient: WebSocketNetworkClientInterface,
     readonly network: XrplNetwork,
   ) {
     this.coreXrplClient = new CoreXrplClient(grpcNetworkClient, network)
@@ -120,7 +120,11 @@ export default class IssuedCurrencyClient {
     callback: (data: WebSocketResponse) => void,
   ): Promise<WebSocketStatusResponse> {
     const id = 'monitor_transactions_' + account
-    return await this.webSocketNetworkClient.subscribe(id, 'ledger', callback)
+    return await this.webSocketNetworkClient.subscribeToAccount(
+      id,
+      callback,
+      account,
+    )
   }
 
   /**

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -52,6 +52,7 @@ export default class IssuedCurrencyClient {
     grpcUrl: string,
     jsonUrl: string,
     webSocketUrl: string,
+    handleWebSocketErrorMessage: (data: string) => void,
     network: XrplNetwork,
     forceWeb = false,
   ): IssuedCurrencyClient {
@@ -62,7 +63,7 @@ export default class IssuedCurrencyClient {
     return new IssuedCurrencyClient(
       grpcNetworkClient,
       new JsonRpcNetworkClient(jsonUrl),
-      new WebSocketNetworkClient(webSocketUrl),
+      new WebSocketNetworkClient(webSocketUrl, handleWebSocketErrorMessage),
       network,
     )
   }

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -115,11 +115,21 @@ export default class IssuedCurrencyClient {
     return trustLines
   }
 
+  /**
+   * Subscribes to an account's incoming transactions, and triggers a callback upon recieving each transaction.
+   * @see https://xrpl.org/monitor-incoming-payments-with-websocket.html
+   * @see https://xrpl.org/subscribe.html
+   *
+   * @param account The account from which to subscribe to incoming transactions, encoded as an X-Address.
+   * @param callback The function to trigger upon recieving each transaction from the ledger.
+   * @returns The response from the websocket confirming the subscription.
+   */
   public async monitorIncomingPayments(
     account: string,
     callback: (data: WebSocketTransactionResponse) => void,
   ): Promise<WebSocketStatusResponse> {
     const id = 'monitor_transactions_' + account
+
     return await this.webSocketNetworkClient.subscribeToAccount(
       id,
       callback,

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -203,15 +203,16 @@ export default class IssuedCurrencyClient {
   }
 
   /**
-   * Subscribes to an account's incoming transactions, and triggers a callback upon recieving each transaction.
+   * Subscribes to all transactions that affect the specified account, and triggers a callback upon
+   * receiving each transaction.
    * @see https://xrpl.org/monitor-incoming-payments-with-websocket.html
    * @see https://xrpl.org/subscribe.html
    *
-   * @param account The account from which to subscribe to incoming transactions, encoded as an X-Address.
-   * @param callback The function to trigger upon recieving each transaction from the ledger.
-   * @returns The response from the websocket confirming the subscription.
+   * @param account The account for which to subscribe to relevant transactions, encoded as an X-Address.
+   * @param callback The function to trigger upon receiving a transaction event from the ledger.
+   * @returns The response from the websocket indicating the result of the subscription request.
    */
-  public async monitorIncomingPayments(
+  public async monitorAccountTransactions(
     account: string,
     callback: (data: WebSocketTransactionResponse) => void,
   ): Promise<WebSocketStatusResponse> {

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -128,12 +128,18 @@ export default class IssuedCurrencyClient {
     account: string,
     callback: (data: WebSocketTransactionResponse) => void,
   ): Promise<WebSocketStatusResponse> {
+    const classicAddress = XrpUtils.decodeXAddress(account)
+    if (!classicAddress) {
+      throw XrpError.xAddressRequired
+    }
+    const address = classicAddress.address
+
     const id = 'monitor_transactions_' + account
 
     return await this.webSocketNetworkClient.subscribeToAccount(
       id,
       callback,
-      account,
+      address,
     )
   }
 

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -22,11 +22,5 @@ export interface WebSocketNetworkClientInterface {
     account: string,
   ): Promise<WebSocketStatusResponse>
 
-  // unsubscribe(
-  //   id: string,
-  //   stream: string,
-  //   // TODO make multiple streams/callbacks an option??
-  // ): Promise<void>
-
   close(): void
 }

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -7,6 +7,15 @@ import {
  * The WebSocketNetworkClientInterface defines the calls available via the rippled WebSocket API.
  */
 export interface WebSocketNetworkClientInterface {
+  /**
+   * Subscribes to incoming transactions to a given account.
+   * @see https://xrpl.org/monitor-incoming-payments-with-websocket.html
+   *
+   * @param id The ID used for the subscription.
+   * @param callback The function called whenever a new transaction is received.
+   * @param account The account from which to subscribe to incoming transactions, encoded as an X-Address.
+   * @returns The response from the websocket confirming the subscription.
+   */
   subscribeToAccount(
     id: string,
     callback: (data: WebSocketTransactionResponse) => void,

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -1,3 +1,8 @@
+import {
+  WebSocketResponse,
+  WebSocketStatusResponse,
+} from '../shared/rippled-web-socket-schema'
+
 /**
  * The WebSocketNetworkClientInterface defines the calls available via the rippled WebSocket API.
  */
@@ -5,9 +10,9 @@ export interface WebSocketNetworkClientInterface {
   subscribe(
     id: string,
     stream: string,
-    callback: (data: any) => void,
+    callback: (data: WebSocketResponse) => void,
     // TODO make multiple streams/callbacks an option??
-  ): Promise<void>
+  ): Promise<WebSocketStatusResponse>
 
   // unsubscribe(
   //   id: string,

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -8,10 +8,10 @@ import {
  */
 export interface WebSocketNetworkClientInterface {
   /**
-   * Subscribes to incoming transactions to a given account.
+   * Subscribes for notification about every validated transaction that affects the given account.
    * @see https://xrpl.org/monitor-incoming-payments-with-websocket.html
    *
-   * @param account The account from which to subscribe to incoming transactions, encoded as an X-Address.
+   * @param account The account from which to subscribe to incoming transactions, encoded as a classic address.
    * @param subscriptionId The ID used for the subscription.
    * @param callback The function called whenever a new transaction is received.
    * @returns The response from the websocket confirming the subscription.

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -2,5 +2,16 @@
  * The WebSocketNetworkClientInterface defines the calls available via the rippled WebSocket API.
  */
 export interface WebSocketNetworkClientInterface {
-  subscribe(account: string): Promise<string>
+  subscribe(
+    id: string,
+    stream: string,
+    callback: (data: any) => void,
+    // TODO make multiple streams/callbacks an option??
+  ): Promise<void>
+
+  // unsubscribe(
+  //   id: string,
+  //   stream: string,
+  //   // TODO make multiple streams/callbacks an option??
+  // ): Promise<void>
 }

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -7,11 +7,10 @@ import {
  * The WebSocketNetworkClientInterface defines the calls available via the rippled WebSocket API.
  */
 export interface WebSocketNetworkClientInterface {
-  subscribe(
+  subscribeToAccount(
     id: string,
-    stream: string,
     callback: (data: WebSocketResponse) => void,
-    // TODO make multiple streams/callbacks an option??
+    account: string,
   ): Promise<WebSocketStatusResponse>
 
   // unsubscribe(
@@ -19,4 +18,6 @@ export interface WebSocketNetworkClientInterface {
   //   stream: string,
   //   // TODO make multiple streams/callbacks an option??
   // ): Promise<void>
+
+  close(): void
 }

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -1,5 +1,5 @@
 import {
-  WebSocketTransactionResponse,
+  TransactionResponse,
   WebSocketStatusResponse,
 } from '../shared/rippled-web-socket-schema'
 
@@ -19,7 +19,7 @@ export interface WebSocketNetworkClientInterface {
   subscribeToAccount(
     account: string,
     subscriptionId: string,
-    callback: (data: WebSocketTransactionResponse) => void,
+    callback: (data: TransactionResponse) => void,
   ): Promise<WebSocketStatusResponse>
 
   close(): void

--- a/src/XRP/network-clients/web-socket-network-client-interface.ts
+++ b/src/XRP/network-clients/web-socket-network-client-interface.ts
@@ -1,5 +1,5 @@
 import {
-  WebSocketResponse,
+  WebSocketTransactionResponse,
   WebSocketStatusResponse,
 } from '../shared/rippled-web-socket-schema'
 
@@ -9,7 +9,7 @@ import {
 export interface WebSocketNetworkClientInterface {
   subscribeToAccount(
     id: string,
-    callback: (data: WebSocketResponse) => void,
+    callback: (data: WebSocketTransactionResponse) => void,
     account: string,
   ): Promise<WebSocketStatusResponse>
 

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -38,12 +38,6 @@ export default class WebSocketNetworkClient {
 
     this.callbacks.set('response', (data: WebSocketResponse) => {
       const dataStatusResponse = data as WebSocketStatusResponse
-      if (dataStatusResponse.id === undefined) {
-        throw new XrpError(
-          XrpErrorType.Unknown,
-          'Response type does not contain an id',
-        )
-      }
       this.waiting.set(dataStatusResponse.id, data)
     })
     this.callbacks.set('transaction', this.handleTransaction)

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -7,7 +7,7 @@ import {
   WebSocketResponse,
   WebSocketStatusResponse,
   WebSocketStatusErrorResponse,
-  WebSocketTransactionResponse,
+  TransactionResponse,
 } from '../shared/rippled-web-socket-schema'
 
 function sleep(ms: number): Promise<void> {
@@ -22,7 +22,7 @@ export default class WebSocketNetworkClient {
   private readonly socket: WebSocket
   private accountCallbacks: Map<
     string,
-    (data: WebSocketTransactionResponse) => void
+    (data: TransactionResponse) => void
   > = new Map()
   private messageCallbacks: Map<
     string,
@@ -47,7 +47,7 @@ export default class WebSocketNetworkClient {
       this.waiting.set(dataStatusResponse.id, data)
     })
     this.messageCallbacks.set('transaction', (data: WebSocketResponse) =>
-      this.handleTransaction(data as WebSocketTransactionResponse),
+      this.handleTransaction(data as TransactionResponse),
     )
 
     this.socket.addEventListener('message', (event) => {
@@ -77,7 +77,7 @@ export default class WebSocketNetworkClient {
    *
    * @param data The web socket response received from the web socket.
    */
-  private handleTransaction(data: WebSocketTransactionResponse) {
+  private handleTransaction(data: TransactionResponse) {
     const destinationAccount = data.transaction.Destination
     const destinationCallback = this.accountCallbacks.get(destinationAccount)
 
@@ -94,8 +94,7 @@ export default class WebSocketNetworkClient {
     if (!destinationCallback && !senderCallback) {
       throw new XrpError(
         XrpErrorType.Unknown,
-        'Received a transaction for an account that has not been subscribed to: ' +
-          destinationAccount,
+        `Received a transaction for an account that has not been subscribed to: ${destinationAccount}`,
       )
     }
   }
@@ -140,7 +139,7 @@ export default class WebSocketNetworkClient {
   public async subscribeToAccount(
     account: string,
     subscriptionId: string,
-    callback: (data: WebSocketTransactionResponse) => void,
+    callback: (data: TransactionResponse) => void,
   ): Promise<WebSocketStatusResponse> {
     const options = {
       id: subscriptionId,

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -77,7 +77,7 @@ export default class WebSocketNetworkClient {
     })
   }
 
-  private async apiRequest(
+  private async sendApiRequest(
     options: WebSocketRequestOptions,
   ): Promise<WebSocketStatusResponse> {
     while (this.socket.readyState === 0) {
@@ -95,27 +95,19 @@ export default class WebSocketNetworkClient {
     return response as WebSocketStatusResponse
   }
 
-  private addCallback(
-    account: string,
-    callback: (data: WebSocketTransactionResponse) => void,
-  ): void {
-    // TODO figure out if there are more exceptions
-    this.accountCallbacks.set(account, callback)
-  }
-
   public async subscribeToAccount(
     id: string,
     callback: (data: WebSocketTransactionResponse) => void,
     account: string,
     // TODO make multiple streams/callbacks an option??
   ): Promise<WebSocketStatusResponse> {
-    this.addCallback(account, callback)
+    this.accountCallbacks.set(account, callback)
     const options = {
       id,
       command: 'subscribe',
       accounts: [account],
     }
-    const response = await this.apiRequest(options)
+    const response = await this.sendApiRequest(options)
     if (response.status !== 'success') {
       console.error('Error subscribing: ', response)
       // TODO throw descriptive error

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -44,11 +44,11 @@ export default class WebSocketNetworkClient {
           'Response type does not contain an id',
         )
       }
+      this.waiting.set(dataStatusResponse.id, data)
       const result = dataStatusResponse.result
       if (result) {
         this.handleTransaction(result)
       }
-      this.waiting[dataStatusResponse.id] = data
     })
     this.callbacks.set('transaction', this.handleTransaction)
 
@@ -111,11 +111,11 @@ export default class WebSocketNetworkClient {
     }
     this.socket.send(JSON.stringify(request))
 
-    this.waiting[request.id] = undefined
-    while (this.waiting[request.id] === undefined) {
+    this.waiting.set(request.id, undefined)
+    while (this.waiting.get(request.id) === undefined) {
       await this.sleep(5)
     }
-    const response = this.waiting[request.id]
+    const response = this.waiting.get(request.id)
     this.waiting.delete(request.id)
 
     return response as WebSocketStatusResponse

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -58,17 +58,17 @@ export default class WebSocketNetworkClient {
         callback(parsedData)
       } else {
         this.handleErrorMessage(
-          'Received unhandlable message: ${event.data as string}',
+          `Received unhandlable message: ${event.data as string}`,
         )
       }
     })
 
     this.socket.addEventListener('close', (event: CloseEvent) => {
-      this.handleErrorMessage('Web socket disconnected, ' + event.reason)
+      this.handleErrorMessage(`Web socket disconnected, ${event.reason}`)
     })
 
     this.socket.addEventListener('error', (event: ErrorEvent) => {
-      this.handleErrorMessage('Error: ' + event.message)
+      this.handleErrorMessage(`Error: ${event.message}`)
     })
   }
 

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -41,6 +41,7 @@ export default class WebSocketNetworkClient {
     private handleErrorMessage: (message: string) => void,
   ) {
     this.socket = new WebSocket(webSocketUrl)
+
     this.messageCallbacks.set('response', (data: WebSocketResponse) => {
       const dataStatusResponse = data as WebSocketStatusResponse
       this.waiting.set(dataStatusResponse.id, data)

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -96,7 +96,7 @@ export default class WebSocketNetworkClient {
     stream: string,
     callback: (data: WebSocketResponse) => void,
     // TODO make multiple streams/callbacks an option??
-  ): Promise<void> {
+  ): Promise<WebSocketStatusResponse> {
     this.addCallback(stream, callback)
     const response = await this.apiRequest({
       id,
@@ -107,5 +107,6 @@ export default class WebSocketNetworkClient {
       console.error('Error subscribing: ', response)
       // TODO throw descriptive error
     }
+    return response
   }
 }

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -51,15 +51,12 @@ export default class WebSocketNetworkClient {
     })
   }
 
-  private async sendMessage(message): Promise<void> {
+  private async apiRequest(options): Promise<any> {
     while (this.socket.readyState === 0) {
       await this.sleep(5)
     }
-    this.socket.send(JSON.stringify(message))
-  }
+    this.socket.send(JSON.stringify(options))
 
-  private async apiRequest(options): Promise<any> {
-    await this.sendMessage(options)
     this.waiting[options.id] = undefined
     while (this.waiting[options.id] === undefined) {
       await this.sleep(5)

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -76,7 +76,6 @@ export default class WebSocketNetworkClient {
     if (callback) {
       callback(dataTransaction)
     } else {
-      console.log('bad transaction')
       throw new XrpError(
         XrpErrorType.Unknown,
         'Received a transaction for an account that has not been subscribed to: ' +
@@ -98,7 +97,7 @@ export default class WebSocketNetworkClient {
       await this.sleep(5)
     }
     if (this.socket.readyState !== 1) {
-      throw new XrpError(XrpErrorType.Unknown, 'Socket is closed')
+      throw new XrpError(XrpErrorType.Unknown, 'Socket is closed/closing')
     }
     this.socket.send(JSON.stringify(request))
 

--- a/src/XRP/network-clients/web-socket-network-client.ts
+++ b/src/XRP/network-clients/web-socket-network-client.ts
@@ -95,7 +95,9 @@ export default class WebSocketNetworkClient {
     while (this.socket.readyState === 0) {
       await this.sleep(5)
     }
-    // TODO add readtState === 1 check
+    if (this.socket.readyState !== 1) {
+      throw new XrpError(XrpErrorType.Unknown, 'Socket is closed')
+    }
     this.socket.send(JSON.stringify(request))
 
     this.waiting[request.id] = undefined
@@ -121,7 +123,6 @@ export default class WebSocketNetworkClient {
     id: string,
     callback: (data: WebSocketTransactionResponse) => void,
     account: string,
-    // TODO make multiple streams/callbacks an option??
   ): Promise<WebSocketStatusResponse> {
     const classicAddress = XrpUtils.decodeXAddress(account)
     if (!classicAddress) {

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -11,14 +11,11 @@ interface WebSocketRequestOptions {
   accounts?: unknown[]
 }
 
-type WebSocketResponse =
-  | WebSocketStatusResponse
-  | WebSocketLedgerResponse
-  | WebSocketTransactionResponse
+type WebSocketResponse = WebSocketStatusResponse | WebSocketTransactionResponse
 
 interface WebSocketStatusResponse {
   id?: string
-  result: WebSocketLedgerResponse | WebSocketTransactionResponse | undefined
+  result: WebSocketTransactionResponse | undefined
   status: string
   type: string
 }
@@ -34,19 +31,6 @@ interface WebSocketTransactionResponse {
   transaction: WebSocketTransaction
   type: string
   validated: boolean
-}
-
-interface WebSocketLedgerResponse {
-  fee_base: number
-  fee_ref: number
-  ledger_hash: string
-  ledger_index: number
-  ledger_time: number
-  reserve_base: number
-  reserve_inc: number
-  txn_count: number
-  type: string
-  validated_ledgers: string
 }
 
 interface WebSocketTransaction {

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -26,11 +26,61 @@ interface WebSocketTransactionResponse {
   engine_result_message: string
   ledger_hash: string
   ledger_index: number
-  meta: any // TODO make this better
+  meta: {
+    AffectedNodes: ChangedNode[] // TODO fix this
+    TransactionIndex: number
+    TransactionResult: string
+    delivered_amount?: string
+  }
   status: string
   transaction: WebSocketTransaction
   type: string
   validated: boolean
+}
+
+type ChangedNode = CreatedNode | ModifiedNode | DeletedNode
+
+interface CreatedNode {
+  LedgerEntryType: string
+  LedgerIndex: string
+  NewFields: {
+    Account: string
+    Balance: string
+    Sequence: number
+  }
+}
+
+interface ModifiedNode {
+  FinalFields: {
+    Account: string
+    Balance: string
+    Flags: number
+    OwnerCount: number
+    Sequence: number
+  }
+  LedgerEntryType: string
+  LedgerIndex: string
+  PreviousFields: {
+    Balance: string
+    OwnerCount?: number
+    Sequence?: number
+  }
+  PreviousTxnID: string
+  PreviousTxnLgrSeq: number
+}
+
+interface DeletedNode {
+  FinalFields: {
+    ExchangeRate: string
+    Flags: number
+    RootIndex: string
+    TakerGetsCurrency: string
+    TakerGetsIssuer: string
+    TakerPaysCurrency: string
+    TakerPaysIssuer: string
+  }
+  LedgerEntryType: string
+  LedgerIndex: string
 }
 
 interface WebSocketTransaction {

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -1,5 +1,12 @@
 /* Schema for adding type information to Web Socket objects. */
 
+enum WebSocketReadyState {
+  Connecting,
+  Open,
+  Closing,
+  Closed,
+}
+
 /**
  * The standard format for a request to the Web Socket API exposed by a rippled node.
  * @see https://xrpl.org/request-formatting.html
@@ -19,13 +26,6 @@ interface WebSocketRequestOptions {
  */
 enum RippledMethod {
   subscribe = 'subscribe',
-}
-
-enum WebSocketReadyState {
-  Connecting,
-  Open,
-  Closing,
-  Closed,
 }
 
 type WebSocketResponse =

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -15,7 +15,7 @@ type WebSocketResponse = WebSocketStatusResponse | WebSocketTransactionResponse
 
 interface WebSocketStatusResponse {
   id: string
-  result: WebSocketTransactionResponse | undefined
+  result: WebSocketTransactionResponse | EmptyObject
   status: string
   type: string
 }
@@ -27,7 +27,7 @@ interface WebSocketTransactionResponse {
   ledger_hash: string
   ledger_index: number
   meta: {
-    AffectedNodes: ChangedNode[] // TODO fix this
+    AffectedNodes: ChangedNode[]
     TransactionIndex: number
     TransactionResult: string
     delivered_amount?: string
@@ -96,6 +96,10 @@ interface WebSocketTransaction {
   TxnSignature: string
   date: number
   hash: string
+}
+
+type EmptyObject = {
+  [K in any]: never
 }
 
 export {

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -58,7 +58,7 @@ interface WebSocketTransaction {
   LastLedgerSequence: number
   Sequence: number
   SigningPubKey: string
-  TranasctionType: string
+  TransactionType: string
   TxnSignature: string
   date: number
   hash: string

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -11,13 +11,29 @@ interface WebSocketRequestOptions {
   accounts?: unknown[]
 }
 
-type WebSocketResponse = WebSocketStatusResponse | WebSocketLedgerResponse
+type WebSocketResponse =
+  | WebSocketStatusResponse
+  | WebSocketLedgerResponse
+  | WebSocketTransactionResponse
 
 interface WebSocketStatusResponse {
   id?: string
-  result: WebSocketLedgerResponse | undefined
+  result: WebSocketLedgerResponse | WebSocketTransactionResponse | undefined
   status: string
   type: string
+}
+
+interface WebSocketTransactionResponse {
+  engine_result: string
+  engine_result_code: number
+  engine_result_message: string
+  ledger_hash: string
+  ledger_index: number
+  meta: unknown // TODO make this better
+  status: string
+  transaction: WebSocketTransaction
+  type: string
+  validated: boolean
 }
 
 interface WebSocketLedgerResponse {
@@ -33,4 +49,25 @@ interface WebSocketLedgerResponse {
   validated_ledgers: string
 }
 
-export { WebSocketRequestOptions, WebSocketResponse, WebSocketStatusResponse }
+interface WebSocketTransaction {
+  Account: string
+  Amount: string
+  Destination: string
+  Fee: string
+  Flags: number
+  LastLedgerSequence: number
+  Sequence: number
+  SigningPubKey: string
+  TranasctionType: string
+  TxnSignature: string
+  date: number
+  hash: string
+}
+
+export {
+  WebSocketRequestOptions,
+  WebSocketResponse,
+  WebSocketStatusResponse,
+  WebSocketTransaction,
+  WebSocketTransactionResponse,
+}

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -14,7 +14,7 @@ interface WebSocketRequestOptions {
 type WebSocketResponse = WebSocketStatusResponse | WebSocketTransactionResponse
 
 interface WebSocketStatusResponse {
-  id?: string
+  id: string
   result: WebSocketTransactionResponse | undefined
   status: string
   type: string

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -5,10 +5,10 @@
  * @see https://xrpl.org/request-formatting.html
  */
 interface WebSocketRequestOptions {
-  command: unknown
+  command: string
   id: string
-  streams?: unknown[]
-  accounts?: unknown[]
+  streams?: string[]
+  accounts?: string[]
 }
 
 type WebSocketResponse = WebSocketStatusResponse | WebSocketTransactionResponse

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -30,7 +30,7 @@ interface WebSocketRequestOptions {
 
 type WebSocketResponse =
   | WebSocketStatusResponse
-  | WebSocketTransactionResponse
+  | TransactionResponse
   | WebSocketStatusErrorResponse
 
 /**
@@ -39,7 +39,7 @@ type WebSocketResponse =
  */
 interface WebSocketStatusResponse {
   id: string
-  result: WebSocketTransactionResponse | EmptyObject
+  result: TransactionResponse | EmptyObject
   status: string
   type: string
 }
@@ -62,7 +62,7 @@ interface WebSocketStatusErrorResponse {
  * The standard format for a response from the WebSocket API for a transaction on the ledger.
  * @see https://xrpl.org/subscribe.html#transaction-streams
  */
-interface WebSocketTransactionResponse {
+interface TransactionResponse {
   engine_result: string
   engine_result_code: number
   engine_result_message: string
@@ -169,5 +169,5 @@ export {
   WebSocketStatusResponse,
   WebSocketStatusErrorResponse,
   WebSocketTransaction,
-  WebSocketTransactionResponse,
+  TransactionResponse,
 }

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -29,7 +29,7 @@ interface WebSocketTransactionResponse {
   engine_result_message: string
   ledger_hash: string
   ledger_index: number
-  meta: unknown // TODO make this better
+  meta: any // TODO make this better
   status: string
   transaction: WebSocketTransaction
   type: string

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -1,0 +1,36 @@
+/* Schema for adding type information to Web Socket objects. */
+
+/**
+ * The standard format for a request to the JSON RPC exposed by a rippled node.
+ * @see https://xrpl.org/request-formatting.html
+ */
+interface WebSocketRequestOptions {
+  command: unknown
+  id: string
+  streams?: unknown[]
+  accounts?: unknown[]
+}
+
+type WebSocketResponse = WebSocketStatusResponse | WebSocketLedgerResponse
+
+interface WebSocketStatusResponse {
+  id?: string
+  result: WebSocketLedgerResponse | undefined
+  status: string
+  type: string
+}
+
+interface WebSocketLedgerResponse {
+  fee_base: number
+  fee_ref: number
+  ledger_hash: string
+  ledger_index: number
+  ledger_time: number
+  reserve_base: number
+  reserve_inc: number
+  txn_count: number
+  type: string
+  validated_ledgers: string
+}
+
+export { WebSocketRequestOptions, WebSocketResponse, WebSocketStatusResponse }

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -8,6 +8,16 @@ enum WebSocketReadyState {
 }
 
 /**
+ * The options for rippled methods (the `command` parameter in WebSocketRequestOptions)
+ *
+ * This is currently only the supported operations, but more will be added as they are supported.
+ * @see https://xrpl.org/public-rippled-methods.html
+ */
+enum RippledMethod {
+  subscribe = 'subscribe',
+}
+
+/**
  * The standard format for a request to the Web Socket API exposed by a rippled node.
  * @see https://xrpl.org/request-formatting.html
  */
@@ -16,16 +26,6 @@ interface WebSocketRequestOptions {
   id: string
   streams?: string[]
   accounts?: string[]
-}
-
-/**
- * The options for rippled methods (the `command` parameter in WebSocketRequestOptions)
- *
- * This is currently only the supported operations, but more will be added as they are supported.
- * @see https://xrpl.org/public-rippled-methods.html
- */
-enum RippledMethod {
-  subscribe = 'subscribe',
 }
 
 type WebSocketResponse =
@@ -44,6 +44,10 @@ interface WebSocketStatusResponse {
   type: string
 }
 
+/**
+ * The standard format for an error response from the WebSocket API exposed by a rippled node.
+ * @see https://xrpl.org/response-formatting.html
+ */
 interface WebSocketStatusErrorResponse {
   id: string
   status: string

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -1,0 +1,76 @@
+import Result from '../../Common/Helpers/result'
+import XrpError, { XrpErrorType } from '../../../src/XRP/shared/xrp-error'
+import { AccountLinesResponse } from '../../../src/XRP/shared/rippled-json-rpc-schema'
+import {
+  WebSocketResponse,
+  WebSocketStatusResponse,
+} from '../../../src/XRP/shared/rippled-web-socket-schema'
+
+/**
+ * A list of responses the fake network client will give.
+ */
+export class FakeWebSocketNetworkClientResponses {
+  /**
+   * A default error.
+   */
+  // TODO: what should an error really look like in this context?
+  public static defaultError = new XrpError(XrpErrorType.Unknown, 'Test error')
+
+  /**
+   * A default set of responses that will always succeed.
+   */
+  public static defaultSuccessfulResponses = new FakeWebSocketNetworkClientResponses()
+
+  /**
+   * A default set of responses that will always fail.
+   */
+  public static defaultErrorResponses = new FakeWebSocketNetworkClientResponses(
+    FakeWebSocketNetworkClientResponses.defaultError,
+  )
+
+  /**
+   * Construct a new set of responses.
+   *
+   * @param getSubscribeResponse The response or error that will be returned from the getAccountLines request.
+   *                                Default is the example at https://xrpl.org/account_lines.html#response-format for JSON-RPC.
+   */
+  public constructor(
+    public readonly getSubscribeResponse: Result<
+      WebSocketStatusResponse
+    > = FakeWebSocketNetworkClientResponses.defaultSubscribeResponse(),
+  ) {}
+
+  /**
+   * Construct a default response for getAccountLines request.
+   */
+  public static defaultSubscribeResponse(): WebSocketStatusResponse {
+    return {
+      id: 'subscribe_transaction',
+      result: undefined,
+      status: 'success',
+      type: 'response',
+    }
+  }
+}
+
+/**
+ * A fake network client which stubs network interaction.
+ */
+export class FakeWebSocketNetworkClient {
+  public constructor(
+    private readonly responses: FakeWebSocketNetworkClientResponses = FakeWebSocketNetworkClientResponses.defaultSuccessfulResponses,
+  ) {}
+
+  subscribe(
+    _id: string,
+    _stream: string,
+    _callback: (data: WebSocketResponse) => void,
+  ): Promise<WebSocketStatusResponse> {
+    const subscribeResponse = this.responses.getSubscribeResponse
+    if (subscribeResponse instanceof Error) {
+      return Promise.reject(subscribeResponse)
+    }
+
+    return Promise.resolve(subscribeResponse)
+  }
+}

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -1,6 +1,5 @@
 import Result from '../../Common/Helpers/result'
 import XrpError, { XrpErrorType } from '../../../src/XRP/shared/xrp-error'
-import { AccountLinesResponse } from '../../../src/XRP/shared/rippled-json-rpc-schema'
 import {
   WebSocketResponse,
   WebSocketStatusResponse,

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -60,10 +60,10 @@ export class FakeWebSocketNetworkClient {
     private readonly responses: FakeWebSocketNetworkClientResponses = FakeWebSocketNetworkClientResponses.defaultSuccessfulResponses,
   ) {}
 
-  subscribe(
+  subscribeToAccount(
     _id: string,
-    _stream: string,
     _callback: (data: WebSocketResponse) => void,
+    _account: string,
   ): Promise<WebSocketStatusResponse> {
     const subscribeResponse = this.responses.getSubscribeResponse
     if (subscribeResponse instanceof Error) {
@@ -71,5 +71,9 @@ export class FakeWebSocketNetworkClient {
     }
 
     return Promise.resolve(subscribeResponse)
+  }
+
+  close(): void {
+    return
   }
 }

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -1,8 +1,8 @@
 import Result from '../../Common/Helpers/result'
 import XrpError, { XrpErrorType } from '../../../src/XRP/shared/xrp-error'
 import {
-  WebSocketResponse,
   WebSocketStatusResponse,
+  WebSocketTransactionResponse,
 } from '../../../src/XRP/shared/rippled-web-socket-schema'
 
 /**
@@ -62,7 +62,7 @@ export class FakeWebSocketNetworkClient {
 
   subscribeToAccount(
     _id: string,
-    _callback: (data: WebSocketResponse) => void,
+    _callback: (data: WebSocketTransactionResponse) => void,
     _account: string,
   ): Promise<WebSocketStatusResponse> {
     const subscribeResponse = this.responses.getSubscribeResponse

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -30,8 +30,7 @@ export class FakeWebSocketNetworkClientResponses {
   /**
    * Construct a new set of responses.
    *
-   * @param getSubscribeResponse The response or error that will be returned from the getAccountLines request.
-   *                                Default is the example at https://xrpl.org/account_lines.html#response-format for JSON-RPC.
+   * @param getSubscribeResponse The response or error that will be returned from the subscribe request.
    */
   public constructor(
     public readonly getSubscribeResponse: Result<
@@ -44,8 +43,9 @@ export class FakeWebSocketNetworkClientResponses {
    */
   public static defaultSubscribeResponse(): WebSocketStatusResponse {
     return {
-      id: 'subscribe_transaction',
-      result: undefined,
+      id:
+        'subscribe_transaction_X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH',
+      result: {},
       status: 'success',
       type: 'response',
     }

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -2,7 +2,7 @@ import Result from '../../Common/Helpers/result'
 import XrpError, { XrpErrorType } from '../../../src/XRP/shared/xrp-error'
 import {
   WebSocketStatusResponse,
-  WebSocketTransactionResponse,
+  TransactionResponse,
 } from '../../../src/XRP/shared/rippled-web-socket-schema'
 
 /**
@@ -63,7 +63,7 @@ export class FakeWebSocketNetworkClient {
   subscribeToAccount(
     _account: string,
     _id: string,
-    _callback: (data: WebSocketTransactionResponse) => void,
+    _callback: (data: TransactionResponse) => void,
   ): Promise<WebSocketStatusResponse> {
     const subscribeResponse = this.responses.getSubscribeResponse
     if (subscribeResponse instanceof Error) {

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -39,12 +39,12 @@ export class FakeWebSocketNetworkClientResponses {
   ) {}
 
   /**
-   * Construct a default response for getAccountLines request.
+   * Construct a default response for a subscribe request.
    */
   public static defaultSubscribeResponse(): WebSocketStatusResponse {
     return {
       id:
-        'subscribe_transaction_X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH',
+        'monitor_transactions_X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH',
       result: {},
       status: 'success',
       type: 'response',

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -588,7 +588,6 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     const address = classicAddress!.address
 
     const xrpAmount = '100'
-    const subscriptionId = 'monitor_transactions_' + xAddress
 
     let messageReceived = false
     const callback = (data: TransactionResponse) => {
@@ -624,9 +623,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     )
 
     // THEN the subscribe request is successfully submitted and received
-    assert.equal(response.status, 'success')
-    assert.equal(response.type, 'response')
-    assert.equal(response.id, subscriptionId)
+    assert.isTrue(response)
 
     // WHEN a payment is sent to that address
     await xrpClient.send(xrpAmount, xAddress, wallet2)

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -543,7 +543,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
 
     // GIVEN a valid test address
     // WHEN subscribeToAccount is called for that address
-    const response = await issuedCurrencyClient.monitorIncomingPayments(
+    const response = await issuedCurrencyClient.monitorAccountTransactions(
       xAddress,
       callback,
     )
@@ -570,7 +570,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     // GIVEN a test address that is malformed.
     // WHEN monitorIncomingPayments is called for that address THEN an error is thrown.
     try {
-      await issuedCurrencyClient.monitorIncomingPayments(
+      await issuedCurrencyClient.monitorAccountTransactions(
         address,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         (_data: WebSocketTransactionResponse) => {},

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -484,9 +484,14 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     assert.equal(response.type, 'response')
     assert.equal(response.id, 'monitor_transactions_' + xAddress)
 
+    await sleep(10)
+
+    // WHEN a payment is sent to that address
     await xrpClient.send(xrpAmount, xAddress, wallet2)
 
     await waitUntilMessageReceived()
+
+    //THEN the payment is successfully received
     assert(messageReceived)
   })
 

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -440,6 +440,8 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     this.timeout(timeoutMs)
 
     const xAddress = wallet.getAddress()
+    const classicAddress = XrpUtils.decodeXAddress(xAddress)
+    const address = classicAddress!.address
 
     const xrpAmount = '100'
 
@@ -457,7 +459,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
       assert.equal(data.type, 'transaction')
       assert.equal(data.validated, true)
       assert.equal(data.transaction.Amount, xrpAmount)
-      assert.equal(data.transaction.Destination, xAddress)
+      assert.equal(data.transaction.Destination, address)
       assert.equal(data.transaction.TransactionType, 'Payment')
     }
 

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -483,4 +483,22 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     await waitUntilMessageReceived()
     assert(messageReceived)
   })
+
+  it('monitorIncomingPayments - bad address', async function (): Promise<void> {
+    this.timeout(timeoutMs)
+
+    const xAddress = 'badAddress'
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const callback = (_data: WebSocketTransactionResponse) => {}
+    // GIVEN a test address that has at least one trust line on testnet
+    // WHEN monitorIncomingPayments is called for that address THEN an error is thrown.
+    try {
+      await issuedCurrencyClient.monitorIncomingPayments(xAddress, callback)
+    } catch (e) {
+      if (!(e instanceof XrpError)) {
+        assert.fail('wrong error')
+      }
+    }
+  })
 })

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -484,8 +484,6 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     assert.equal(response.type, 'response')
     assert.equal(response.id, 'monitor_transactions_' + xAddress)
 
-    await sleep(10)
-
     // WHEN a payment is sent to that address
     await xrpClient.send(xrpAmount, xAddress, wallet2)
 

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -48,9 +48,8 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     wallet2 = await XRPTestUtils.randomWalletFromFaucet()
   })
 
-  after(function (done) {
+  after(function () {
     issuedCurrencyClient.webSocketNetworkClient.close()
-    done()
   })
 
   it('getTrustLines - valid request', async function (): Promise<void> {
@@ -459,7 +458,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
       assert.equal(data.transaction.Destination, xAddress)
       assert.equal(data.transaction.TransactionType, 'Payment')
     }
-    // GIVEN a test address that has at least one trust line on testnet
+    // GIVEN a valid test address
     // WHEN monitorIncomingPayments is called for that address
     const response = await issuedCurrencyClient.monitorIncomingPayments(
       xAddress,

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -9,7 +9,7 @@ import {
   TransactionStatus,
   XrpErrorType,
 } from '../../src/XRP/shared'
-import { WebSocketTransactionResponse } from '../../src/XRP/shared/rippled-web-socket-schema'
+import { TransactionResponse } from '../../src/XRP/shared/rippled-web-socket-schema'
 import XrpClient from '../../src/XRP/xrp-client'
 
 // A timeout for these tests.
@@ -550,7 +550,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     const subscriptionId = 'monitor_transactions_' + xAddress
 
     let messageReceived = false
-    const callback = (data: WebSocketTransactionResponse) => {
+    const callback = (data: TransactionResponse) => {
       messageReceived = true
       assert.equal(data.engine_result, 'tesSUCCESS')
       assert.equal(data.engine_result_code, 0)
@@ -607,7 +607,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
       await issuedCurrencyClient.monitorAccountTransactions(
         address,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        (_data: WebSocketTransactionResponse) => {},
+        (_data: TransactionResponse) => {},
       )
     } catch (e) {
       if (!(e instanceof XrpError)) {

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -513,7 +513,7 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     const address = classicAddress!.address
 
     const xrpAmount = '100'
-    const subscriptionId = 'subscribe_transaction_' + address
+    const subscriptionId = 'monitor_transactions_' + xAddress
 
     let messageReceived = false
     const callback = (data: WebSocketTransactionResponse) => {

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -17,9 +17,11 @@ const testAddressWithTrustLines =
 // An IssuedCurrencyClient that makes requests.
 const rippledGrpcUrl = 'test.xrp.xpring.io:50051'
 const rippledJsonUrl = 'http://test.xrp.xpring.io:51234'
+const rippledWebSocketUrl = 'wss://test.xrp.xpring.io'
 const issuedCurrencyClient = IssuedCurrencyClient.issuedCurrencyClientWithEndpoint(
   rippledGrpcUrl,
   rippledJsonUrl,
+  rippledWebSocketUrl,
   XrplNetwork.Test,
 )
 

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -439,9 +439,6 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     this.timeout(timeoutMs)
 
     const xAddress = wallet.getAddress()
-    const classicAddress = XrpUtils.decodeXAddress(xAddress)
-    assert(classicAddress)
-    const address = classicAddress!.address
 
     const xrpAmount = '100'
 
@@ -459,20 +456,20 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
       assert.equal(data.type, 'transaction')
       assert.equal(data.validated, true)
       assert.equal(data.transaction.Amount, xrpAmount)
-      assert.equal(data.transaction.Destination, address)
+      assert.equal(data.transaction.Destination, xAddress)
       assert.equal(data.transaction.TransactionType, 'Payment')
     }
     // GIVEN a test address that has at least one trust line on testnet
     // WHEN monitorIncomingPayments is called for that address
     const response = await issuedCurrencyClient.monitorIncomingPayments(
-      address,
+      xAddress,
       callback,
     )
 
     // THEN the subscribe request is successfully submitted and received
     assert.equal(response.status, 'success')
     assert.equal(response.type, 'response')
-    assert.equal(response.id, 'monitor_transactions_' + address)
+    assert.equal(response.id, 'monitor_transactions_' + xAddress)
 
     const waitUntilMessageReceived = async () => {
       while (!messageReceived) {

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -16,7 +16,6 @@ import XrpClient from '../../src/XRP/xrp-client'
 // A timeout for these tests.
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- 1 minute in milliseconds
 const timeoutMs = 60 * 1000
-// const shortTimeoutMs = 10 * 1000
 
 // An address on TestNet that has a balance.
 const testAddressWithTrustLines =

--- a/test/XRP/issued-currency-client-integration.test.ts
+++ b/test/XRP/issued-currency-client-integration.test.ts
@@ -30,6 +30,7 @@ const issuedCurrencyClient = IssuedCurrencyClient.issuedCurrencyClientWithEndpoi
   rippledGrpcUrl,
   rippledJsonUrl,
   rippledWebSocketUrl,
+  console.log,
   XrplNetwork.Test,
 )
 
@@ -482,7 +483,6 @@ describe('IssuedCurrencyClient Integration Tests', function (): void {
     assert.equal(response.status, 'success')
     assert.equal(response.type, 'response')
     assert.equal(response.id, 'monitor_transactions_' + xAddress)
-
 
     await xrpClient.send(xrpAmount, xAddress, wallet2)
 

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -402,7 +402,6 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
-
       fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
@@ -946,13 +945,13 @@ describe('Issued Currency Client', function (): void {
       return
     }
 
-    const failingNetworkClient = new FakeWebSocketNetworkClient(
+    const failingWebSocketClient = new FakeWebSocketNetworkClient(
       failureResponses,
     )
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
-      failingNetworkClient,
+      failingWebSocketClient,
       XrplNetwork.Test,
     )
 

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -634,11 +634,12 @@ describe('Issued Currency Client', function (): void {
       callback,
     )
     const expectedSubscribeResponse = {
-      id: 'subscribe_transaction_' + testAddress,
+      id: 'subscribe_transaction',
       result: undefined,
       status: 'success',
       type: 'response',
     }
+    // TODO get the fake websocket client to handle the address too
 
     // THEN the result is as expected
     assert.deepEqual(subscribeResponse, expectedSubscribeResponse)

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -632,19 +632,19 @@ describe('Issued Currency Client', function (): void {
     }
 
     // WHEN monitorIncomingPayments is called
-    const subscribeResponse = await issuedCurrencyClient.monitorIncomingPayments(
+    const monitorResponse = await issuedCurrencyClient.monitorIncomingPayments(
       testAddress,
       callback,
     )
-    const expectedSubscribeResponse = {
-      id: 'subscribe_transaction_' + testAddress,
+    const expectedMonitorResponse = {
+      id: 'monitor_transactions_' + testAddress,
       result: {},
       status: 'success',
       type: 'response',
     }
 
     // THEN the result is as expected
-    assert.deepEqual(subscribeResponse, expectedSubscribeResponse)
+    assert.deepEqual(monitorResponse, expectedMonitorResponse)
   })
 
   it('monitorIncomingPayments - submission failure', function (): void {

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -14,10 +14,13 @@ import 'mocha'
 import TrustLine from '../../src/XRP/shared/trustline'
 import { XrpError } from '../../src/XRP'
 import { AccountLinesResponse } from '../../src/XRP/shared/rippled-json-rpc-schema'
+import { FakeWebSocketNetworkClient } from './fakes/fake-web-socket-network-client'
 
 const fakeSucceedingGrpcClient = new FakeXRPNetworkClient()
 
 const fakeSucceedingJsonClient = new FakeJsonNetworkClient()
+
+const fakeSucceedingWebSocketClient = new FakeWebSocketNetworkClient()
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -33,6 +36,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -59,6 +63,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -88,6 +93,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeErroringJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
     // WHEN getTrustLines is called THEN an error is propagated.
@@ -105,6 +111,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -134,6 +141,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -152,6 +160,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -181,6 +190,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -197,6 +207,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -224,6 +235,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -240,6 +252,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -267,6 +280,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -283,6 +297,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -310,6 +325,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -326,6 +342,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -355,6 +372,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -371,6 +389,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -398,6 +417,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -412,6 +432,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -444,6 +465,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -464,6 +486,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -491,6 +514,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -507,6 +531,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -534,6 +559,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -548,6 +574,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -575,6 +602,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       failingNetworkClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -920,7 +920,7 @@ describe('Issued Currency Client', function (): void {
     }
 
     // WHEN monitorIncomingPayments is called
-    const monitorResponse = await issuedCurrencyClient.monitorIncomingPayments(
+    const monitorResponse = await issuedCurrencyClient.monitorAccountTransactions(
       testAddress,
       callback,
     )
@@ -957,7 +957,7 @@ describe('Issued Currency Client', function (): void {
 
     // WHEN monitorIncomingPayments is attempted THEN an error is propagated.
     issuedCurrencyClient
-      .monitorIncomingPayments(testAddress, callback)
+      .monitorAccountTransactions(testAddress, callback)
       .catch((error) => {
         assert.deepEqual(
           error,

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -924,15 +924,9 @@ describe('Issued Currency Client', function (): void {
       testAddress,
       callback,
     )
-    const expectedMonitorResponse = {
-      id: 'monitor_transactions_' + testAddress,
-      result: {},
-      status: 'success',
-      type: 'response',
-    }
 
     // THEN the result is as expected
-    assert.deepEqual(monitorResponse, expectedMonitorResponse)
+    assert.isTrue(monitorResponse)
   })
 
   it('monitorIncomingPayments - submission failure', function (): void {

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -86,6 +86,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
 
@@ -148,6 +149,7 @@ describe('Issued Currency Client', function (): void {
     const issuedCurrencyClient = new IssuedCurrencyClient(
       fakeSucceedingGrpcClient,
       fakeErroringJsonClient,
+      fakeSucceedingWebSocketClient,
       XrplNetwork.Test,
     )
     // WHEN getTrustLines is called THEN an error is thrown.

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -15,6 +15,7 @@ import TrustLine from '../../src/XRP/shared/trustline'
 import { XrpError } from '../../src/XRP'
 import { AccountLinesResponse } from '../../src/XRP/shared/rippled-json-rpc-schema'
 import { FakeWebSocketNetworkClient } from './fakes/fake-web-socket-network-client'
+import { WebSocketResponse } from '../../src/XRP/shared/rippled-web-socket-schema'
 
 const fakeSucceedingGrpcClient = new FakeXRPNetworkClient()
 
@@ -610,5 +611,36 @@ describe('Issued Currency Client', function (): void {
     issuedCurrencyClient.enableNoFreeze(this.wallet).catch((error) => {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
     })
+  })
+
+  it('monitorIncomingPayments - successful response', async function (): Promise<
+    void
+  > {
+    // GIVEN an IssuedCurrencyClient.
+    const issuedCurrencyClient = new IssuedCurrencyClient(
+      fakeSucceedingGrpcClient,
+      fakeSucceedingJsonClient,
+      fakeSucceedingWebSocketClient,
+      XrplNetwork.Test,
+    )
+
+    const callback = (_data: WebSocketResponse) => {
+      return
+    }
+
+    // WHEN monitorIncomingPayments is called
+    const subscribeResponse = await issuedCurrencyClient.monitorIncomingPayments(
+      testAddress,
+      callback,
+    )
+    const expectedSubscribeResponse = {
+      id: 'subscribe_transaction_' + testAddress,
+      result: undefined,
+      status: 'success',
+      type: 'response',
+    }
+
+    // THEN the result is as expected
+    assert.deepEqual(subscribeResponse, expectedSubscribeResponse)
   })
 })

--- a/test/XRP/issued-currency-payment-integration.test.ts
+++ b/test/XRP/issued-currency-payment-integration.test.ts
@@ -12,9 +12,12 @@ const timeoutMs = 60 * 1000
 // An IssuedCurrencyClient that makes requests.
 const rippledGrpcUrl = 'test.xrp.xpring.io:50051'
 const rippledJsonUrl = 'http://test.xrp.xpring.io:51234'
+const rippledWebSocketUrl = 'wss://wss.test.xrp.xpring.io'
 const issuedCurrencyClient = IssuedCurrencyClient.issuedCurrencyClientWithEndpoint(
   rippledGrpcUrl,
   rippledJsonUrl,
+  rippledWebSocketUrl,
+  console.log,
   XrplNetwork.Test,
 )
 

--- a/test/XRP/issued-currency-payment-integration.test.ts
+++ b/test/XRP/issued-currency-payment-integration.test.ts
@@ -28,6 +28,11 @@ describe('Issued Currency Payment Integration Tests', function (): void {
   // Retry integration tests on failure.
   this.retries(3)
 
+  after(function (done) {
+    issuedCurrencyClient.webSocketNetworkClient.close()
+    done()
+  })
+
   it('issuedCurrencyPayment - issuing issued currency, combined cases', async function (): Promise<
     void
   > {

--- a/test/XRP/web-socket-network-client.test.ts
+++ b/test/XRP/web-socket-network-client.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai'
 import { Wallet, XrplNetwork, XrpUtils } from 'xpring-common-js'
 import WebSocketNetworkClient from '../../src/XRP/network-clients/web-socket-network-client'
-import { WebSocketTransactionResponse } from '../../src/XRP/shared/rippled-web-socket-schema'
+import { TransactionResponse } from '../../src/XRP/shared/rippled-web-socket-schema'
 import XrpError from '../../src/XRP/shared/xrp-error'
 import XrpClient from '../../src/XRP/xrp-client'
 
@@ -51,7 +51,7 @@ describe('WebSocket Tests', function (): void {
     const subscriptionId = 'subscribe_transaction_' + address
 
     let messageReceived = false
-    const callback = (data: WebSocketTransactionResponse) => {
+    const callback = (data: TransactionResponse) => {
       messageReceived = true
       assert.equal(data.engine_result, 'tesSUCCESS')
       assert.equal(data.engine_result_code, 0)
@@ -110,7 +110,7 @@ describe('WebSocket Tests', function (): void {
         address,
         'subscribe_transaction_' + address,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        (_data: WebSocketTransactionResponse) => {},
+        (_data: TransactionResponse) => {},
       )
     } catch (e) {
       if (!(e instanceof XrpError)) {


### PR DESCRIPTION
## High Level Overview of Change

Gateways need a subscription method on the SDK, to be alerted when transactions occur that trigger off-ledger actions. This is very possible with the new IOU support that is currently being implemented in the SDK (for example, when IOUs are redeemed and gateways need to repay people off-ledger). This PR adds that subscription method for accounts. 

### Context of Change

A consequence of the IOU effort

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

IssuedCurrencyClient has a new method for subscribing to incoming payments for an account. 

## Test Plan

CI passes.

## Future Tasks
* More robust testing, to cover various use cases (such as sending issued currency payments). 
* Add an unsubscribe method.
