### PR TITLE
Updates `CoreXrplClient::getTransactionStatus` to reflect `TransactionStatus` granularity

### DIFF
--- a/src/XRP/core-xrpl-client.ts
+++ b/src/XRP/core-xrpl-client.ts
@@ -25,6 +25,7 @@ import { LedgerSpecifier } from './Generated/web/org/xrpl/rpc/v1/ledger_pb'
 import TransactionResult from './shared/transaction-result'
 import isNode from '../Common/utils'
 import CoreXrplClientInterface from './core-xrpl-client-interface'
+import TransactionPrefix from './shared/transaction-prefix'
 
 async function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
@@ -311,13 +312,13 @@ export default class CoreXrplClient implements CoreXrplClientInterface {
     const statusPrefix = statusCode.substr(0, 3)
 
     switch (statusPrefix) {
-      case 'tes':
+      case TransactionPrefix.Success:
         return TransactionStatus.Succeeded
-      case 'tem':
+      case TransactionPrefix.MalformedTransaction:
         return TransactionStatus.MalformedTransaction
-      case 'tef':
+      case TransactionPrefix.Failure:
         return TransactionStatus.Failed
-      case 'tec':
+      case TransactionPrefix.ClaimedCostOnly:
         switch (statusCode) {
           case 'tecPATH_PARTIAL':
             return TransactionStatus.ClaimedCostOnly_PathPartial

--- a/src/XRP/core-xrpl-client.ts
+++ b/src/XRP/core-xrpl-client.ts
@@ -307,9 +307,28 @@ export default class CoreXrplClient implements CoreXrplClientInterface {
       return TransactionStatus.Pending
     }
 
-    return transactionStatus.transactionStatusCode?.startsWith('tes')
-      ? TransactionStatus.Succeeded
-      : TransactionStatus.Failed
+    const statusCode = transactionStatus.transactionStatusCode
+    const statusPrefix = statusCode.substr(0, 3)
+
+    switch (statusPrefix) {
+      case 'tes':
+        return TransactionStatus.Succeeded
+      case 'tem':
+        return TransactionStatus.MalformedTransaction
+      case 'tef':
+        return TransactionStatus.Failed
+      case 'tec':
+        switch (statusCode) {
+          case 'tecPATH_PARTIAL':
+            return TransactionStatus.ClaimedCostOnly_PathPartial
+          case 'tecPATH_DRY':
+            return TransactionStatus.ClaimedCostOnly_PathDry
+          default:
+            return TransactionStatus.ClaimedCostOnly
+        }
+      default:
+        return TransactionStatus.Unknown
+    }
   }
 
   /**

--- a/src/XRP/shared/transaction-prefix.ts
+++ b/src/XRP/shared/transaction-prefix.ts
@@ -1,0 +1,11 @@
+/** Represents prefixes of transaction statuses. */
+enum TransactionPrefix {
+  ClaimedCostOnly = 'tec',
+  Failure = 'tef',
+  LocalError = 'tel',
+  MalformedTransaction = 'tem',
+  Retry = 'ter',
+  Success = 'tes',
+}
+
+export default TransactionPrefix

--- a/src/XRP/shared/transaction-status.ts
+++ b/src/XRP/shared/transaction-status.ts
@@ -31,7 +31,7 @@ enum TransactionStatus {
   /** The transaction's last ledger sequence has been surpassed; the transaction will never be included in a validated ledger. */
   LastLedgerSequenceExpired,
 
-  /** The transaction was included in a finalized ledger and succeeded. */
+  /** The transaction status is unknown. */
   Unknown,
 }
 

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -39,6 +39,8 @@ const transactionStatusFailureCodes = [
   'telBAD_PUBLIC_KEY',
   'temBAD_FEE',
   'terRETRY',
+  'tecPATH_PARTIAL',
+  'tecPATH_DRY',
 ]
 
 const transactionHash = 'DEADBEEF'
@@ -209,6 +211,8 @@ describe('Default XRP Client', function (): void {
       TransactionStatus.Unknown,
       TransactionStatus.MalformedTransaction,
       TransactionStatus.Unknown,
+      TransactionStatus.ClaimedCostOnly_PathPartial,
+      TransactionStatus.ClaimedCostOnly_PathDry,
     ]
 
     // Iterate over different types of transaction status codes which represent failures.

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -243,7 +243,7 @@ describe('Default XRP Client', function (): void {
         transactionHash,
       )
 
-      // THEN the status is failed.
+      // THEN the status is as expected.
       assert.deepEqual(
         transactionStatus,
         expectedTransactionStatusFailureCodeResponses[i],

--- a/test/XRP/default-xrp-client.test.ts
+++ b/test/XRP/default-xrp-client.test.ts
@@ -203,6 +203,14 @@ describe('Default XRP Client', function (): void {
   })
 
   it('Get Payment Status - Validated Transaction and Failure Code', async function (): Promise<void> {
+    const expectedTransactionStatusFailureCodeResponses: number[] = [
+      TransactionStatus.Failed,
+      TransactionStatus.ClaimedCostOnly,
+      TransactionStatus.Unknown,
+      TransactionStatus.MalformedTransaction,
+      TransactionStatus.Unknown,
+    ]
+
     // Iterate over different types of transaction status codes which represent failures.
     /* eslint-disable no-await-in-loop */
     for (let i = 0; i < transactionStatusFailureCodes.length; i += 1) {
@@ -232,7 +240,10 @@ describe('Default XRP Client', function (): void {
       )
 
       // THEN the status is failed.
-      assert.deepEqual(transactionStatus, TransactionStatus.Failed)
+      assert.deepEqual(
+        transactionStatus,
+        expectedTransactionStatusFailureCodeResponses[i],
+      )
     }
     /* eslint-enable no-await-in-loop */
   })


### PR DESCRIPTION
## High Level Overview of Change

`CoreXrplClient::getTransactionStatus` only returns `Pending`, `Failed`, or `Succeeded`. This PR adds more granularity to those responses, covvering the entire gamut of `TransactionStatus` options, so that the function becomes more useful.

### Context of Change

Code cleanup

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Instead of just returning `Pending`, `Failed`, or `Succeeded`, `CoreXrplClient::getTransactionStatus` now returns the whole gamut of transaction status options.

## Test Plan

CI passes. 
