### PR TITLE
Refactors `IssuedCurrencyClient` methods to use the `IssuedCurrency` interface

### DIFF
--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -436,7 +436,7 @@ export default class IssuedCurrencyClient {
       wallet,
     )
 
-    return await this.coreXrplClient.getFinalTransactionResultAsync(
+    return this.coreXrplClient.getFinalTransactionResultAsync(
       transactionHash,
       wallet,
     )
@@ -512,7 +512,7 @@ export default class IssuedCurrencyClient {
     qualityIn?: number,
     qualityOut?: number,
   ): Promise<TransactionResult> {
-    return await this.sendTrustSetTransaction(
+    return this.sendTrustSetTransaction(
       issuerXAddress,
       currencyName,
       amount,
@@ -543,7 +543,7 @@ export default class IssuedCurrencyClient {
   ): Promise<TransactionResult> {
     // When authorizing a trust line, the value of the trust line is set to 0.
     // See https://xrpl.org/authorized-trust-lines.html#authorizing-trust-lines
-    return await this.sendTrustSetTransaction(
+    return this.sendTrustSetTransaction(
       accountToAuthorize,
       currencyName,
       '0',
@@ -567,7 +567,7 @@ export default class IssuedCurrencyClient {
     currencyName: string,
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return await this.sendTrustSetTransaction(
+    return this.sendTrustSetTransaction(
       trustLinePeerAccount,
       currencyName,
       // You can change the trust line when you freeze it, but an amount of 0
@@ -593,7 +593,7 @@ export default class IssuedCurrencyClient {
     currencyName: string,
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return await this.sendTrustSetTransaction(
+    return this.sendTrustSetTransaction(
       trustLinePeerAccount,
       currencyName,
       // You can change the trust line amount when you unfreeze it, but this would typically
@@ -620,7 +620,7 @@ export default class IssuedCurrencyClient {
     amount: string,
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return await this.sendTrustSetTransaction(
+    return this.sendTrustSetTransaction(
       trustLinePeerAccount,
       currencyName,
       amount,
@@ -645,7 +645,7 @@ export default class IssuedCurrencyClient {
     amount: string,
     wallet: Wallet,
   ): Promise<TransactionResult> {
-    return await this.sendTrustSetTransaction(
+    return this.sendTrustSetTransaction(
       trustLinePeerAccount,
       currencyName,
       amount,
@@ -690,7 +690,7 @@ export default class IssuedCurrencyClient {
       wallet,
     )
 
-    return await this.coreXrplClient.getFinalTransactionResultAsync(
+    return this.coreXrplClient.getFinalTransactionResultAsync(
       transactionHash,
       wallet,
     )
@@ -798,7 +798,7 @@ export default class IssuedCurrencyClient {
       issuer,
       value: amount,
     }
-    return await this.issuedCurrencyPayment(sender, destination, issuedCurrency)
+    return this.issuedCurrencyPayment(sender, destination, issuedCurrency)
   }
 
   /**
@@ -823,7 +823,7 @@ export default class IssuedCurrencyClient {
       issuer: sender.getAddress(),
       value: issuedCurrency.value,
     }
-    return await this.issuedCurrencyPayment(
+    return this.issuedCurrencyPayment(
       sender,
       issuedCurrency.issuer,
       specialIssuedCurrency,
@@ -863,7 +863,7 @@ export default class IssuedCurrencyClient {
       )
     }
 
-    return await this.issuedCurrencyPayment(
+    return this.issuedCurrencyPayment(
       sender,
       destination,
       issuedCurrency,

--- a/src/XRP/issued-currency-client.ts
+++ b/src/XRP/issued-currency-client.ts
@@ -819,9 +819,8 @@ export default class IssuedCurrencyClient {
     // set to the address of the account initiating the redemption.
     // See: https://xrpl.org/payment.html#special-issuer-values-for-sendmax-and-amount
     const specialIssuedCurrency: IssuedCurrency = {
-      currency: issuedCurrency.currency,
+      ...issuedCurrency,
       issuer: sender.getAddress(),
-      value: issuedCurrency.value,
     }
     return this.issuedCurrencyPayment(
       sender,

--- a/src/XRP/shared/issued-currency.ts
+++ b/src/XRP/shared/issued-currency.ts
@@ -1,6 +1,10 @@
 /**
  * Represents an issued currency on the XRP Ledger.
  * @see https://xrpl.org/currency-formats.html#issued-currency-amounts
+ *
+ * @property currency - Arbitrary three-letter code for currency to issue. Cannot be XRP.
+ * @property issuer - The unique XRPL account address of the entity issuing the currency.
+ * @property value - Quoted decimal representation of the amount of currency.
  */
 export default interface IssuedCurrency {
   currency: string

--- a/src/XRP/shared/rippled-web-socket-schema.ts
+++ b/src/XRP/shared/rippled-web-socket-schema.ts
@@ -296,9 +296,9 @@ interface DeletedNode {
     ExchangeRate: string
     Flags: number
     RootIndex: string
-    TakerGetsCurrency: string
+    TakerGetsCurrency: string | IssuedCurrency
     TakerGetsIssuer: string
-    TakerPaysCurrency: string
+    TakerPaysCurrency: string | IssuedCurrency
     TakerPaysIssuer: string
   }
   LedgerEntryType: string

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -36,18 +36,10 @@ export class FakeWebSocketNetworkClientResponses {
    * @param subscribeResponse The response or error that will be returned from the subscribe request.
    */
   public constructor(
-    public readonly subscribeResponse: Result<
-      StatusResponse
-    > = FakeWebSocketNetworkClientResponses.defaultSubscribeResponse(),
-    public readonly unsubscribeResponse: Result<
-      StatusResponse
-    > = FakeWebSocketNetworkClientResponses.defaultUnsubscribeResponse(),
-    public readonly getAccountLinesResponse: Result<
-      AccountLinesResponse
-    > = FakeWebSocketNetworkClientResponses.defaultGetAccountLinesResponse(),
-    public readonly getGatewayBalancesResponse: Result<
-      GatewayBalancesResponse
-    > = FakeWebSocketNetworkClientResponses.defaultGetGatewayBalancesResponse(),
+    public readonly subscribeResponse: Result<StatusResponse> = FakeWebSocketNetworkClientResponses.defaultSubscribeResponse(),
+    public readonly unsubscribeResponse: Result<StatusResponse> = FakeWebSocketNetworkClientResponses.defaultUnsubscribeResponse(),
+    public readonly getAccountLinesResponse: Result<AccountLinesResponse> = FakeWebSocketNetworkClientResponses.defaultGetAccountLinesResponse(),
+    public readonly getGatewayBalancesResponse: Result<GatewayBalancesResponse> = FakeWebSocketNetworkClientResponses.defaultGetGatewayBalancesResponse(),
   ) {}
 
   /**

--- a/test/XRP/fakes/fake-web-socket-network-client.ts
+++ b/test/XRP/fakes/fake-web-socket-network-client.ts
@@ -36,10 +36,18 @@ export class FakeWebSocketNetworkClientResponses {
    * @param subscribeResponse The response or error that will be returned from the subscribe request.
    */
   public constructor(
-    public readonly subscribeResponse: Result<StatusResponse> = FakeWebSocketNetworkClientResponses.defaultSubscribeResponse(),
-    public readonly unsubscribeResponse: Result<StatusResponse> = FakeWebSocketNetworkClientResponses.defaultUnsubscribeResponse(),
-    public readonly getAccountLinesResponse: Result<AccountLinesResponse> = FakeWebSocketNetworkClientResponses.defaultGetAccountLinesResponse(),
-    public readonly getGatewayBalancesResponse: Result<GatewayBalancesResponse> = FakeWebSocketNetworkClientResponses.defaultGetGatewayBalancesResponse(),
+    public readonly subscribeResponse: Result<
+      StatusResponse
+    > = FakeWebSocketNetworkClientResponses.defaultSubscribeResponse(),
+    public readonly unsubscribeResponse: Result<
+      StatusResponse
+    > = FakeWebSocketNetworkClientResponses.defaultUnsubscribeResponse(),
+    public readonly getAccountLinesResponse: Result<
+      AccountLinesResponse
+    > = FakeWebSocketNetworkClientResponses.defaultGetAccountLinesResponse(),
+    public readonly getGatewayBalancesResponse: Result<
+      GatewayBalancesResponse
+    > = FakeWebSocketNetworkClientResponses.defaultGetGatewayBalancesResponse(),
   ) {}
 
   /**

--- a/test/XRP/issued-currency-client.test.ts
+++ b/test/XRP/issued-currency-client.test.ts
@@ -836,13 +836,17 @@ describe('Issued Currency Client', function (): void {
       XrplNetwork.Test,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'FOO',
+      issuer: testAddress,
+      value: '100',
+    }
+
     // WHEN issuedCurrencyPayment is called
     const transactionResult = await issuedCurrencyClient.issuedCurrencyPayment(
       this.wallet,
       testAddress,
-      'FOO',
-      testAddress,
-      '100',
+      issuedCurrency,
       0.5,
     )
 
@@ -869,14 +873,18 @@ describe('Issued Currency Client', function (): void {
       XrplNetwork.Test,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'FOO',
+      issuer: testAddress,
+      value: '100',
+    }
+
     // WHEN issuedCurrencyPayment is called THEN an error is propagated.
     try {
       await issuedCurrencyClient.issuedCurrencyPayment(
         this.wallet,
         testAddress,
-        'FOO',
-        testAddress,
-        '100',
+        issuedCurrency,
         0.5,
       )
     } catch (error) {
@@ -892,14 +900,18 @@ describe('Issued Currency Client', function (): void {
       XrplNetwork.Test,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'FOO',
+      issuer: testAddress,
+      value: '100',
+    }
+
     // WHEN issuedCurrencyPayment is called with a classic address argument for destination THEN an error is thrown.
     try {
       await issuedCurrencyClient.issuedCurrencyPayment(
         this.wallet,
         testClassicAddress,
-        'FOO',
-        testAddress,
-        '100',
+        issuedCurrency,
         0.5,
       )
     } catch (error) {
@@ -915,14 +927,18 @@ describe('Issued Currency Client', function (): void {
       XrplNetwork.Test,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'FOO',
+      issuer: testClassicAddress,
+      value: '100',
+    }
+
     // WHEN issuedCurrencyPayment is called with a classic address argument for issuer THEN an error is thrown.
     try {
       await issuedCurrencyClient.issuedCurrencyPayment(
         this.wallet,
         testAddress,
-        'FOO',
-        testClassicAddress,
-        '100',
+        issuedCurrency,
         0.5,
       )
     } catch (error) {
@@ -938,14 +954,18 @@ describe('Issued Currency Client', function (): void {
       XrplNetwork.Test,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'FOO',
+      issuer: this.wallet.getAddress(),
+      value: '100',
+    }
+
     // WHEN sendIssuedCurrencyPayment is called with matching sender and issuer addresses, THEN an error is thrown.
     try {
       await issuedCurrencyClient.sendIssuedCurrencyPayment(
         this.wallet,
         testAddress,
-        'FOO',
-        this.wallet.getAddress(),
-        '100',
+        issuedCurrency,
         0.5,
       )
     } catch (error) {
@@ -961,14 +981,18 @@ describe('Issued Currency Client', function (): void {
       XrplNetwork.Test,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'FOO',
+      issuer: testAddress,
+      value: '100',
+    }
+
     // WHEN sendIssuedCurrencyPayment is called with matching sender and issuer addresses, THEN an error is thrown.
     try {
       await issuedCurrencyClient.sendIssuedCurrencyPayment(
         this.wallet,
         testAddress,
-        'FOO',
-        testAddress,
-        '100',
+        issuedCurrency,
         0.5,
       )
     } catch (error) {

--- a/test/XRP/issued-currency-payment-integration.test.ts
+++ b/test/XRP/issued-currency-payment-integration.test.ts
@@ -4,6 +4,7 @@ import IssuedCurrencyClient from '../../src/XRP/issued-currency-client'
 
 import XRPTestUtils from './helpers/xrp-test-utils'
 import { TransactionResult, TransactionStatus } from '../../src/XRP/shared'
+import IssuedCurrency from '../../src/XRP/shared/issued-currency'
 
 // A timeout for these tests.
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- 1 minute in milliseconds
@@ -137,13 +138,17 @@ describe('Issued Currency Payment Integration Tests', function (): void {
       customerWallet,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      issuer: issuerWallet.getAddress(),
+      value: '100',
+      currency: 'FOO',
+    }
+
     // WHEN an issued currency payment is made to another funded account
     const transactionResult = await issuedCurrencyClient.sendIssuedCurrencyPayment(
       operationalWallet,
       customerWallet.getAddress(),
-      'FOO',
-      issuerWallet.getAddress(),
-      '100',
+      issuedCurrency,
     )
 
     // THEN the payment fails with CalimedCostOnly_PathDry
@@ -193,13 +198,17 @@ describe('Issued Currency Payment Integration Tests', function (): void {
       customerWallet,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'FOO',
+      issuer: issuerWallet.getAddress(),
+      value: '100',
+    }
+
     // WHEN an issued currency payment is made to another funded account
     const transactionResult = await issuedCurrencyClient.sendIssuedCurrencyPayment(
       operationalWallet,
       customerWallet.getAddress(),
-      'FOO',
-      issuerWallet.getAddress(),
-      '100',
+      issuedCurrency,
     )
 
     // THEN the transaction succeeds.
@@ -248,13 +257,17 @@ describe('Issued Currency Payment Integration Tests', function (): void {
       customerWallet,
     )
 
+    const issuedCurrency: IssuedCurrency = {
+      currency: 'BAR',
+      issuer: issuerWallet.getAddress(),
+      value: '100',
+    }
+
     // WHEN an issued currency payment of BAR is made to another funded account
     const transactionResult = await issuedCurrencyClient.sendIssuedCurrencyPayment(
       operationalWallet,
       customerWallet.getAddress(),
-      'BAR',
-      issuerWallet.getAddress(),
-      '100',
+      issuedCurrency,
     )
 
     // THEN the transaction fails with ClaimedCostOnly_PathDry
@@ -304,13 +317,17 @@ describe('Issued Currency Payment Integration Tests', function (): void {
       customerWallet,
     )
 
+    const issuedCurrency = {
+      currency: 'FOO',
+      issuer: issuerWallet.getAddress(),
+      value: '100',
+    }
+
     // WHEN an issued currency payment is made to another funded account, without the transferFee argument supplied
     let transactionResult = await issuedCurrencyClient.sendIssuedCurrencyPayment(
       operationalWallet,
       customerWallet.getAddress(),
-      'FOO',
-      issuerWallet.getAddress(),
-      '100',
+      issuedCurrency,
     )
 
     // THEN the transaction fails with ClaimedCostOnly_PathPartial.
@@ -327,9 +344,7 @@ describe('Issued Currency Payment Integration Tests', function (): void {
     transactionResult = await issuedCurrencyClient.sendIssuedCurrencyPayment(
       operationalWallet,
       customerWallet.getAddress(),
-      'FOO',
-      issuerWallet.getAddress(),
-      '100',
+      issuedCurrency,
       0.5,
     )
 
@@ -368,12 +383,16 @@ describe('Issued Currency Payment Integration Tests', function (): void {
       '500',
     )
 
+    const issuedCurrency = {
+      currency: 'FOO',
+      issuer: issuerWallet.getAddress(),
+      value: '100',
+    }
+
     // WHEN an issued currency payment is made back to the issuer
     const transactionResult = await issuedCurrencyClient.redeemIssuedCurrency(
       customerWallet,
-      'FOO',
-      issuerWallet.getAddress(),
-      '100',
+      issuedCurrency,
     )
 
     // THEN the payment succeeds.


### PR DESCRIPTION
## High Level Overview of Change
To clean up the IOU functions, this PR replaces all instances where there are 3 parameters in a function for the 3 elements of an issued currency (currency, value, issuer) with an issued currency interface. 

### Context of Change

Cleaning up IOU code before deployment

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Where possible, the public IOU methods use `IssuedCurrency` interfaces instead of 3 separate parameters.

## Test Plan

CI passes. 
