### PR TITLE
Refactors integration tests to use `XrpTestUtils.randomWalletFromFaucet` instead of deprecated `Wallet.generateRandomWallet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ Xpring-JS can generate a new and random HD Wallet. The result of a wallet genera
 - A reference to the new wallet
 
 ```javascript
-const { Wallet } = require('xpring-js')
+const { WalletFactory, XrplNetwork } = require('xpring-js')
 
 // Generate a random wallet.
-const generationResult = Wallet.generateRandomWallet()
+const walletFactory = new WalletFactory(XrplNetwork.Test)
+const generationResult = await walletFactory.generateRandomWallet()!
 const newWallet = generationResult.wallet
 
 // Wallet can be recreated with the artifacts of the initial generation.
@@ -143,12 +144,13 @@ const copyOfNewWallet = Wallet.generateWalletFromMnemonic(
 A generated wallet can provide its public key, private key, and address on the XRP ledger.
 
 ```javascript
-const { Wallet } = require('xpring-js')
+const { WalletFactory, XrplNetwork } = require('xpring-js')
 
 const mnemonic =
   'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
 
-const wallet = Wallet.generateWalletFromMnemonic(mnemonic)
+const walletFactory = new WalletFactory(XrplNetwork.Test)
+const wallet = await walletFactory.generateRandomHdWallet(mnemonic)!
 
 console.log(wallet.getAddress()) // XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ
 console.log(wallet.getPublicKey()) // 031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE
@@ -160,13 +162,14 @@ console.log(wallet.getPrivateKey()) // 0090802A50AA84EFB6CDB225F17C27616EA94048C
 A wallet can also sign and verify arbitrary hex messages. Generally, users should use the functions on `XrpClient` to perform cryptographic functions rather than using these low level APIs.
 
 ```javascript
-const { Wallet } = require('xpring-js')
+const { WalletFactory, XrplNetwork } = require('xpring-js')
 
 const mnemonic =
   'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
 const message = 'deadbeef'
 
-const wallet = Wallet.generateWalletFromMnemonic(mnemonic)
+const walletFactory = new WalletFactory(XrplNetwork.Test)
+const wallet = await walletFactory.generateRandomHdWallet(mnemonic)!
 
 const signature = wallet.sign(message)
 wallet.verify(message, signature) // true
@@ -267,7 +270,7 @@ An `XrpClient` can send XRP to other accounts on the XRP Ledger.
 **Note:** The payment operation will block the calling thread until the operation reaches a definitive and irreversible success or failure state.
 
 ```javascript
-const { Wallet, XrpClient, XrplNetwork } = require("xpring-js");
+const { WalletFactory, XrpClient, XrplNetwork } = require("xpring-js");
 
 const remoteURL = test.xrp.xpring.io:50051; // Testnet URL, use main.xrp.xpring.io:50051 for Mainnet
 const xrpClient = new XrpClient(remoteURL, XrplNetwork.Test);
@@ -279,7 +282,8 @@ const amount = BigInt("10");
 const destinationAddress = "X7u4MQVhU2YxS4P9fWzQjnNuDRUkP3GM6kiVjTjcQgUU3Jr";
 
 // Wallet which will send XRP
-const generationResult = Wallet.generateRandomWallet();
+const walletFactory = new WalletFactory(XrplNetwork.Test)
+const generationResult = await walletFactory.generateRandomWallet()!
 const senderWallet = generationResult.wallet;
 
 const transactionResult = await xrpClient.sendXrp(amount, destinationAddress, senderWallet);
@@ -291,15 +295,16 @@ the randomly generated wallet contains no XRP.
 ### Enabling Deposit Authorization
 
 ```javascript
-const { Wallet, XrpClient, XrplNetwork } = require("xpring-js");
+const { WalletFactory, XrpClient, XrplNetwork } = require("xpring-js");
 
 const remoteURL = test.xrp.xpring.io:50051; // Testnet URL, use main.xrp.xpring.io:50051 for Mainnet
 const xrpClient = new XrpClient(remoteURL, XrplNetwork.Test);
 
 // Wallet for which to enable Deposit Authorization
-const seedWallet = Wallet.generateWalletFromSeed(
+const walletFactory = new WalletFactory(XrplNetwork.Test)
+const seedWallet = await walletFactory.generateRandomWallet(
   'snRiAJGeKCkPVddbjB3zRwiYDBm1M',
-)
+)!
 
 const transactionResult = await xrpClient.enableDepositAuth(seedWallet);
 const transactionHash = transactionResult.hash;
@@ -474,7 +479,7 @@ PaymentResponse payment = ilpClient.sendPayment(paymentRequest, "2S1PZh3fEKnKg")
 Xpring components compose PayID and XRP components to make complex interactions easy.
 
 ```javascript
-import { XpringClient, XrpClient, XrpPayIdClient, XrplNetwork } from 'xpring-js'
+import { WalletFactory, XpringClient, XrpClient, XrpPayIdClient, XrplNetwork } from 'xpring-js'
 
 const network = XrplNetwork.Test
 
@@ -489,7 +494,9 @@ const payIdClient = new XrpPayIdClient(network)
 const xpringClient = new XpringClient(payIdClient, xrpClient)
 
 // A wallet with some balance on TestNet.
-const wallet = Wallet.generateWalletFromSeed('snYP7oArxKepd3GPDcrjMsJYiJeJB')!
+const walletFactory = new WalletFactory(XrplNetwork.Test)
+const generationResult =
+const wallet = await walletFactory.generateRandomWallet('snYP7oArxKepd3GPDcrjMsJYiJeJB')!
 
 // A PayID which will receive the payment.
 const payId = 'alice$dev.payid.xpring.money'

--- a/test/XRP/core-xrpl-client.test.ts
+++ b/test/XRP/core-xrpl-client.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 import { assert } from 'chai'
 
-import { Wallet, XrplNetwork } from 'xpring-common-js'
+import { Wallet, WalletFactory, XrplNetwork } from 'xpring-common-js'
 import {
   FakeXRPNetworkClient,
   FakeXRPNetworkClientResponses,
@@ -26,7 +26,8 @@ import {
 import { AccountRoot } from '../../src/XRP/Generated/node/org/xrpl/rpc/v1/ledger_objects_pb'
 import TransactionResult from '../../src/XRP/shared/transaction-result'
 import TransactionStatus from '../../src/XRP/shared/transaction-status'
-import XRPTestUtils from './helpers/xrp-test-utils'
+
+const walletFactory = new WalletFactory(XrplNetwork.Test)
 
 // The network layer is faked, so this is a perfunctory argument
 const transactionHash = 'DEADBEEF'
@@ -61,7 +62,7 @@ function makeAccountInfoResponse(
 describe('Common XRPL Client', function (): void {
   let wallet: Wallet
   before(async function () {
-    wallet = await XRPTestUtils.randomWalletFromFaucet()
+    wallet = (await walletFactory.generateRandomWallet()!).wallet
   })
   it('getFinalTransactionResultAsync - returns when transaction is validated', async function (): Promise<void> {
     // GIVEN a CoreXrplClient with fake networking that will succeed with a not-yet-validated transaction response

--- a/test/XRP/core-xrpl-client.test.ts
+++ b/test/XRP/core-xrpl-client.test.ts
@@ -26,10 +26,10 @@ import {
 import { AccountRoot } from '../../src/XRP/Generated/node/org/xrpl/rpc/v1/ledger_objects_pb'
 import TransactionResult from '../../src/XRP/shared/transaction-result'
 import TransactionStatus from '../../src/XRP/shared/transaction-status'
+import XRPTestUtils from './helpers/xrp-test-utils'
 
 // The network layer is faked, so this is a perfunctory argument
 const transactionHash = 'DEADBEEF'
-const { wallet } = Wallet.generateRandomWallet()!
 
 /**
  * Convenience function which allows construction of `GetAccountInfoResponse` objects.
@@ -59,6 +59,10 @@ function makeAccountInfoResponse(
 }
 
 describe('Common XRPL Client', function (): void {
+  let wallet: Wallet
+  before(async function () {
+    wallet = await XRPTestUtils.randomWalletFromFaucet()
+  })
   it('getFinalTransactionResultAsync - returns when transaction is validated', async function (): Promise<void> {
     // GIVEN a CoreXrplClient with fake networking that will succeed with a not-yet-validated transaction response
     const getTransactionResponse = FakeXRPNetworkClientResponses.defaultGetTransactionResponse()

--- a/test/XRP/core-xrpl-client.test.ts
+++ b/test/XRP/core-xrpl-client.test.ts
@@ -62,7 +62,7 @@ function makeAccountInfoResponse(
 describe('Common XRPL Client', function (): void {
   let wallet: Wallet
   before(async function () {
-    wallet = (await walletFactory.generateRandomWallet()!).wallet
+    wallet = (await walletFactory.generateRandomWallet())!.wallet
   })
   it('getFinalTransactionResultAsync - returns when transaction is validated', async function (): Promise<void> {
     // GIVEN a CoreXrplClient with fake networking that will succeed with a not-yet-validated transaction response

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -385,7 +385,7 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionResult.hash, expectedTransactionHash)
   })
 
-  it('Send XRP Transaction - failure with invalid string', async function (done) {
+  it('Send XRP Transaction - failure with invalid string', async function () {
     // GIVEN a DefaultXrpClient, a wallet and an amount that is invalid.
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
@@ -398,11 +398,10 @@ describe('Default XRP Client', function (): void {
     // WHEN the account makes a transaction THEN an error is propagated.
     xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.typeOf(error, 'Error')
-      done()
     })
   })
 
-  it('Send XRP Transaction - get fee failure', async function (done) {
+  it('Send XRP Transaction - get fee failure', async function () {
     // GIVEN a DefaultXrpClient which will fail to retrieve a fee.
     const feeFailureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -427,11 +426,10 @@ describe('Default XRP Client', function (): void {
         error.message,
         FakeXRPNetworkClientResponses.defaultError.message,
       )
-      done()
     })
   })
 
-  it('Send XRP Transaction - failure with classic address', async function (done) {
+  it('Send XRP Transaction - failure with classic address', async function () {
     // GIVEN a DefaultXrpClient, a wallet, and a classic address as the destination.
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
@@ -444,11 +442,10 @@ describe('Default XRP Client', function (): void {
     // WHEN the account makes a transaction THEN an error is thrown.
     xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.equal((error as XrpError).errorType, XrpErrorType.XAddressRequired)
-      done()
     })
   })
 
-  it('Send XRP Transaction - get account info failure', async function (done) {
+  it('Send XRP Transaction - get account info failure', async function () {
     // GIVEN a DefaultXrpClient which will fail to retrieve account info.
     const feeFailureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultError,
@@ -469,11 +466,10 @@ describe('Default XRP Client', function (): void {
     // WHEN a payment is attempted THEN an error is propagated.
     xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
-      done()
     })
   })
 
-  it('Send XRP Transaction - submission failure', async function (done) {
+  it('Send XRP Transaction - submission failure', async function () {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const feeFailureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -494,7 +490,6 @@ describe('Default XRP Client', function (): void {
     // WHEN a payment is attempted THEN an error is propagated.
     xrpClient.sendXrp(amount, destinationAddress, wallet).catch((error) => {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
-      done()
     })
   })
 
@@ -796,7 +791,7 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionHash, expectedTransactionHash)
   })
 
-  it('Enable Deposit Auth - submission failure', async function (done): Promise<void> {
+  it('Enable Deposit Auth - submission failure', async function () {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const failureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -813,7 +808,6 @@ describe('Default XRP Client', function (): void {
     // WHEN enableDepositAuth is attempted THEN an error is propagated.
     xrpClient.enableDepositAuth(wallet).catch((error) => {
       assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
-      done()
     })
   })
 
@@ -844,7 +838,7 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionHash, expectedTransactionHash)
   })
 
-  it('authorizeSendingAccount - submission failure', async function (done): Promise<void> {
+  it('authorizeSendingAccount - submission failure', async function () {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const failureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -866,11 +860,10 @@ describe('Default XRP Client', function (): void {
       .authorizeSendingAccount(xAddressToAuthorize, wallet)
       .catch((error) => {
         assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
-        done()
       })
   })
 
-  it('authorizeSendingAccount - failure with malformed sender X-Address', async function (done): Promise<void> {
+  it('authorizeSendingAccount - failure with malformed sender X-Address', async function () {
     // GIVEN a DefaultXrpClient with mocked networking.
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
@@ -885,7 +878,6 @@ describe('Default XRP Client', function (): void {
       .authorizeSendingAccount(xAddressToAuthorize, wallet)
       .catch((error) => {
         assert.deepEqual(error, XrpError.xAddressRequired)
-        done()
       })
   })
 
@@ -916,7 +908,7 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionHash, expectedTransactionHash)
   })
 
-  it('unauthorizeSendingAccount - submission failure', async function (done): Promise<void> {
+  it('unauthorizeSendingAccount - submission failure', async function () {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const failureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -938,11 +930,10 @@ describe('Default XRP Client', function (): void {
       .unauthorizeSendingAccount(xAddressToUnauthorize, wallet)
       .catch((error) => {
         assert.deepEqual(error, FakeXRPNetworkClientResponses.defaultError)
-        done()
       })
   })
 
-  it('unauthorizeSendingAccount - failure with malformed sender X-Address', async function (done): Promise<void> {
+  it('unauthorizeSendingAccount - failure with malformed sender X-Address', async function () {
     // GIVEN a DefaultXrpClient with mocked networking
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
@@ -957,7 +948,6 @@ describe('Default XRP Client', function (): void {
       .unauthorizeSendingAccount(xAddressToUnauthorize, wallet)
       .catch((error) => {
         assert.deepEqual(error, XrpError.xAddressRequired)
-        done()
       })
   })
 })

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -287,7 +287,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
     const memoList = [iForgotToPickUpCarlMemo]
@@ -315,7 +315,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -341,7 +341,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 10
 
@@ -367,7 +367,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = '10'
 
@@ -393,7 +393,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 'not_a_number'
 
@@ -417,7 +417,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -437,7 +437,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
     const amount = bigInt('10')
 
@@ -461,7 +461,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -485,7 +485,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -778,7 +778,7 @@ describe('Default XRP Client', function (): void {
       XrplNetwork.Test,
     )
 
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN enableDepositAuth is called
     const result = await xrpClient.enableDepositAuth(wallet)
@@ -805,7 +805,7 @@ describe('Default XRP Client', function (): void {
       failingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN enableDepositAuth is attempted THEN an error is propagated.
     xrpClient.enableDepositAuth(wallet).catch((error) => {
@@ -822,7 +822,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN authorizeSendingAccount is called.
     const result = await xrpClient.authorizeSendingAccount(
@@ -855,7 +855,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -873,7 +873,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToAuthorize = 'notanxaddress'
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -892,7 +892,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN unauthorizeSendingAccount is called.
     const result = await xrpClient.unauthorizeSendingAccount(
@@ -925,7 +925,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -943,7 +943,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToUnauthorize = 'notanxaddress'
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -2,7 +2,7 @@
 import { assert } from 'chai'
 
 import bigInt from 'big-integer'
-import { Utils, XrplNetwork } from 'xpring-common-js'
+import { Utils, WalletFactory, XrplNetwork } from 'xpring-common-js'
 import { StatusCode as grpcStatusCode } from 'grpc-web'
 import FakeGRPCError from '../Common/Fakes/fake-grpc-error'
 import XRPTestUtils, { iForgotToPickUpCarlMemo } from './helpers/xrp-test-utils'
@@ -42,6 +42,8 @@ const transactionStatusFailureCodes = [
 ]
 
 const transactionHash = 'DEADBEEF'
+
+const walletFactory = new WalletFactory(XrplNetwork.Test)
 
 const fakeSucceedingNetworkClient = new FakeXRPNetworkClient()
 const fakeErroringNetworkClient = new FakeXRPNetworkClient(
@@ -285,7 +287,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
     const memoList = [iForgotToPickUpCarlMemo]
@@ -313,7 +315,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -339,7 +341,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 10
 
@@ -365,7 +367,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = '10'
 
@@ -391,7 +393,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 'not_a_number'
 
@@ -415,7 +417,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -435,7 +437,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
     const amount = bigInt('10')
 
@@ -459,7 +461,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -483,7 +485,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -776,7 +778,7 @@ describe('Default XRP Client', function (): void {
       XrplNetwork.Test,
     )
 
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN enableDepositAuth is called
     const result = await xrpClient.enableDepositAuth(wallet)
@@ -803,7 +805,7 @@ describe('Default XRP Client', function (): void {
       failingNetworkClient,
       XrplNetwork.Test,
     )
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN enableDepositAuth is attempted THEN an error is propagated.
     xrpClient.enableDepositAuth(wallet).catch((error) => {
@@ -820,7 +822,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN authorizeSendingAccount is called.
     const result = await xrpClient.authorizeSendingAccount(
@@ -853,7 +855,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -871,7 +873,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToAuthorize = 'notanxaddress'
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -890,7 +892,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN unauthorizeSendingAccount is called.
     const result = await xrpClient.unauthorizeSendingAccount(
@@ -923,7 +925,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -941,7 +943,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToUnauthorize = 'notanxaddress'
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -285,7 +285,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
     const memoList = [iForgotToPickUpCarlMemo]
@@ -313,7 +313,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -339,7 +339,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 10
 
@@ -365,7 +365,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = '10'
 
@@ -385,13 +385,13 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionResult.hash, expectedTransactionHash)
   })
 
-  it('Send XRP Transaction - failure with invalid string', function (done) {
+  it('Send XRP Transaction - failure with invalid string', async function (done) {
     // GIVEN a DefaultXrpClient, a wallet and an amount that is invalid.
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 'not_a_number'
 
@@ -402,7 +402,7 @@ describe('Default XRP Client', function (): void {
     })
   })
 
-  it('Send XRP Transaction - get fee failure', function (done) {
+  it('Send XRP Transaction - get fee failure', async function (done) {
     // GIVEN a DefaultXrpClient which will fail to retrieve a fee.
     const feeFailureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -416,7 +416,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -431,13 +431,13 @@ describe('Default XRP Client', function (): void {
     })
   })
 
-  it('Send XRP Transaction - failure with classic address', function (done) {
+  it('Send XRP Transaction - failure with classic address', async function (done) {
     // GIVEN a DefaultXrpClient, a wallet, and a classic address as the destination.
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
     const amount = bigInt('10')
 
@@ -448,7 +448,7 @@ describe('Default XRP Client', function (): void {
     })
   })
 
-  it('Send XRP Transaction - get account info failure', function (done) {
+  it('Send XRP Transaction - get account info failure', async function (done) {
     // GIVEN a DefaultXrpClient which will fail to retrieve account info.
     const feeFailureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultError,
@@ -462,7 +462,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -473,7 +473,7 @@ describe('Default XRP Client', function (): void {
     })
   })
 
-  it('Send XRP Transaction - submission failure', function (done) {
+  it('Send XRP Transaction - submission failure', async function (done) {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const feeFailureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -487,7 +487,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -781,7 +781,7 @@ describe('Default XRP Client', function (): void {
       XrplNetwork.Test,
     )
 
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN enableDepositAuth is called
     const result = await xrpClient.enableDepositAuth(wallet)
@@ -796,7 +796,7 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionHash, expectedTransactionHash)
   })
 
-  it('Enable Deposit Auth - submission failure', function (done): void {
+  it('Enable Deposit Auth - submission failure', async function (done): Promise<void> {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const failureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -808,7 +808,7 @@ describe('Default XRP Client', function (): void {
       failingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN enableDepositAuth is attempted THEN an error is propagated.
     xrpClient.enableDepositAuth(wallet).catch((error) => {
@@ -826,7 +826,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN authorizeSendingAccount is called.
     const result = await xrpClient.authorizeSendingAccount(
@@ -844,7 +844,7 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionHash, expectedTransactionHash)
   })
 
-  it('authorizeSendingAccount - submission failure', function (done): void {
+  it('authorizeSendingAccount - submission failure', async function (done): Promise<void> {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const failureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -859,7 +859,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -870,7 +870,7 @@ describe('Default XRP Client', function (): void {
       })
   })
 
-  it('authorizeSendingAccount - failure with malformed sender X-Address', function (done): void {
+  it('authorizeSendingAccount - failure with malformed sender X-Address', async function (done): Promise<void> {
     // GIVEN a DefaultXrpClient with mocked networking.
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
@@ -878,7 +878,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToAuthorize = 'notanxaddress'
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -898,7 +898,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN unauthorizeSendingAccount is called.
     const result = await xrpClient.unauthorizeSendingAccount(
@@ -916,7 +916,7 @@ describe('Default XRP Client', function (): void {
     assert.strictEqual(transactionHash, expectedTransactionHash)
   })
 
-  it('unauthorizeSendingAccount - submission failure', function (done): void {
+  it('unauthorizeSendingAccount - submission failure', async function (done): Promise<void> {
     // GIVEN a DefaultXrpClient which will fail to submit a transaction.
     const failureResponses = new FakeXRPNetworkClientResponses(
       FakeXRPNetworkClientResponses.defaultAccountInfoResponse(),
@@ -931,7 +931,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -942,7 +942,7 @@ describe('Default XRP Client', function (): void {
       })
   })
 
-  it('unauthorizeSendingAccount - failure with malformed sender X-Address', function (done): void {
+  it('unauthorizeSendingAccount - failure with malformed sender X-Address', async function (done): Promise<void> {
     // GIVEN a DefaultXrpClient with mocked networking
     const xrpClient = new DefaultXrpClient(
       fakeSucceedingNetworkClient,
@@ -950,7 +950,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToUnauthorize = 'notanxaddress'
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -287,7 +287,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
     const memoList = [iForgotToPickUpCarlMemo]
@@ -315,7 +315,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -341,7 +341,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 10
 
@@ -367,7 +367,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = '10'
 
@@ -393,7 +393,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = 'not_a_number'
 
@@ -417,7 +417,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -437,7 +437,7 @@ describe('Default XRP Client', function (): void {
       fakeSucceedingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'rsegqrgSP8XmhCYwL9enkZ9BNDNawfPZnn'
     const amount = bigInt('10')
 
@@ -461,7 +461,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -485,7 +485,7 @@ describe('Default XRP Client', function (): void {
       feeFailingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
     const destinationAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
     const amount = bigInt('10')
 
@@ -778,7 +778,7 @@ describe('Default XRP Client', function (): void {
       XrplNetwork.Test,
     )
 
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN enableDepositAuth is called
     const result = await xrpClient.enableDepositAuth(wallet)
@@ -805,7 +805,7 @@ describe('Default XRP Client', function (): void {
       failingNetworkClient,
       XrplNetwork.Test,
     )
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN enableDepositAuth is attempted THEN an error is propagated.
     xrpClient.enableDepositAuth(wallet).catch((error) => {
@@ -822,7 +822,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN authorizeSendingAccount is called.
     const result = await xrpClient.authorizeSendingAccount(
@@ -855,7 +855,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToAuthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -873,7 +873,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToAuthorize = 'notanxaddress'
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN authorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -892,7 +892,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN unauthorizeSendingAccount is called.
     const result = await xrpClient.unauthorizeSendingAccount(
@@ -925,7 +925,7 @@ describe('Default XRP Client', function (): void {
 
     const xAddressToUnauthorize =
       'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient
@@ -943,7 +943,7 @@ describe('Default XRP Client', function (): void {
     )
 
     const xAddressToUnauthorize = 'notanxaddress'
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN unauthorizeSendingAccount is attempted THEN an error is propagated.
     xrpClient

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -2,7 +2,7 @@
 import { assert } from 'chai'
 
 import bigInt from 'big-integer'
-import { Utils, Wallet, XrplNetwork } from 'xpring-common-js'
+import { Utils, XrplNetwork } from 'xpring-common-js'
 import { StatusCode as grpcStatusCode } from 'grpc-web'
 import FakeGRPCError from '../Common/Fakes/fake-grpc-error'
 import XRPTestUtils, { iForgotToPickUpCarlMemo } from './helpers/xrp-test-utils'

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -93,7 +93,7 @@ describe('Reliable Submission XRP Client', function (): void {
 
   it('sendXrp - Returns when the transaction is validated', async function () {
     // Increase timeout because `setTimeout` is only accurate to 1500ms.
-    this.timeout(5000)
+    this.timeout(10000)
 
     // GIVEN A transaction that will validate itself in 200ms.
     setTimeout(() => {
@@ -124,7 +124,7 @@ describe('Reliable Submission XRP Client', function (): void {
 
   it('enableDepositAuth - Returns when the transaction is validated', async function () {
     // Increase timeout because `setTimeout` is only accurate to 1500ms.
-    this.timeout(5000)
+    this.timeout(10000)
 
     // GIVEN A transaction that will validate itself in 200ms.
     setTimeout(() => {
@@ -141,7 +141,7 @@ describe('Reliable Submission XRP Client', function (): void {
 
   it('authorizeSendingAccount - Returns when the transaction is validated', async function () {
     // Increase timeout because `setTimeout` is only accurate to 1500ms.
-    this.timeout(5000)
+    this.timeout(10000)
 
     // GIVEN A transaction that will validate itself in 200ms.
     setTimeout(() => {
@@ -161,7 +161,7 @@ describe('Reliable Submission XRP Client', function (): void {
 
   it('unauthorizeSendingAccount - Returns when the transaction is validated', async function () {
     // Increase timeout because `setTimeout` is only accurate to 1500ms.
-    this.timeout(5000)
+    this.timeout(10000)
 
     // GIVEN A transaction that will validate itself in 200ms.
     setTimeout(() => {

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { Wallet, XrplNetwork } from 'xpring-common-js'
+import { XrplNetwork } from 'xpring-common-js'
 import bigInt from 'big-integer'
 import FakeXrpClient from './fakes/fake-xrp-client'
 import ReliableSubmissionXrpClient from '../../src/XRP/reliable-submission-xrp-client'

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -100,7 +100,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN a reliable send is submitted
     const transactionResult = await this.reliableSubmissionClient.sendXrp(
@@ -131,7 +131,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN enableDepositAuth is called
     const result = await this.reliableSubmissionClient.enableDepositAuth(wallet)
@@ -148,7 +148,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN authorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.authorizeSendingAccount(
@@ -168,7 +168,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = (await walletFactory.generateRandomWallet()!).wallet
+    const wallet = (await walletFactory.generateRandomWallet())!.wallet
 
     // WHEN unauthorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.unauthorizeSendingAccount(

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -100,7 +100,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN a reliable send is submitted
     const transactionResult = await this.reliableSubmissionClient.sendXrp(
@@ -131,7 +131,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN enableDepositAuth is called
     const result = await this.reliableSubmissionClient.enableDepositAuth(wallet)
@@ -148,7 +148,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN authorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.authorizeSendingAccount(
@@ -168,7 +168,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = await walletFactory.generateRandomWallet()!
+    const wallet = (await walletFactory.generateRandomWallet()!).wallet
 
     // WHEN unauthorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.unauthorizeSendingAccount(

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { XrplNetwork } from 'xpring-common-js'
+import { WalletFactory, XrplNetwork } from 'xpring-common-js'
 import bigInt from 'big-integer'
 import FakeXrpClient from './fakes/fake-xrp-client'
 import ReliableSubmissionXrpClient from '../../src/XRP/reliable-submission-xrp-client'
@@ -8,7 +8,6 @@ import TransactionStatus from '../../src/XRP/shared/transaction-status'
 import { testXrpTransaction } from './fakes/fake-xrp-protobufs'
 import TransactionResult from '../../src/XRP/shared/transaction-result'
 import FakeCoreXrplClient from './fakes/fake-core-xrpl-client'
-import XRPTestUtils from './helpers/xrp-test-utils'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -35,6 +34,8 @@ const fakedTransactionResultValue = TransactionResult.createFinalTransactionResu
   TransactionStatus.Succeeded,
   true,
 )
+
+const walletFactory = new WalletFactory(XrplNetwork.Test)
 
 describe('Reliable Submission XRP Client', function (): void {
   beforeEach(function () {
@@ -99,7 +100,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN a reliable send is submitted
     const transactionResult = await this.reliableSubmissionClient.sendXrp(
@@ -130,7 +131,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN enableDepositAuth is called
     const result = await this.reliableSubmissionClient.enableDepositAuth(wallet)
@@ -147,7 +148,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN authorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.authorizeSendingAccount(
@@ -167,7 +168,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const wallet = await XRPTestUtils.randomWalletFromFaucet()
+    const { wallet } = await walletFactory.generateRandomWallet()!
 
     // WHEN unauthorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.unauthorizeSendingAccount(

--- a/test/XRP/reliable-submission-xrp-client.test.ts
+++ b/test/XRP/reliable-submission-xrp-client.test.ts
@@ -8,6 +8,7 @@ import TransactionStatus from '../../src/XRP/shared/transaction-status'
 import { testXrpTransaction } from './fakes/fake-xrp-protobufs'
 import TransactionResult from '../../src/XRP/shared/transaction-result'
 import FakeCoreXrplClient from './fakes/fake-core-xrpl-client'
+import XRPTestUtils from './helpers/xrp-test-utils'
 
 const testAddress = 'X76YZJgkFzdSLZQTa7UzVSs34tFgyV2P16S3bvC8AWpmwdH'
 
@@ -98,7 +99,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN a reliable send is submitted
     const transactionResult = await this.reliableSubmissionClient.sendXrp(
@@ -129,7 +130,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN enableDepositAuth is called
     const result = await this.reliableSubmissionClient.enableDepositAuth(wallet)
@@ -146,7 +147,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN authorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.authorizeSendingAccount(
@@ -166,7 +167,7 @@ describe('Reliable Submission XRP Client', function (): void {
     setTimeout(() => {
       this.fakedRawTransactionStatusValue.isValidated = true
     }, 200)
-    const { wallet } = Wallet.generateRandomWallet()!
+    const wallet = await XRPTestUtils.randomWalletFromFaucet()
 
     // WHEN unauthorizeSendingAccount is called
     const result = await this.reliableSubmissionClient.unauthorizeSendingAccount(


### PR DESCRIPTION
## High Level Overview of Change

This PR refactors all the integration test files to stop using the now-deprecated method `Wallet.generateRandomWallet` and instead use `XrpTestUtils.randomWalletFromFaucet`. 

### Context of Change

Code cleanup

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
CI passes. 

<!--
## Future Tasks
For future tasks related to PR.
-->
