### PR TITLE
Removes Unnecessary Check from Construction of `XrpPayment` Object

### DIFF
--- a/src/XRP/protobuf-wrappers/xrp-payment.ts
+++ b/src/XRP/protobuf-wrappers/xrp-payment.ts
@@ -74,13 +74,6 @@ export default class XrpPayment {
         'Payment protobuf `sendMax` field should be omitted for XRP-to-XRP interactions.',
       )
     }
-    // For non-XRP amounts, the nested field names in `sendMax` MUST be lower-case.
-    if (sendMax === undefined && amount.issuedCurrency !== undefined) {
-      throw new XrpError(
-        XrpErrorType.MalformedProtobuf,
-        'Payment protobuf `sendMax` field must be present for non-XRP-to-XRP interactions.',
-      )
-    }
 
     const paymentDeliverMinValue = payment.getDeliverMin()?.getValue()
     const deliverMin =

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -814,7 +814,6 @@ export {
   testInvalidPaymentProtoNoDestination,
   testInvalidPaymentProtoXrpPaths,
   testInvalidPaymentProtoXrpSendMax,
-  testInvalidPaymentProtoNoSendMax,
   testInvalidPaymentTransaction,
   testInvalidSignerProtoNoAccount,
   testInvalidSignerProtoBadAccount,

--- a/test/XRP/protos-models-flags-utils/xrp-protocol-buffer-conversion.test.ts
+++ b/test/XRP/protos-models-flags-utils/xrp-protocol-buffer-conversion.test.ts
@@ -65,7 +65,6 @@ import {
   testInvalidPaymentProtoNoDestination,
   testInvalidPaymentProtoXrpPaths,
   testInvalidPaymentProtoXrpSendMax,
-  testInvalidPaymentProtoNoSendMax,
   testInvalidSignerProtoNoAccount,
   testInvalidSignerProtoBadAccount,
   testInvalidSignerProtoNoPublicKey,
@@ -427,14 +426,6 @@ describe('Protocol Buffer Conversion', function (): void {
     // WHEN the protocol buffer is converted to a native TypeScript type THEN an error is thrown
     assert.throws(() => {
       XrpPayment.from(testInvalidPaymentProtoXrpSendMax, XrplNetwork.Test)
-    }, XrpError)
-  })
-
-  it('Convert Payment with no sendMax field in non-XRP transaction', function (): void {
-    // GIVEN a payment protocol buffer with no sendMax field in a non-XRP transaction
-    // WHEN the protocol buffer is converted to a native TypeScript type THEN an error is thrown
-    assert.throws(() => {
-      XrpPayment.from(testInvalidPaymentProtoNoSendMax, XrplNetwork.Test)
     }, XrpError)
   })
 


### PR DESCRIPTION
## High Level Overview of Change
This PR removes a safety check in the construction of `XrpPayment` objects that wanted to see a value for the `sendMax` field in ANY payment that involved an issued currency.  This was probably just due to a misinterpretation of the documentation, but now that we are issued currency experts, we know that issued currency payments can actually omit the `sendMax` sometimes, since it is only _required_ for cross-currency payments (not required for issuances or redemptions).

(The documentation reads "For non-XRP amounts, the nested field names MUST be lower-case. Must be supplied for cross-currency/cross-issue payments. Must be omitted for XRP-to-XRP payments.")

This came to light through the cbdc demo work, since their attempt to get an account's payment history using the `XrpClient.paymentHistory` was throwing while trying to construct `XrpPayment` objects from issued currency payment transactions.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
IOU MVP Dogfood
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Wrote myself an integration test that verifies `paymentHistory` can handle issued currency payments once this check is removed.  It is not included here because I don't want to mix clients yet, or add time to our integration tests if we can avoid it.

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
